### PR TITLE
debian: Add Lao translations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+qt6-translations (6.8.0-0deepin2) unstable; urgency=medium
+
+  * Add Lao (lo) translations
+    - Add Lao language translation files for all Qt modules
+    - Total 13 translation files with 5283 translated messages
+
+ -- wangjinrun <wangjinrun@uniontech.com>  Thu, 06 Feb 2026 22:30:00 +0800
+
 qt6-translations (6.8.0-0deepin1) unstable; urgency=medium
 
   * Add zh_HK translations and update zh_TW translations

--- a/debian/patches/add-lao-translations.patch
+++ b/debian/patches/add-lao-translations.patch
@@ -1,0 +1,18248 @@
+Description: Add Lao (lo) translations
+ This patch adds Lao language translation files for various Qt modules
+ including assistant, designer, linguist, qtbase, qtconnectivity,
+ qtdeclarative, qtlocation, qtmultimedia, qtserialport, qtwebengine,
+ qtwebsockets, and qt_help.
+Author: wangjinrun <wangjinrun@uniontech.com>
+Forwarded: not-needed
+Last-Update: 2026-02-06
+
+diff --git a/translations/assistant_lo.ts b/translations/assistant_lo.ts
+new file mode 100644
+index 0000000..7541ec5
+--- /dev/null
++++ b/translations/assistant_lo.ts
+@@ -0,0 +1,807 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>AboutDialog</name>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;ປິດ</translation></message>
++</context>
++<context>
++    <name>AboutLabel</name>
++    <message>
++        <source>Warning</source>
++        <translation>ຄຳເຕືອນ</translation></message>
++    <message>
++        <source>Unable to launch external application.</source>
++        <translation>ບໍ່ສາມາດເປີດແອັບພລິເຄຊັນພາຍນອກໄດ້.</translation></message>
++    <message>
++        <source>OK</source>
++        <translation>ຕົກລົງ</translation></message>
++</context>
++<context>
++    <name>Assistant</name>
++    <message>
++        <source>Error registering documentation file '%1': %2</source>
++        <translation>ຜິດພາດໃນການລົງທະບຽນໄຟລ໌ເອກະສານ '%1': %2</translation></message>
++    <message>
++        <source>Could not register documentation file
++%1
++
++Reason:
++%2</source>
++        <translation>ບໍ່ສາມາດລົງທະບຽນໄຟລ໌ເອກະສານ
++%1
++
++ເຫດຜົນ:
++%2</translation></message>
++    <message>
++        <source>Documentation successfully registered.</source>
++        <translation>ເອກະສານຖືກລົງທະບຽນສຳເລັດແລ້ວ</translation></message>
++    <message>
++        <source>Could not unregister documentation file
++%1
++
++Reason:
++%2</source>
++        <translation>ບໍ່ສາມາດຍົກເລີກການລົງທະບຽນໄຟລ໌ເອກະສານ
++%1
++
++ເຫດຜົນ:
++%2</translation></message>
++    <message>
++        <source>Documentation successfully unregistered.</source>
++        <translation>ເອກະສານຖືກຍົກເລີກການລົງທະບຽນສຳເລັດແລ້ວ.</translation></message>
++    <message>
++        <source>Error reading collection file '%1': %2.</source>
++        <translation>ຜິດພາດໃນການອ່ານໄຟລ໌ຄອນເລັກຊັນ '%1': %2.</translation></message>
++    <message>
++        <source>Error creating collection file '%1': %2.</source>
++        <translation>ຜິດພາດໃນການສ້າງໄຟລ໌ຄົມລວມ '%1': %2.</translation></message>
++    <message>
++        <source>Cannot load sqlite database driver!</source>
++        <translation>ບໍ່ສາມາດໂຫຼດຕົວຂັບຖານຂໍ້ມູນ sqlite ໄດ້!</translation></message>
++</context>
++<context>
++    <name>BookmarkDialog</name>
++    <message>
++        <source>Add Bookmark</source>
++        <translation>ເພີ່ມບຸກມາກ</translation></message>
++    <message>
++        <source>Bookmark:</source>
++        <translation>ບຸກມາກ:</translation></message>
++    <message>
++        <source>Add in Folder:</source>
++        <translation>ເພີ່ມໃນໂຟນເດີ:</translation></message>
++    <message>
++        <source>+</source>
++        <translation>+</translation></message>
++    <message>
++        <source>New Folder</source>
++        <translation>ໂຟນເດີໃໝ່</translation></message>
++    <message>
++        <source>Rename Folder</source>
++        <translation>ປ່ຽນຊື່ໂຟນເດີ</translation></message>
++</context>
++<context>
++    <name>BookmarkItem</name>
++    <message>
++        <source>New Folder</source>
++        <translation>ໂຟນເດີໃໝ່</translation></message>
++    <message>
++        <source>Untitled</source>
++        <translation>ບໍ່ມີຫົວຂໍ້</translation></message>
++</context>
++<context>
++    <name>BookmarkManager</name>
++    <message>
++        <source>Untitled</source>
++        <translation>ບໍ່ມີຊື່</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>You are going to delete a Folder, this will also&lt;br&gt;remove it's content. Are you sure to continue?</source>
++        <translation>ທ່ານກຳລັງຈະລຶບໂຟນເດີ, ນີ້ຈະ&lt;br&gt;ລຶບເນື້ອໃນຂອງມັນອອກເຊັ່ນກັນ. ທ່ານແນ່ໃຈບໍ່ທີ່ຈະດຳເນີນຕໍ່?</translation></message>
++    <message>
++        <source>Manage Bookmarks...</source>
++        <translation>ຈັດການບຸກມາກ...</translation></message>
++    <message>
++        <source>Add Bookmark...</source>
++        <translation>ເພີ່ມບຸກມາກ...</translation></message>
++    <message>
++        <source>Ctrl+D</source>
++        <translation>Ctrl+D</translation></message>
++    <message>
++        <source>Delete Folder</source>
++        <translation>ລຶບໂຟນເດີ</translation></message>
++    <message>
++        <source>Rename Folder</source>
++        <translation>ປ່ຽນຊື່ໂຟນເດີ</translation></message>
++    <message>
++        <source>Show Bookmark</source>
++        <translation>ສະແດງບຸກມາກ</translation></message>
++    <message>
++        <source>Show Bookmark in New Tab</source>
++        <translation>ສະແດງບຸກມາກໃນແຖບໃໝ່</translation></message>
++    <message>
++        <source>Delete Bookmark</source>
++        <translation>ລຶບບຸກມາກ</translation></message>
++    <message>
++        <source>Rename Bookmark</source>
++        <translation>ປ່ຽນຊື່ບຸກມາກ</translation></message>
++</context>
++<context>
++    <name>BookmarkManagerWidget</name>
++    <message>
++        <source>Manage Bookmarks</source>
++        <translation>ຈັດການບຸກມາກ</translation></message>
++    <message>
++        <source>Search:</source>
++        <translation>ຄົ້ນຫາ:</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Import and Backup</source>
++        <translation>ນຳເຂົ້າ ແລະ ສຳຮອງຂໍ້ມູນ</translation></message>
++    <message>
++        <source>OK</source>
++        <translation>ຕົກລົງ</translation></message>
++    <message>
++        <source>Import...</source>
++        <translation>ນຳເຂົ້າ...</translation></message>
++    <message>
++        <source>Export...</source>
++        <translation>ສົ່ງອອກ...</translation></message>
++    <message>
++        <source>Open File</source>
++        <translation>ເປີດໄຟລ໌</translation></message>
++    <message>
++        <source>Files (*.xbel)</source>
++        <translation>ຟາຍ (*.xbel)</translation></message>
++    <message>
++        <source>Save File</source>
++        <translation>ບັນທຶກໄຟລ໌</translation></message>
++    <message>
++        <source>Qt Assistant</source>
++        <translation>Qt Assistant</translation></message>
++    <message>
++        <source>Unable to save bookmarks.</source>
++        <translation>ບໍ່ສາມາດບັນທຶກບຸກມາກໄດ້.</translation></message>
++    <message>
++        <source>You are goingto delete a Folder, this will also&lt;br&gt; remove it's content. Are you sure to continue?</source>
++        <translation>ທ່ານກຳລັງຈະລຶບໂຟນເດີ, ນີ້ຈະ&lt;br&gt; ລຶບເນື້ອໃນຂອງມັນອອກເຊັ່ນກັນ. ທ່ານແນ່ໃຈທີ່ຈະດຳເນີນຕໍ່ບໍ?</translation></message>
++    <message>
++        <source>Delete Folder</source>
++        <translation>ລຶບໂຟນເດີ</translation></message>
++    <message>
++        <source>Rename Folder</source>
++        <translation>ປ່ຽນຊື່ໂຟນເດີ</translation></message>
++    <message>
++        <source>Show Bookmark</source>
++        <translation>ສະແດງບຸກມາກ</translation></message>
++    <message>
++        <source>Show Bookmark in New Tab</source>
++        <translation>ສະແດງບຸກມາກໃນແຖບໃໝ່</translation></message>
++    <message>
++        <source>Delete Bookmark</source>
++        <translation>ລຶບບຸກມາກ</translation></message>
++    <message>
++        <source>Rename Bookmark</source>
++        <translation>ປ່ຽນຊື່ບຸກມາກ</translation></message>
++</context>
++<context>
++    <name>BookmarkModel</name>
++    <message>
++        <source>Name</source>
++        <translation>ຊື່</translation></message>
++    <message>
++        <source>Address</source>
++        <translation>ທີ່ຢູ່</translation></message>
++    <message>
++        <source>Bookmarks Toolbar</source>
++        <translation>ແຖບເຄື່ອງມືບຸກມາກ</translation></message>
++    <message>
++        <source>Bookmarks Menu</source>
++        <translation>ເມນູບຸກມາກ</translation></message>
++</context>
++<context>
++    <name>BookmarkWidget</name>
++    <message>
++        <source>Bookmarks</source>
++        <translation>ບຸກມາກ</translation></message>
++    <message>
++        <source>Filter:</source>
++        <translation>ກັ່ນຕອງ:</translation></message>
++    <message>
++        <source>Add</source>
++        <translation>ເພີ່ມ</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++</context>
++<context>
++    <name>CentralWidget</name>
++    <message>
++        <source>Print Document</source>
++        <translation>ພິມເອກະສານ</translation></message>
++</context>
++<context>
++    <name>CmdLineParser</name>
++    <message>
++        <source>Usage: assistant [Options]
++
++-collectionFile file       Uses the specified collection
++                           file instead of the default one
++-showUrl url               Shows the document with the
++                           url.
++-enableRemoteControl       Enables Assistant to be
++                           remotely controlled.
++-show widget               Shows the specified dockwidget
++                           which can be "contents", "index",
++                           "bookmarks" or "search".
++-activate widget           Activates the specified dockwidget
++                           which can be "contents", "index",
++                           "bookmarks" or "search".
++-hide widget               Hides the specified dockwidget
++                           which can be "contents", "index"
++                           "bookmarks" or "search".
++-register helpFile         Registers the specified help file
++                           (.qch) in the given collection
++                           file.
++-unregister helpFile       Unregisters the specified help file
++                           (.qch) from the give collection
++                           file.
++-setCurrentFilter filter   Set the filter as the active filter.
++-remove-search-index       Removes the full text search index.
++-rebuild-search-index      Obsolete. Use -remove-search-index instead.
++                           Removes the full text search index.
++                           It will be rebuilt on next Assistant run.
++-quiet                     Does not display any error or
++                           status message.
++-help                      Displays this help.
++</source>
++        <translation>ການນຳໃຊ້: assistant [ຕົວເລືອກ]
++
++-collectionFile ໄຟລ໌       ໃຊ້ໄຟລ໌ຄອນເລັກຊັນທີ່ລະບຸແທນທີ່ຈະໃຊ້ໄຟລ໌ເລີ່ມຕົ້ນ
++-showUrl url               ສະແດງເອກະສານທີ່ມີ url ນັ້ນ.
++-enableRemoteControl       ເປີດໃຊ້ງານການຄວບຄຸມຈາກໄກສຳລັບ Assistant.
++-show widget               ສະແດງ dockwidget ທີ່ລະບຸເຊັ່ນ "contents", "index",
++                           "bookmarks" ຫຼື "search".
++-activate widget           ເປີດໃຊ້ງານ dockwidget ທີ່ລະບຸເຊັ່ນ "contents", "index",
++                           "bookmarks" ຫຼື "search".
++-hide widget               ເຊື່ອງ dockwidget ທີ່ລະບຸເຊັ່ນ "contents", "index"
++                           "bookmarks" ຫຼື "search".
++-register helpFile         ລົງທະບຽນໄຟລ໌ຊ່ວຍເຫຼືອທີ່ລະບຸ (.qch) ໃນໄຟລ໌ຄອນເລັກຊັນທີ່ໃຫ້.
++-unregister helpFile       ຍົກເລີກການລົງທະບຽນໄຟລ໌ຊ່ວຍເຫຼືອທີ່ລະບຸ (.qch) ຈາກໄຟລ໌ຄອນເລັກຊັນທີ່ໃຫ້.
++-setCurrentFilter filter   ຕັ້ງຕົວກອງເປັນຕົວກອງທີ່ໃຊ້ງານຢູ່.
++-remove-search-index       ລຶບດັດສະນີການຄົ້ນຫາຂໍ້ຄວາມເຕັມ.
++-rebuild-search-index      ລ້າສະໄໝ. ໃຊ້ -remove-search-index ແທນ.
++                           ລຶບດັດສະນີການຄົ້ນຫາຂໍ້ຄວາມເຕັມ.
++                           ມັນຈະຖືກສ້າງຄືນໃໝ່ໃນການໃຊ້ງານ Assistant ຄັ້ງຕໍ່ໄປ.
++-quiet                     ບໍ່ສະແດງຂໍ້ຄວາມຜິດພາດ ຫຼື ສະຖານະໃດໆ.
++-help                      ສະແດງຄວາມຊ່ວຍເຫຼືອນີ້.</translation></message>
++    <message>
++        <source>Unknown option: %1</source>
++        <translation>ທາງເລືອກທີ່ບໍ່ຮູ້: %1</translation></message>
++    <message>
++        <source>The collection file '%1' does not exist.</source>
++        <translation>ໄຟລ໌ຄໍເລັກຊັນ '%1' ບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>Missing collection file.</source>
++        <translation>ບໍ່ມີໄຟລ໌ການລວບລວມ.</translation></message>
++    <message>
++        <source>Invalid URL '%1'.</source>
++        <translation>URL ບໍ່ຖືກຕ້ອງ '%1'.</translation></message>
++    <message>
++        <source>Missing URL.</source>
++        <translation>ຂາດ URL.</translation></message>
++    <message>
++        <source>Unknown widget: %1</source>
++        <translation>ວິດເຈັດທີ່ບໍ່ຮູ້ຈັກ: %1</translation></message>
++    <message>
++        <source>Missing widget.</source>
++        <translation>ວິດເຈັດຫາຍໄປ.</translation></message>
++    <message>
++        <source>The Qt help file '%1' does not exist.</source>
++        <translation>ໄຟລ໌ຊ່ວຍເຫຼືອ Qt '%1' ບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>Missing help file.</source>
++        <translation>ໄຟລ໌ຊ່ວຍເຫຼືອບໍ່ມີ.</translation></message>
++    <message>
++        <source>Missing filter argument.</source>
++        <translation>ຂໍ້ມູນຕົວກອງການກັ່ນຕອງບໍ່ພົບ.</translation></message>
++    <message>
++        <source>Error</source>
++        <translation>ຜິດພາດ</translation></message>
++    <message>
++        <source>Notice</source>
++        <translation>ແຈ້ງເຕືອນ</translation></message>
++</context>
++<context>
++    <name>ContentWindow</name>
++    <message>
++        <source>Open Link</source>
++        <translation>ເປີດລິງ</translation></message>
++    <message>
++        <source>Open Link in New Tab</source>
++        <translation>ເປີດລິງໃນແທບໃໝ່</translation></message>
++</context>
++<context>
++    <name>FilterNameDialogClass</name>
++    <message>
++        <source>Add Filter Name</source>
++        <translation>ເພີ່ມຊື່ຕົວກັ່ນຕອງ</translation></message>
++    <message>
++        <source>Filter Name:</source>
++        <translation>ຊື່ຕົວກອງ:</translation></message>
++</context>
++<context>
++    <name>FindWidget</name>
++    <message>
++        <source>Previous</source>
++        <translation>ກ່ອນໜ້ານີ້</translation></message>
++    <message>
++        <source>Next</source>
++        <translation>ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Case Sensitive</source>
++        <translation>ກໍລະນີອ່ານອັກສອນໃຫຍ່-ນ້ອຍ</translation></message>
++    <message>
++        <source>&lt;img src=":/qt-project.org/assistant/images/wrap.png"&gt;&amp;nbsp;Search wrapped</source>
++        <translation>&lt;img src=":/qt-project.org/assistant/images/wrap.png"&gt;&amp;nbsp;ຄົ້ນຫາທີ່ຫໍ່ຫຸ້ມ</translation></message>
++</context>
++<context>
++    <name>FontPanel</name>
++    <message>
++        <source>Font</source>
++        <translation>ຟອນ</translation></message>
++    <message>
++        <source>&amp;Writing system</source>
++        <translation>&amp;lt;ລະບົບການຂຽນ</translation></message>
++    <message>
++        <source>&amp;Family</source>
++        <translation>&amp;ຄອບຄົວ</translation></message>
++    <message>
++        <source>&amp;Style</source>
++        <translation>&amp;ຮູບແບບ</translation></message>
++    <message>
++        <source>&amp;Point size</source>
++        <translation>ຂະໜາດຈຸດ</translation></message>
++</context>
++<context>
++    <name>GlobalActions</name>
++    <message>
++        <source>&amp;Back</source>
++        <translation>&amp;ກັບຄືນ</translation></message>
++    <message>
++        <source>&amp;Forward</source>
++        <translation>&amp;ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>&amp;Home</source>
++        <translation>&amp;ໜ້າຫຼັກ</translation></message>
++    <message>
++        <source>ALT+Home</source>
++        <translation>ALT+Home</translation></message>
++    <message>
++        <source>Zoom &amp;in</source>
++        <translation>ຂະຫຍາຍ &amp;in</translation></message>
++    <message>
++        <source>Zoom &amp;out</source>
++        <translation>ຂະຫຍາຍອອກ</translation></message>
++    <message>
++        <source>&amp;Copy selected Text</source>
++        <translation>&amp;lt;ສຳເນົາຂໍ້ຄວາມທີ່ເລືອກ&amp;gt;</translation></message>
++    <message>
++        <source>&amp;Print...</source>
++        <translation>&amp;ພິມ...</translation></message>
++    <message>
++        <source>&amp;Find in Text...</source>
++        <translation>&amp;ຊອກຫາໃນຂໍ້ຄວາມ...</translation></message>
++    <message>
++        <source>&amp;Find</source>
++        <translation>&amp;ຊອກຫາ</translation></message>
++</context>
++<context>
++    <name>HelpEngineWrapper</name>
++    <message>
++        <source>Unfiltered</source>
++        <translation>ບໍ່ມີການກັ່ນຕອງ</translation></message>
++</context>
++<context>
++    <name>HelpViewer</name>
++    <message>
++        <source>Error 404...</source>
++        <translation>ຜິດພາດ 404...</translation></message>
++    <message>
++        <source>The page could not be found</source>
++        <translation>ໜ້ານີ້ບໍ່ພົບເຫັນ</translation></message>
++    <message>
++        <source>Please make sure that you have all documentation sets installed.</source>
++        <translation>ກະລຸນາຮັບປະກັນວ່າທ່ານໄດ້ຕິດຕັ້ງຊຸດເອກະສານທັງໝົດແລ້ວ.</translation></message>
++    <message>
++        <source>Error loading: %1</source>
++        <translation>ຜິດພາດໃນການໂຫຼດ: %1</translation></message>
++    <message>
++        <source>&lt;title&gt;about:blank&lt;/title&gt;</source>
++        <translation>&lt;title&gt;ກ່ຽວກັບ:ຫວ່າງ&lt;/title&gt;</translation></message>
++    <message>
++        <source>&lt;title&gt;Error 404...&lt;/title&gt;&lt;div align="center"&gt;&lt;br&gt;&lt;br&gt;&lt;h1&gt;The page could not be found.&lt;/h1&gt;&lt;br&gt;&lt;h3&gt;'%1'&lt;/h3&gt;&lt;/div&gt;</source>
++        <translation>&lt;title&gt;ຂໍ້ຜິດພາດ 404...&lt;/title&gt;&lt;div align="center"&gt;&lt;br&gt;&lt;br&gt;&lt;h1&gt;ບໍ່ສາມາດພົບໜ້ານີ້ໄດ້.&lt;/h1&gt;&lt;br&gt;&lt;h3&gt;'%1'&lt;/h3&gt;&lt;/div&gt;</translation></message>
++    <message>
++        <source>Open Link</source>
++        <translation>ເປີດລິງ</translation></message>
++    <message>
++        <source>Open Link in New Tab	Ctrl+LMB</source>
++        <translation>ເປີດລິງໃນແທບໃໝ່	Ctrl+LMB</translation></message>
++    <message>
++        <source>Copy &amp;Link Location</source>
++        <translation>ສຳເນົາ &amp;ຕຳແໜ່ງລິ້ງ</translation></message>
++    <message>
++        <source>Copy</source>
++        <translation>ສຳເນົາ</translation></message>
++    <message>
++        <source>Reload</source>
++        <translation>ໂຫຼດຄືນໃໝ່</translation></message>
++    <message>
++        <source>Open Link in New Page</source>
++        <translation>ເປີດລິງໃນໜ້າໃໝ່</translation></message>
++</context>
++<context>
++    <name>IndexWindow</name>
++    <message>
++        <source>&amp;Look for:</source>
++        <translation>&amp;ຊອກຫາ:</translation></message>
++    <message>
++        <source>Open Link</source>
++        <translation>ເປີດລິງ</translation></message>
++    <message>
++        <source>Open Link in New Tab</source>
++        <translation>ເປີດລິ້ງໃນແທັບໃໝ່</translation></message>
++</context>
++<context>
++    <name>MainWindow</name>
++    <message>
++        <source>Index</source>
++        <translation>ດັດສະນີ</translation></message>
++    <message>
++        <source>Contents</source>
++        <translation>ເນື້ອໃນ</translation></message>
++    <message>
++        <source>Search</source>
++        <translation>ຄົ້ນຫາ</translation></message>
++    <message>
++        <source>Bookmarks</source>
++        <translation>ບຸກມາກ</translation></message>
++    <message>
++        <source>Open Pages</source>
++        <translation>ເປີດໜ້າ</translation></message>
++    <message>
++        <source>Qt Assistant</source>
++        <translation>Qt Assistant</translation></message>
++    <message>
++        <source>Bookmark Toolbar</source>
++        <translation>ແຖບເຄື່ອງມືບຸກມາກ</translation></message>
++    <message>
++        <source>Looking for Qt Documentation...</source>
++        <translation>ກຳລັງຊອກຫາເອກະສານ Qt...</translation></message>
++    <message>
++        <source>&amp;File</source>
++        <translation>&amp;ໄຟລ໌</translation></message>
++    <message>
++        <source>New &amp;Tab</source>
++        <translation>ໃໝ່ &amp;Tab</translation></message>
++    <message>
++        <source>&amp;Close Tab</source>
++        <translation>&amp;ປິດແຖບ</translation></message>
++    <message>
++        <source>Page Set&amp;up...</source>
++        <translation>ຕັ້ງຄ່າໜ້າ...</translation></message>
++    <message>
++        <source>Print Preview...</source>
++        <translation>ພິມຕົວຢ່າງ...</translation></message>
++    <message>
++        <source>E&amp;xit</source>
++        <translation>E&amp;xit</translation></message>
++    <message>
++        <source>CTRL+Q</source>
++        <translation>CTRL+Q</translation></message>
++    <message>
++        <source>&amp;Quit</source>
++        <translation>&amp;ອອກ</translation></message>
++    <message>
++        <source>&amp;Edit</source>
++        <translation>&amp;ແກ້ໄຂ</translation></message>
++    <message>
++        <source>Find &amp;Next</source>
++        <translation>ຊອກຫາ &amp; ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Find &amp;Previous</source>
++        <translation>ຊອກຫາ &amp; ກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>Preferences...</source>
++        <translation>ການຕັ້ງຄ່າ...</translation></message>
++    <message>
++        <source>&amp;View</source>
++        <translation>&amp;ເບິ່ງ</translation></message>
++    <message>
++        <source>Normal &amp;Size</source>
++        <translation>ປົກກະຕິ &amp;Size</translation></message>
++    <message>
++        <source>Ctrl+0</source>
++        <translation>Ctrl+0</translation></message>
++    <message>
++        <source>ALT+C</source>
++        <translation>ALT+C</translation></message>
++    <message>
++        <source>ALT+I</source>
++        <translation>ALT+I</translation></message>
++    <message>
++        <source>ALT+O</source>
++        <translation>ALT+O</translation></message>
++    <message>
++        <source>ALT+S</source>
++        <translation>ALT+S</translation></message>
++    <message>
++        <source>ALT+P</source>
++        <translation>ALT+P</translation></message>
++    <message>
++        <source>&amp;Go</source>
++        <translation>&amp;ໄປ</translation></message>
++    <message>
++        <source>Sync with Table of Contents</source>
++        <translation>ຊິງກັບຕາຕະລາງເນື້ອໃນ</translation></message>
++    <message>
++        <source>Sync</source>
++        <translation>ຊິງຄ໌</translation></message>
++    <message>
++        <source>Next Page</source>
++        <translation>ຫນ້າຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Ctrl+Alt+Right</source>
++        <translation>Ctrl+Alt+Right</translation></message>
++    <message>
++        <source>Previous Page</source>
++        <translation>ຫນ້າກ່ອນຫນ້າ</translation></message>
++    <message>
++        <source>Ctrl+Alt+Left</source>
++        <translation>Ctrl+Alt+Left</translation></message>
++    <message>
++        <source>&amp;Bookmarks</source>
++        <translation>&amp;ບຸກມາກ</translation></message>
++    <message>
++        <source>&amp;Help</source>
++        <translation>&amp;ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>About...</source>
++        <translation>ກ່ຽວກັບ...</translation></message>
++    <message>
++        <source>Navigation Toolbar</source>
++        <translation>ແຖບເຄື່ອງມືນຳທາງ</translation></message>
++    <message>
++        <source>&amp;Window</source>
++        <translation>&amp;ຫນ້າຕ່າງ</translation></message>
++    <message>
++        <source>Zoom</source>
++        <translation>ຊູມ</translation></message>
++    <message>
++        <source>Minimize</source>
++        <translation>ຫຼຸດຂະຫນາດນ້ອຍສຸດ</translation></message>
++    <message>
++        <source>Ctrl+M</source>
++        <translation>Ctrl+M</translation></message>
++    <message>
++        <source>Toolbars</source>
++        <translation>ແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>Filter Toolbar</source>
++        <translation>ແຖບເຄື່ອງມືກັ່ນຕອງ</translation></message>
++    <message>
++        <source>Filtered by:</source>
++        <translation>ກັ່ນຕອງໂດຍ:</translation></message>
++    <message>
++        <source>Address Toolbar</source>
++        <translation>ແຖບທີ່ຢູ່</translation></message>
++    <message>
++        <source>Address:</source>
++        <translation>ທີ່ຢູ່:</translation></message>
++    <message>
++        <source>Could not find the associated content item.</source>
++        <translation>ບໍ່ສາມາດຊອກຫາລາຍການເນື້ອຫາທີ່ກ່ຽວຂ້ອງໄດ້.</translation></message>
++    <message>
++        <source>&lt;center&gt;&lt;h3&gt;%1&lt;/h3&gt;&lt;p&gt;Version %2&lt;/p&gt;&lt;p&gt;Browser: %3&lt;/p&gt;&lt;/center&gt;&lt;p&gt;Copyright (C) %4 The Qt Company Ltd.&lt;/p&gt;</source>
++        <translation>&lt;center&gt;&lt;h3&gt;%1&lt;/h3&gt;&lt;p&gt;ເວີຊັນ %2&lt;/p&gt;&lt;p&gt;ບຣາວເຊີ: %3&lt;/p&gt;&lt;/center&gt;&lt;p&gt;ລິຂະສິດ (C) %4 ບໍລິສັດ The Qt ຈຳກັດ&lt;/p&gt;</translation></message>
++    <message>
++        <source>About %1</source>
++        <translation>ກ່ຽວກັບ %1</translation></message>
++    <message>
++        <source>Updating search index</source>
++        <translation>ອັບເດດດັດຊະນີການຊອກຫາ</translation></message>
++    <message>
++        <source>Could not register file '%1': %2</source>
++        <translation>ບໍ່ສາມາດລົງທະບຽນໄຟລ໌ '%1': %2</translation></message>
++</context>
++<context>
++    <name>OpenPagesWidget</name>
++    <message>
++        <source>Close %1</source>
++        <translation>ປິດ %1</translation></message>
++    <message>
++        <source>Close All Except %1</source>
++        <translation>ປິດທຸກຢ່າງເວັ້ນເສຍແຕ່ %1</translation></message>
++</context>
++<context>
++    <name>PreferencesDialog</name>
++    <message>
++        <source>Add Documentation</source>
++        <translation>ເພີ່ມເອກະສານ</translation></message>
++    <message>
++        <source>Qt Compressed Help Files (*.qch)</source>
++        <translation>Qt ເອກະສານຊ່ວຍເຫຼືອທີ່ບີບອັດ (*.qch)</translation></message>
++    <message>
++        <source>The namespace %1 is already registered!</source>
++        <translation>ຊື່ເຂດ %1 ໄດ້ຖືກລົງທະບຽນແລ້ວ!</translation></message>
++    <message>
++        <source>The specified file is not a valid Qt Help File!</source>
++        <translation>ໄຟລ໌ທີ່ກຳນົດໄວ້ບໍ່ແມ່ນໄຟລ໌ຊ່ວຍເຫຼືອ Qt ທີ່ຖືກຕ້ອງ!</translation></message>
++    <message>
++        <source>Remove Documentation</source>
++        <translation>ລຶບເອກະສານການນຳໃຊ້</translation></message>
++    <message>
++        <source>Some documents currently opened in Assistant reference the documentation you are attempting to remove. Removing the documentation will close those documents.</source>
++        <translation>ເອກະສານບາງສ່ວນທີ່ກຳລັງເປີດຢູ່ໃນຜູ້ຊ່ວຍອ້າງອີງເຖິງເອກະສານທີ່ທ່ານກຳລັງພະຍາຍາມລຶບອອກ. ການລຶບເອກະສານອອກຈະປິດເອກະສານເຫຼົ່ານັ້ນ.</translation></message>
++    <message>
++        <source>Cancel</source>
++        <translation>ຍົກເລີກ</translation></message>
++    <message>
++        <source>OK</source>
++        <translation>ຕົກລົງ</translation></message>
++    <message>
++        <source>Use custom settings</source>
++        <translation>ໃຊ້ການຕັ້ງຄ່າທີ່ກຳນົດເອງ</translation></message>
++</context>
++<context>
++    <name>PreferencesDialogClass</name>
++    <message>
++        <source>Preferences</source>
++        <translation>ການຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>Fonts</source>
++        <translation>ຟອນ</translation></message>
++    <message>
++        <source>Font settings:</source>
++        <translation>ການຕັ້ງຄ່າຟອນ:</translation></message>
++    <message>
++        <source>Browser</source>
++        <translation>ບຣາວເຊີ</translation></message>
++    <message>
++        <source>Application</source>
++        <translation>ແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>Filters</source>
++        <translation>ຕົວກອງ</translation></message>
++    <message>
++        <source>Filter:</source>
++        <translation>ກັ່ນຕອງ:</translation></message>
++    <message>
++        <source>Attributes:</source>
++        <translation>ຄຸນລັກສະນະ:</translation></message>
++    <message>
++        <source>1</source>
++        <translation>1</translation></message>
++    <message>
++        <source>Add</source>
++        <translation>ເພີ່ມ</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Documentation</source>
++        <translation>ເອກະສານອ້າງອີງ</translation></message>
++    <message>
++        <source>Registered Documentation:</source>
++        <translation>ຈົດໝາຍທະບຽນທີ່ລົງທະບຽນແລ້ວ:</translation></message>
++    <message>
++        <source>&lt;Filter&gt;</source>
++        <translation>&lt;Filter&gt;</translation></message>
++    <message>
++        <source>Add...</source>
++        <translation>ເພີ່ມ...</translation></message>
++    <message>
++        <source>Options</source>
++        <translation>ຕົວເລືອກ</translation></message>
++    <message>
++        <source>On help start:</source>
++        <translation>ກ່ຽວກັບການເລີ່ມຕົ້ນຊ່ວຍເຫຼືອ:</translation></message>
++    <message>
++        <source>Show my home page</source>
++        <translation>ສະແດງໜ້າຫຼັກຂອງຂ້ອຍ</translation></message>
++    <message>
++        <source>Show a blank page</source>
++        <translation>ສະແດງໜ້າວ່າງ</translation></message>
++    <message>
++        <source>Show my tabs from last session</source>
++        <translation>ສະແດງແຖບຂອງຂ້ອຍຈາກເຊດຊັນກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>Homepage</source>
++        <translation>ໜ້າຫຼັກ</translation></message>
++    <message>
++        <source>Current Page</source>
++        <translation>ຫນ້າປັດຈຸບັນ</translation></message>
++    <message>
++        <source>Blank Page</source>
++        <translation>ໜ້າຫວ່າງ</translation></message>
++    <message>
++        <source>Restore to default</source>
++        <translation>ຟື້ນຟູເປັນຄ່າເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Appearance</source>
++        <translation>ຮູບລັກສະນະ</translation></message>
++    <message>
++        <source>Show tabs for each individual page</source>
++        <translation>ສະແດງແຖບສໍາລັບແຕ່ລະໜ້າດ່ຽວ</translation></message>
++</context>
++<context>
++    <name>RemoteControl</name>
++    <message>
++        <source>Debugging Remote Control</source>
++        <translation>ກຳລັງດີບັກການຄວບຄຸມທາງໄກ</translation></message>
++    <message>
++        <source>Received Command: %1 %2</source>
++        <translation>ຮັບຄຳສັ່ງ: %1 %2</translation></message>
++</context>
++<context>
++    <name>SearchWidget</name>
++    <message>
++        <source>&amp;Copy</source>
++        <translation>&amp;ສຳເນົາ</translation></message>
++    <message>
++        <source>Copy &amp;Link Location</source>
++        <translation>ສຳເນົາ &amp;ຕຳແໜ່ງລິ້ງ</translation></message>
++    <message>
++        <source>Open Link in New Tab</source>
++        <translation>ເປີດລິ້ງໃນແທັບໃໝ່</translation></message>
++    <message>
++        <source>Select All</source>
++        <translation>ເລືອກທັງໝົດ</translation></message>
++</context>
++<context>
++    <name>TabBar</name>
++    <message>
++        <source>(Untitled)</source>
++        <translation>(ບໍ່ມີຫົວຂໍ້)</translation></message>
++    <message>
++        <source>New &amp;Tab</source>
++        <translation>ໃໝ່ &amp;Tab</translation></message>
++    <message>
++        <source>&amp;Close Tab</source>
++        <translation>&amp;ປິດແຖບ</translation></message>
++    <message>
++        <source>Close Other Tabs</source>
++        <translation>ປິດແຖບອື່ນໆ</translation></message>
++    <message>
++        <source>Add Bookmark for this Page...</source>
++        <translation>ເພີ່ມບຸກມາກສໍາລັບໜ້ານີ້...</translation></message>
++</context>
++<context>
++    <name>TopicChooser</name>
++    <message>
++        <source>Choose Topic</source>
++        <translation>ເລືອກຫົວຂໍ້</translation></message>
++    <message>
++        <source>&amp;Topics</source>
++        <translation>&amp;ຫົວຂໍ້</translation></message>
++    <message>
++        <source>&amp;Display</source>
++        <translation>&amp;ສະແດງ</translation></message>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;ປິດ</translation></message>
++    <message>
++        <source>Filter</source>
++        <translation>ກັ່ນຕອງ</translation></message>
++    <message>
++        <source>Choose a topic for &lt;b&gt;%1&lt;/b&gt;:</source>
++        <translation>ເລືອກຫົວຂໍ້ສຳລັບ &lt;b&gt;%1&lt;/b&gt;:</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/designer_lo.ts b/translations/designer_lo.ts
+new file mode 100644
+index 0000000..56db82f
+--- /dev/null
++++ b/translations/designer_lo.ts
+@@ -0,0 +1,4480 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>AbstractFindWidget</name>
++    <message>
++        <source>&amp;Previous</source>
++        <translation>&amp;ກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>&amp;Next</source>
++        <translation>&amp;ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>&amp;Case sensitive</source>
++        <translation>&amp;ຕົວອັກສອນຕ່າງກັນ</translation></message>
++    <message>
++        <source>Whole &amp;words</source>
++        <translation>ທັງໝົດ &amp;ຄຳສັບ</translation></message>
++    <message>
++        <source>&lt;img src=":/qt-project.org/shared/images/wrap.png"&gt;&amp;nbsp;Search wrapped</source>
++        <translation>&lt;img src=":/qt-project.org/shared/images/wrap.png"&gt;&amp;nbsp;ຄົ້ນຫາທີ່ຫໍ່ໄວ້</translation></message>
++</context>
++<context>
++    <name>AbstractItemEditor</name>
++    <message>
++        <source>Selectable</source>
++        <translation>ເລືອກໄດ້</translation></message>
++    <message>
++        <source>Editable</source>
++        <translation>ສາມາດແກ້ໄຂໄດ້</translation></message>
++    <message>
++        <source>DragEnabled</source>
++        <translation>ລາກເພື່ອເປີດໃຊ້ງານ</translation></message>
++    <message>
++        <source>DropEnabled</source>
++        <translation>ອະນຸຍາດໃຫ້ລົງ</translation></message>
++    <message>
++        <source>UserCheckable</source>
++        <translation>ຜູ້ໃຊ້ສາມາດກວດສອບໄດ້</translation></message>
++    <message>
++        <source>Enabled</source>
++        <translation>ເປີດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Tristate</source>
++        <translation>ສາມລັດ</translation></message>
++    <message>
++        <source>Unchecked</source>
++        <translation>ບໍ່ໄດ້ກວດສອບ</translation></message>
++    <message>
++        <source>PartiallyChecked</source>
++        <translation>ກວດສອບບາງສ່ວນ</translation></message>
++    <message>
++        <source>Checked</source>
++        <translation>ກວດສອບແລ້ວ</translation></message>
++</context>
++<context>
++    <name>AddLinkDialog</name>
++    <message>
++        <source>Insert Link</source>
++        <translation>ໃສ່ລິ້ງ</translation></message>
++    <message>
++        <source>Title:</source>
++        <translation>ຫົວຂໍ້:</translation></message>
++    <message>
++        <source>URL:</source>
++        <translation>URL:</translation></message>
++</context>
++<context>
++    <name>AppFontDialog</name>
++    <message>
++        <source>Additional Fonts</source>
++        <translation>ຟອນເພີ່ມເຕີມ</translation></message>
++</context>
++<context>
++    <name>AppFontManager</name>
++    <message>
++        <source>'%1' is not a file.</source>
++        <translation>'%1' ບໍ່ແມ່ນໄຟລ໌.</translation></message>
++    <message>
++        <source>The font file '%1' does not have read permissions.</source>
++        <translation>ໄຟລ໌ຟອນ '%1' ບໍ່ມີສິດທິໃນການອ່ານ.</translation></message>
++    <message>
++        <source>The font file '%1' is already loaded.</source>
++        <translation>ໄຟລ໌ຟອນ '%1' ໄດ້ຖືກໂຫຼດແລ້ວ.</translation></message>
++    <message>
++        <source>The font file '%1' could not be loaded.</source>
++        <translation>ໄຟລ໌ຟອນ '%1' ບໍ່ສາມາດໂຫຼດໄດ້.</translation></message>
++    <message>
++        <source>'%1' is not a valid font id.</source>
++        <translation>'%1' ບໍ່ແມ່ນລະຫັດຟອນທີ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>There is no loaded font matching the id '%1'.</source>
++        <translation>ບໍ່ມີຟອນທີ່ໂຫຼດຕົວອັກສອນທີ່ກົງກັບລະຫັດ '%1'.</translation></message>
++    <message>
++        <source>The font '%1' (%2) could not be unloaded.</source>
++        <translation>ຟອນ '%1' (%2) ບໍ່ສາມາດຖອດອອກໄດ້.</translation></message>
++</context>
++<context>
++    <name>AppFontWidget</name>
++    <message>
++        <source>Fonts</source>
++        <translation>ຟອນ</translation></message>
++    <message>
++        <source>Add font files</source>
++        <translation>ເພີ່ມໄຟລ໌ຟອນ</translation></message>
++    <message>
++        <source>Remove current font file</source>
++        <translation>ລຶບໄຟລ໌ຟອນປະຈຸບັນ</translation></message>
++    <message>
++        <source>Remove all font files</source>
++        <translation>ລຶບໄຟລ໌ຟອນທັງໝົດ</translation></message>
++    <message>
++        <source>Add Font Files</source>
++        <translation>ເພີ່ມໄຟລ໌ຟອນ</translation></message>
++    <message>
++        <source>Font files (*.ttf)</source>
++        <translation>ໄຟລ໌ຟອນ ( *.ttf)</translation></message>
++    <message>
++        <source>Error Adding Fonts</source>
++        <translation>ຜິດພາດໃນການເພີ່ມຟອນ</translation></message>
++    <message>
++        <source>Error Removing Fonts</source>
++        <translation>ຜິດພາດໃນການລຶບໂຟນ</translation></message>
++    <message>
++        <source>Remove Fonts</source>
++        <translation>ລຶບໂຟນ</translation></message>
++    <message>
++        <source>Would you like to remove all fonts?</source>
++        <translation>ທ່ານຕ້ອງການລຶບໂຟນທັງໝົດບໍ?</translation></message>
++</context>
++<context>
++    <name>AppearanceOptionsWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>User Interface Mode</source>
++        <translation>ໂໝດສ່ວນຕິດຕໍ່ຜູ້ໃຊ້</translation></message>
++</context>
++<context>
++    <name>AssistantClient</name>
++    <message>
++        <source>Unable to send request: Assistant is not responding.</source>
++        <translation>ບໍ່ສາມາດສົ່ງຄຳຂໍໄດ້: ຜູ້ຊ່ວຍບໍ່ຕອບສະໜອງ.</translation></message>
++    <message>
++        <source>The binary '%1' does not exist.</source>
++        <translation>ໄຟລ໌ຖານສອງ '%1' ບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>Unable to launch assistant (%1).</source>
++        <translation>ບໍ່ສາມາດເປີດຜູ້ຊ່ວຍ (%1) ໄດ້.</translation></message>
++</context>
++<context>
++    <name>BrushPropertyManager</name>
++    <message>
++        <source>No brush</source>
++        <translation>ບໍ່ມີແປງ</translation></message>
++    <message>
++        <source>Solid</source>
++        <translation>ທົດສອບ</translation></message>
++    <message>
++        <source>Dense 1</source>
++        <translation>ຫນາແຫນ້ນ 1</translation></message>
++    <message>
++        <source>Dense 2</source>
++        <translation>ຫນາແຫນ້ນ 2</translation></message>
++    <message>
++        <source>Dense 3</source>
++        <translation>ຫນາແຫນ້ນ 3</translation></message>
++    <message>
++        <source>Dense 4</source>
++        <translation>ຫນາແຫນ້ນ 4</translation></message>
++    <message>
++        <source>Dense 5</source>
++        <translation>ຫນາແຫນ້ນ 5</translation></message>
++    <message>
++        <source>Dense 6</source>
++        <translation>ຫນາແຫນ້ນ 6</translation></message>
++    <message>
++        <source>Dense 7</source>
++        <translation>ຫນາແຫນ້ນ 7</translation></message>
++    <message>
++        <source>Horizontal</source>
++        <translation>ອອກນອນ</translation></message>
++    <message>
++        <source>Vertical</source>
++        <translation>ຕັ້ງຕົວ</translation></message>
++    <message>
++        <source>Cross</source>
++        <translation>ຂ້າມ</translation></message>
++    <message>
++        <source>Backward diagonal</source>
++        <translation>ທາງເລືອກທາງຫຼັງ</translation></message>
++    <message>
++        <source>Forward diagonal</source>
++        <translation>ຂ້າມໄປຂ້າງໜ້າ</translation></message>
++    <message>
++        <source>Crossing diagonal</source>
++        <translation>ຂ້າມເສັ້ນທາງເສັ້ນທາງທີ່ຂ້າມ</translation></message>
++    <message>
++        <source>Style</source>
++        <translation>ຮູບແບບ</translation></message>
++    <message>
++        <source>Color</source>
++        <translation>ສີ</translation></message>
++    <message>
++        <source>[%1, %2]</source>
++        <translation>[%1, %2]</translation></message>
++</context>
++<context>
++    <name>Command</name>
++    <message>
++        <source>Add connection</source>
++        <translation>ເພີ່ມການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Adjust connection</source>
++        <translation>ປັບປຸງການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Delete connections</source>
++        <translation>ລຶບການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Change source</source>
++        <translation>ປ່ຽນແຫຼ່ງຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Change target</source>
++        <translation>ປ່ຽນເປົ້າໝາຍ</translation></message>
++    <message>
++        <source>Add '%1' to '%2'</source>
++        <extracomment>Command description for adding buttons to a QButtonGroup</extracomment>
++        <translation>ເພີ່ມ '%1' ເຂົ້າໃນ '%2'</translation></message>
++    <message>
++        <source>Morph %1/'%2' into %3</source>
++        <extracomment>MorphWidgetCommand description</extracomment>
++        <translation>ປ່ຽນຮູບຮ່າງ %1/'%2' ເປັນ %3</translation></message>
++    <message>
++        <source>Insert '%1'</source>
++        <translation>ໃສ່ '%1'</translation></message>
++    <message>
++        <source>Change Z-order of '%1'</source>
++        <translation>ປ່ຽນ Z-order ຂອງ '%1'</translation></message>
++    <message>
++        <source>Raise '%1'</source>
++        <translation>ຍົກ '%1'</translation></message>
++    <message>
++        <source>Lower '%1'</source>
++        <translation>ຫຼຸດລົງ '%1'</translation></message>
++    <message>
++        <source>Delete '%1'</source>
++        <translation>ລຶບ '%1'</translation></message>
++    <message>
++        <source>Reparent '%1'</source>
++        <translation>ປ່ຽນພໍ່ແມ່ '%1'</translation></message>
++    <message>
++        <source>Promote to custom widget</source>
++        <translation>ຍົກລະດັບເປັນເວັດເຈັດທີ່ກຳນົດເອງ</translation></message>
++    <message>
++        <source>Demote from custom widget</source>
++        <translation>ຫຼຸດລະດັບຈາກວິດເຈັດທີ່ກຳນົດເອງ</translation></message>
++    <message>
++        <source>Lay out using grid</source>
++        <translation>ຈັດແຈງໂດຍໃຊ້ຕາຂ່າຍ</translation></message>
++    <message>
++        <source>Lay out vertically</source>
++        <translation>ຈັດແຈງແນວຕັ້ງ</translation></message>
++    <message>
++        <source>Lay out horizontally</source>
++        <translation>ຈັດແຈງແນວນອນ</translation></message>
++    <message>
++        <source>Break layout</source>
++        <translation>ຂັດຂວາງການຈັດແຈງໂຄງຮ່າງ</translation></message>
++    <message>
++        <source>Simplify Grid Layout</source>
++        <translation>ງ່າຍຂຶ້ນກັບການຈັດແຈງຕາຕະລາງ</translation></message>
++    <message>
++        <source>Move Page</source>
++        <translation>ຍ້າຍໜ້າ</translation></message>
++    <message>
++        <source>Delete Page</source>
++        <translation>ລຶບໜ້າ</translation></message>
++    <message>
++        <source>Page</source>
++        <translation>ໜ້າ</translation></message>
++    <message>
++        <source>Insert Page</source>
++        <translation>ໃສ່ໜ້າ</translation></message>
++    <message>
++        <source>Change Tab order</source>
++        <translation>ປ່ຽນລຳດັບແຖບ</translation></message>
++    <message>
++        <source>Create Menu Bar</source>
++        <translation>ສ້າງແຖບເມນູ</translation></message>
++    <message>
++        <source>Delete Menu Bar</source>
++        <translation>ລຶບແຖບເມນູ</translation></message>
++    <message>
++        <source>Create Status Bar</source>
++        <translation>ສ້າງແຖບສະຖານະ</translation></message>
++    <message>
++        <source>Delete Status Bar</source>
++        <translation>ລຶບແຖບສະຖານະ</translation></message>
++    <message>
++        <source>Add Tool Bar</source>
++        <translation>ເພີ່ມແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>Add Dock Window</source>
++        <translation>ເພີ່ມຫນ້າຕ່າງ Dock</translation></message>
++    <message>
++        <source>Adjust Size of '%1'</source>
++        <translation>ປັບຂະໜາດຂອງ '%1'</translation></message>
++    <message>
++        <source>Change Form Layout Item Geometry</source>
++        <translation>ປ່ຽນຮູບແບບຂອງລາຍການໃນແບບຟອມ</translation></message>
++    <message>
++        <source>Change Layout Item Geometry</source>
++        <translation>ປ່ຽນຮູບຮ່າງຂອງລາຍການລະບຽບແບບ</translation></message>
++    <message>
++        <source>Delete Subwindow</source>
++        <translation>ລຶບຫນ້າຕ່າງຍ່ອຍ</translation></message>
++    <message>
++        <source>Insert Subwindow</source>
++        <translation>ໃສ່ຫນ້າຕ່າງຍ່ອຍ</translation></message>
++    <message>
++        <source>Subwindow</source>
++        <translation>ຫນ້າຕ່າງຍ່ອຍ</translation></message>
++    <message>
++        <source>Change Table Contents</source>
++        <translation>ປ່ຽນເນື້ອໃນຕາຕະລາງ</translation></message>
++    <message>
++        <source>Change Tree Contents</source>
++        <translation>ປ່ຽນເນື້ອໃນຂອງຕົ້ນໄມ້</translation></message>
++    <message>
++        <source>Add action</source>
++        <translation>ເພີ່ມການກະທຳ</translation></message>
++    <message>
++        <source>Remove action</source>
++        <translation>ລຶບການກະທຳ</translation></message>
++    <message>
++        <source>Add menu</source>
++        <translation>ເພີ່ມເມນູ</translation></message>
++    <message>
++        <source>Remove menu</source>
++        <translation>ລຶບເມນູ</translation></message>
++    <message>
++        <source>Create submenu</source>
++        <translation>ສ້າງເມນູຍ່ອຍ</translation></message>
++    <message>
++        <source>Delete Tool Bar</source>
++        <translation>ລຶບແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>Change layout of '%1' from %2 to %3</source>
++        <translation>ປ່ຽນໂຄງຮ່າງຂອງ '%1' ຈາກ %2 ເປັນ %3</translation></message>
++    <message>
++        <source>Change layout alignment</source>
++        <translation>ປ່ຽນການຈັດຮູບແບບ</translation></message>
++    <message>
++        <source>Set action text</source>
++        <translation>ຕັ້ງຂໍ້ຄວາມການກະທໍາ</translation></message>
++    <message>
++        <source>Insert action</source>
++        <translation>ເພີ່ມການກະທຳ</translation></message>
++    <message>
++        <source>Move action</source>
++        <translation>ການຍ້າຍ</translation></message>
++    <message>
++        <source>Change Title</source>
++        <translation>ປ່ຽນຫົວຂໍ້</translation></message>
++    <message>
++        <source>Insert Menu</source>
++        <translation>ເພີ່ມເມນູ</translation></message>
++    <message>
++        <source>Changed '%1' of '%2'</source>
++        <translation>ປ່ຽນແປງ '%1' ຂອງ '%2'</translation></message>
++    <message numerus="yes">
++        <source>Changed '%1' of %n objects</source>
++        <translation>
++            <numerusform>ປ່ຽນ '%1' ຂອງ %n ວັດຖຸ</numerusform>
++        </translation></message>
++    <message>
++        <source>Reset '%1' of '%2'</source>
++        <translation>ຣີເຊັດ '%1' ຂອງ '%2'</translation></message>
++    <message numerus="yes">
++        <source>Reset '%1' of %n objects</source>
++        <translation>
++            <numerusform>ຣີເຊັດ '%1' ຂອງ %n ວັດຖຸ</numerusform>
++        </translation></message>
++    <message>
++        <source>Add dynamic property '%1' to '%2'</source>
++        <translation>ເພີ່ມຄຸນສົມບັດແບບໄດນາມິກ '%1' ໃສ່ '%2'</translation></message>
++    <message numerus="yes">
++        <source>Add dynamic property '%1' to %n objects</source>
++        <translation>
++            <numerusform>ເພີ່ມຄຸນສົມບັດແບບເຄື່ອນໄຫວ '%1' ໃຫ້ກັບ %n ວັດຖຸ</numerusform>
++        </translation></message>
++    <message>
++        <source>Remove dynamic property '%1' from '%2'</source>
++        <translation>ລຶບຄຸນສົມບັດແບບໄດນາມິກ '%1' ອອກຈາກ '%2'</translation></message>
++    <message numerus="yes">
++        <source>Remove dynamic property '%1' from %n objects</source>
++        <translation>
++            <numerusform>ລຶບຄຸນສົມບັດແບບເຄື່ອນໄຫວ '%1' ອອກຈາກ %n ວັດຖຸ</numerusform>
++        </translation></message>
++    <message>
++        <source>Change signals/slots</source>
++        <translation>ປ່ຽນສັນຍານ/ຊ່ອງ</translation></message>
++    <message>
++        <source>Change signal</source>
++        <translation>ປ່ຽນສັນຍານ</translation></message>
++    <message>
++        <source>Change slot</source>
++        <translation>ປ່ຽນຊ່ອງ</translation></message>
++    <message>
++        <source>Change signal-slot connection</source>
++        <translation>ປ່ຽນການເຊື່ອມຕໍ່ສັນຍານ-ຊັອດ</translation></message>
++    <message>
++        <source>Change sender</source>
++        <translation>ປ່ຽນຜູ້ສົ່ງ</translation></message>
++    <message>
++        <source>Change receiver</source>
++        <translation>ປ່ຽນຜູ້ຮັບ</translation></message>
++    <message>
++        <source>Create button group</source>
++        <translation>ສ້າງກຸ່ມປຸ່ມ</translation></message>
++    <message>
++        <source>Break button group</source>
++        <translation>ປຸ່ມກຸ່ມພັກ</translation></message>
++    <message>
++        <source>Break button group '%1'</source>
++        <translation>ປຸ່ມກຸ່ມ '%1' ພັກ</translation></message>
++    <message>
++        <source>Add buttons to group</source>
++        <translation>ເພີ່ມປຸ່ມເຂົ້າກຸ່ມ</translation></message>
++    <message>
++        <source>Remove buttons from group</source>
++        <translation>ລຶບປຸ່ມອອກຈາກກຸ່ມ</translation></message>
++    <message>
++        <source>Remove '%1' from '%2'</source>
++        <extracomment>Command description for removing buttons from a QButtonGroup</extracomment>
++        <translation>ລຶບ '%1' ອອກຈາກ '%2'</translation></message>
++</context>
++<context>
++    <name>ConnectDialog</name>
++    <message>
++        <source>Configure Connection</source>
++        <translation>ຕັ້ງຄ່າການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>GroupBox</source>
++        <translation>ກຸ່ມບັອກ</translation></message>
++    <message>
++        <source>Edit...</source>
++        <translation>ແກ້ໄຂ...</translation></message>
++    <message>
++        <source>Show signals and slots inherited from QWidget</source>
++        <translation>ສະແດງສັນຍານ ແລະ ຊ່ອງທີ່ສືບທອດມາຈາກ QWidget</translation></message>
++</context>
++<context>
++    <name>ConnectionDelegate</name>
++    <message>
++        <source>&lt;object&gt;</source>
++        <translation>&lt;object&gt;</translation></message>
++    <message>
++        <source>&lt;signal&gt;</source>
++        <translation>&lt;signal&gt;</translation></message>
++    <message>
++        <source>&lt;slot&gt;</source>
++        <translation>&lt;slot&gt;</translation></message>
++</context>
++<context>
++    <name>DPI_Chooser</name>
++    <message>
++        <source>Standard (96 x 96)</source>
++        <extracomment>Embedded device standard screen resolution</extracomment>
++        <translation>ມາດຕະຖານ (96 x 96)</translation></message>
++    <message>
++        <source>Greenphone (179 x 185)</source>
++        <extracomment>Embedded device screen resolution</extracomment>
++        <translation>ໂທລະສັບສີຂຽວ (179 x 185)</translation></message>
++    <message>
++        <source>High (192 x 192)</source>
++        <extracomment>Embedded device high definition screen resolution</extracomment>
++        <translation>ສູງ (192 x 192)</translation></message>
++</context>
++<context>
++    <name>Designer</name>
++    <message>
++        <source>Unable to launch %1.</source>
++        <translation>ບໍ່ສາມາດເປີດໃຊ້ %1 ໄດ້.</translation></message>
++    <message>
++        <source>%1 timed out.</source>
++        <translation>%1 ໝົດເວລາ.</translation></message>
++    <message>
++        <source>Custom Widgets</source>
++        <translation>ວິດເຈັດທີ່ປັບແຕ່ງເອງ</translation></message>
++    <message>
++        <source>Promoted Widgets</source>
++        <translation>ວິດເຈັດທີ່ສົ່ງເສີມ</translation></message>
++    <message>
++        <source>Qt Designer</source>
++        <translation>Qt Designer</translation></message>
++    <message>
++        <source>This file cannot be read because the extra info extension failed to load.</source>
++        <translation>ໄຟລ໌ນີ້ບໍ່ສາມາດອ່ານໄດ້ເພາະວ່າສ່ວນຂະຫຍາຍຂໍ້ມູນເພີ່ມເຕີມບໍ່ສາມາດໂຫຼດໄດ້.</translation></message>
++</context>
++<context>
++    <name>DesignerMetaEnum</name>
++    <message>
++        <source>%1 is not a valid enumeration value of '%2'.</source>
++        <translation>%1 ບໍ່ແມ່ນຄ່າການຈັດລຽງທີ່ຖືກຕ້ອງຂອງ '%2'.</translation></message>
++    <message>
++        <source>'%1' could not be converted to an enumeration value of type '%2'.</source>
++        <translation>'%1' ບໍ່ສາມາດປ່ຽນເປັນຄ່າການຈັດລຽງປະເພດ '%2' ໄດ້.</translation></message>
++</context>
++<context>
++    <name>DesignerMetaFlags</name>
++    <message>
++        <source>'%1' could not be converted to a flag value of type '%2'.</source>
++        <translation>'%1' ບໍ່ສາມາດປ່ຽນເປັນຄ່າທຸງປະເພດ '%2' ໄດ້.</translation></message>
++</context>
++<context>
++    <name>DeviceProfile</name>
++    <message>
++        <source>'%1' is not a number.</source>
++        <extracomment>Reading a number for an embedded device profile</extracomment>
++        <translation>'%1' ບໍ່ແມ່ນຕົວເລກ.</translation></message>
++    <message>
++        <source>An invalid tag &lt;%1&gt; was encountered.</source>
++        <translation>ແທັກ &lt;%1&gt; ທີ່ບໍ່ຖືກຕ້ອງໄດ້ຖືກພົບເຫັນ.</translation></message>
++</context>
++<context>
++    <name>DeviceProfileDialog</name>
++    <message>
++        <source>&amp;Family</source>
++        <translation>&amp;ຄອບຄົວ</translation></message>
++    <message>
++        <source>&amp;Point Size</source>
++        <translation>&amp;ຂະໜາດຈຸດ</translation></message>
++    <message>
++        <source>Style</source>
++        <translation>ຮູບແບບ</translation></message>
++    <message>
++        <source>Device DPI</source>
++        <translation>ອຸປະກອນ DPI</translation></message>
++    <message>
++        <source>Name</source>
++        <translation>ຊື່</translation></message>
++</context>
++<context>
++    <name>DeviceSkin</name>
++    <message>
++        <source>The image file '%1' could not be loaded.</source>
++        <translation>ຟາຍຮູບພາບ '%1' ບໍ່ສາມາດໂຫຼດໄດ້.</translation></message>
++    <message>
++        <source>The skin directory '%1' does not contain a configuration file.</source>
++        <translation>ໂຟນເດີສະກິນ '%1' ບໍ່ມີໄຟລ໌ການຕັ້ງຄ່າ.</translation></message>
++    <message>
++        <source>The skin configuration file '%1' could not be opened.</source>
++        <translation>ຟາຍການຕັ້ງຄ່າຜິວ '%1' ບໍ່ສາມາດເປີດໄດ້.</translation></message>
++    <message>
++        <source>The skin configuration file '%1' could not be read: %2</source>
++        <translation>ຟາຍການຕັ້ງຄ່າຜິວ '%1' ບໍ່ສາມາດອ່ານໄດ້: %2</translation></message>
++    <message>
++        <source>Syntax error: %1</source>
++        <translation>ຂໍ້ຜິດພາດທາງວິທີການຂຽນ: %1</translation></message>
++    <message>
++        <source>The skin "up" image file '%1' does not exist.</source>
++        <translation>ຟາຍຮູບພາບ "ຂຶ້ນ" ຂອງຜິວ '%1' ບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>The skin "down" image file '%1' does not exist.</source>
++        <translation>ຟາຍຮູບພາບ "down" ຂອງຜິວຫນັງ '%1' ບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>The skin "closed" image file '%1' does not exist.</source>
++        <translation>ຟາຍຮູບພາບ "ປິດ" ຂອງຜິວໜັງ '%1' ບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>The skin cursor image file '%1' does not exist.</source>
++        <translation>ໄຟລ໌ຮູບພາບຕົວຊີ້ວັດຜິວຫນັງ '%1' ບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>Syntax error in area definition: %1</source>
++        <translation>ຂໍ້ຜິດພາດໃນການກໍານົດພື້ນທີ່: %1</translation></message>
++    <message>
++        <source>Mismatch in number of areas, expected %1, got %2.</source>
++        <translation>ຈຳນວນພື້ນທີ່ບໍ່ກົງກັນ, ຄາດຫວັງ %1, ໄດ້ຮັບ %2.</translation></message>
++</context>
++<context>
++    <name>EmbeddedOptionsControl</name>
++    <message>
++        <source>&lt;html&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;&lt;b&gt;Font&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1, %2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;b&gt;Style&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;b&gt;Resolution&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4 x %5&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/html&gt;</source>
++        <extracomment>Format embedded device profile description</extracomment>
++        <translation>&lt;html&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;&lt;b&gt;ຟອນ&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1, %2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;b&gt;ຮູບແບບ&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;b&gt;ຄວາມລະອຽດ&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4 x %5&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/html&gt;</translation></message>
++</context>
++<context>
++    <name>EmbeddedOptionsPage</name>
++    <message>
++        <source>Embedded Design</source>
++        <extracomment>Tab in preferences dialog</extracomment>
++        <translation>ການອອກແບບທີ່ຝັງເຂົ້າ</translation></message>
++    <message>
++        <source>Device Profiles</source>
++        <extracomment>EmbeddedOptionsControl group box"</extracomment>
++        <translation>ໂປຣໄຟລ໌ອຸປະກອນ</translation></message>
++</context>
++<context>
++    <name>FontPanel</name>
++    <message>
++        <source>Font</source>
++        <translation>ຟອນ</translation></message>
++    <message>
++        <source>&amp;Writing system</source>
++        <translation>&amp;lt;ລະບົບການຂຽນ</translation></message>
++    <message>
++        <source>&amp;Family</source>
++        <translation>&amp;ຄອບຄົວ</translation></message>
++    <message>
++        <source>&amp;Style</source>
++        <translation>&amp;ຮູບແບບ</translation></message>
++    <message>
++        <source>&amp;Point size</source>
++        <translation>&amp;ຂະໜາດຈຸດ</translation></message>
++</context>
++<context>
++    <name>FontPropertyManager</name>
++    <message>
++        <source>PreferDefault</source>
++        <translation>ຕ້ອງການຄ່າເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>NoAntialias</source>
++        <translation>ບໍ່ມີການຕໍ່ຕ້ານການສະຫຼັບສີ</translation></message>
++    <message>
++        <source>PreferAntialias</source>
++        <translation>ຕ້ອງການການຕໍ່ຕ້ານການສະກົດຄຳ</translation></message>
++    <message>
++        <source>Antialiasing</source>
++        <translation>ການຕ້ານການສັ່ນສະເທືອນ</translation></message>
++</context>
++<context>
++    <name>FormBuilder</name>
++    <message>
++        <source>Invalid stretch value for '%1': '%2'</source>
++        <extracomment>Parsing layout stretch values</extracomment>
++        <translation>ຄ່າການຍືດທີ່ບໍ່ຖືກຕ້ອງສໍາລັບ '%1': '%2'</translation></message>
++    <message>
++        <source>Invalid minimum size for '%1': '%2'</source>
++        <extracomment>Parsing grid layout minimum size values</extracomment>
++        <translation>ຂະໜາດຕ່ຳສຸດທີ່ບໍ່ຖືກຕ້ອງສຳລັບ '%1': '%2'</translation></message>
++</context>
++<context>
++    <name>FormEditorOptionsPage</name>
++    <message>
++        <source>%1 %</source>
++        <extracomment>Zoom percentage</extracomment>
++        <translation>%1 %</translation></message>
++    <message>
++        <source>Preview Zoom</source>
++        <translation>ຂະຫຍາຍຕົວຢ່າງກ່ອນພິມ</translation></message>
++    <message>
++        <source>Default Zoom</source>
++        <translation>ຂະຫນາດເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Forms</source>
++        <extracomment>Tab in preferences dialog</extracomment>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Default Grid</source>
++        <translation>ຕາຂ່າຍໄຟຟ້າເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Object Naming Convention</source>
++        <translation>ກົດໝາຍການຕັ້ງຊື່ວັດຖຸ</translation></message>
++    <message>
++        <source>Naming convention used for generating action object names from their text</source>
++        <translation>ກົດເກນການຕັ້ງຊື່ທີ່ໃຊ້ໃນການສ້າງຊື່ວັດຖຸການກະທຳຈາກຂໍ້ຄວາມຂອງພວກມັນ</translation></message>
++    <message>
++        <source>Camel Case</source>
++        <translation>ກໍລະນີອູດ</translation></message>
++    <message>
++        <source>Underscore</source>
++        <translation>ຂີດສຳນວນ</translation></message>
++</context>
++<context>
++    <name>FormLayoutRowDialog</name>
++    <message>
++        <source>Add Form Layout Row</source>
++        <translation>ເພີ່ມແຖວຮູບແບບຟອມ</translation></message>
++    <message>
++        <source>&amp;Label text:</source>
++        <translation>&amp;ຂໍ້ຄວາມປ້າຍຊື່:</translation></message>
++    <message>
++        <source>Field &amp;type:</source>
++        <translation>ຟີວ &amp;type:</translation></message>
++    <message>
++        <source>&amp;Field name:</source>
++        <translation>&amp;ຊື່ຟິວ:</translation></message>
++    <message>
++        <source>&amp;Buddy:</source>
++        <translation>&amp;ຫມູ່:</translation></message>
++    <message>
++        <source>&amp;Row:</source>
++        <translation>&amp;ແຖວ:</translation></message>
++    <message>
++        <source>Label &amp;name:</source>
++        <translation>ປ້າຍ &amp;name:</translation></message>
++</context>
++<context>
++    <name>FormWindow</name>
++    <message>
++        <source>Unexpected element &lt;%1&gt;</source>
++        <translation>ອົງປະກອບທີ່ບໍ່ຄາດຄິດ &lt;%1&gt;</translation></message>
++    <message>
++        <source>Error while pasting clipboard contents at line %1, column %2: %3</source>
++        <translation>ຜິດພາດໃນການວາງເນື້ອຫາຈາກຄລິບບອດທີ່ເສັ້ນ %1, ຖັນ %2: %3</translation></message>
++</context>
++<context>
++    <name>FormWindowSettings</name>
++    <message>
++        <source>Form Settings</source>
++        <translation>ການຕັ້ງຄ່າແບບຟອມ</translation></message>
++    <message>
++        <source>Layout &amp;Default</source>
++        <translation>ຮູບແບບ &amp;Default</translation></message>
++    <message>
++        <source>&amp;Spacing:</source>
++        <translation>&amp;ຊ່ອງຫວ່າງ:</translation></message>
++    <message>
++        <source>&amp;Margin:</source>
++        <translation>&amp;ຂອບ:</translation></message>
++    <message>
++        <source>&amp;Layout Function</source>
++        <translation>&amp;Layout Function</translation></message>
++    <message>
++        <source>Ma&amp;rgin:</source>
++        <translation>ຂອບເຂດ:</translation></message>
++    <message>
++        <source>Spa&amp;cing:</source>
++        <translation>ຊ່ອງຫວ່າງ:</translation></message>
++    <message>
++        <source>&amp;Pixmap Function</source>
++        <translation>&amp;Pixmap ຟັງຊັນ</translation></message>
++    <message>
++        <source>&amp;Include Hints</source>
++        <translation>&amp;lt;ລວມເອົາຄຳແນະນຳ&amp;gt;</translation></message>
++    <message>
++        <source>Grid</source>
++        <translation>ຕາຕະລາງ</translation></message>
++    <message>
++        <source>Embedded Design</source>
++        <translation>ການອອກແບບທີ່ຝັງເຂົ້າ</translation></message>
++    <message>
++        <source>&amp;Author</source>
++        <translation>&amp;ຜູ້ຂຽນ</translation></message>
++    <message>
++        <source>Translations</source>
++        <translation>ການແປ</translation></message>
++    <message>
++        <source>ID-based</source>
++        <translation>ອີງໃສ່ລະຫັດປະຈຳຕົວ</translation></message>
++</context>
++<context>
++    <name>IconSelector</name>
++    <message>
++        <source>The pixmap file '%1' cannot be read.</source>
++        <translation>ຟາຍພິກສ໌ແມບ '%1' ບໍ່ສາມາດອ່ານໄດ້.</translation></message>
++    <message>
++        <source>The file '%1' does not appear to be a valid pixmap file: %2</source>
++        <translation>ໄຟລ໌ '%1' ບໍ່ໄດ້ປາກົດວ່າເປັນໄຟລ໌ pixmap ທີ່ຖືກຕ້ອງ: %2</translation></message>
++    <message>
++        <source>The file '%1' could not be read: %2</source>
++        <translation>ຟາຍ '%1' ບໍ່ສາມາດອ່ານໄດ້: %2</translation></message>
++    <message>
++        <source>All Pixmaps (</source>
++        <translation>ພາບພິກເຊັບທັງໝົດ (</translation></message>
++    <message>
++        <source>Choose a Pixmap</source>
++        <translation>ເລືອກ Pixmap</translation></message>
++    <message>
++        <source>Pixmap Read Error</source>
++        <translation>ຜິດພາດໃນການອ່ານ Pixmap</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>Normal Off</source>
++        <translation>ປົກກະຕິ ປິດ</translation></message>
++    <message>
++        <source>Normal On</source>
++        <translation>ປົກກະຕິ ເປີດ</translation></message>
++    <message>
++        <source>Disabled Off</source>
++        <translation>ປິດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Disabled On</source>
++        <translation>ປິດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Active Off</source>
++        <translation>ເປີດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Active On</source>
++        <translation>ເປີດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Selected Off</source>
++        <translation>ເລືອກປິດ</translation></message>
++    <message>
++        <source>Selected On</source>
++        <translation>ເລືອກແລ້ວ</translation></message>
++    <message>
++        <source>Choose Resource...</source>
++        <translation>ເລືອກຊັບພະຍາກອນ...</translation></message>
++    <message>
++        <source>Choose File...</source>
++        <translation>ເລືອກໄຟລ໌...</translation></message>
++    <message>
++        <source>Reset</source>
++        <translation>ຣີເຊັດ</translation></message>
++    <message>
++        <source>Reset All</source>
++        <translation>ຣີເຊັດທັງໝົດ</translation></message>
++</context>
++<context>
++    <name>ItemPropertyBrowser</name>
++    <message>
++        <source>XX Icon Selected off</source>
++        <extracomment>Sample string to determinate the width for the first column of the list item property browser</extracomment>
++        <translation>ໄອຄອນ XX ຖືກເລືອກປິດ</translation></message>
++</context>
++<context>
++    <name>MainWindowBase</name>
++    <message>
++        <source>Main</source>
++        <extracomment>Not currently used (main tool bar)</extracomment>
++        <translation>ຫຼັກ</translation></message>
++    <message>
++        <source>File</source>
++        <translation>ໄຟລ໌</translation></message>
++    <message>
++        <source>Edit</source>
++        <translation>ແກ້ໄຂ</translation></message>
++    <message>
++        <source>Tools</source>
++        <translation>ເຄື່ອງມື</translation></message>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Qt Designer</source>
++        <translation>Qt Designer</translation></message>
++</context>
++<context>
++    <name>NewForm</name>
++    <message>
++        <source>Show this Dialog on Startup</source>
++        <translation>ສະແດງກ່ອງຂໍ້ຄວາມນີ້ເມື່ອເປີດໃຊ້ງານ</translation></message>
++    <message>
++        <source>C&amp;reate</source>
++        <translation>C&amp;ສ້າງ</translation></message>
++    <message>
++        <source>Recent</source>
++        <translation>ຫຼ້າສຸດ</translation></message>
++    <message>
++        <source>New Form</source>
++        <translation>ແບບຟອມໃໝ່</translation></message>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;ປິດ</translation></message>
++    <message>
++        <source>&amp;Open...</source>
++        <translation>&amp;ເປີດ...</translation></message>
++    <message>
++        <source>&amp;Recent Forms</source>
++        <translation>&amp;ແບບຟອມຫຼ້າສຸດ</translation></message>
++    <message>
++        <source>Read error</source>
++        <translation>ອ່ານຜິດພາດ</translation></message>
++    <message>
++        <source>A temporary form file could not be created in %1: %2</source>
++        <translation>ໄຟລ໌ຮູບແບບຊົ່ວຄາວບໍ່ສາມາດສ້າງໄດ້ໃນ %1: %2</translation></message>
++    <message>
++        <source>The temporary form file %1 could not be written: %2</source>
++        <translation>ໄຟລ໌ຮູບແບບຊົ່ວຄາວ %1 ບໍ່ສາມາດຂຽນໄດ້: %2</translation></message>
++</context>
++<context>
++    <name>ObjectInspectorModel</name>
++    <message>
++        <source>Object</source>
++        <translation>ວັດຖຸ</translation></message>
++    <message>
++        <source>Class</source>
++        <translation>ຫ້ອງຮຽນ</translation></message>
++    <message>
++        <source>separator</source>
++        <translation>ແຍກ</translation></message>
++    <message>
++        <source>&lt;noname&gt;</source>
++        <translation>&lt;noname&gt;</translation></message>
++</context>
++<context>
++    <name>ObjectNameDialog</name>
++    <message>
++        <source>Change Object Name</source>
++        <translation>ປ່ຽນຊື່ວັດຖຸ</translation></message>
++    <message>
++        <source>Object Name</source>
++        <translation>ຊື່ວັດຖຸ</translation></message>
++</context>
++<context>
++    <name>PluginDialog</name>
++    <message>
++        <source>Plugin Information</source>
++        <translation>ຂໍ້ມູນປລັອກອິນ</translation></message>
++    <message>
++        <source>1</source>
++        <translation>1</translation></message>
++</context>
++<context>
++    <name>PreferencesDialog</name>
++    <message>
++        <source>Preferences</source>
++        <translation>ການຕັ້ງຄ່າ</translation></message>
++</context>
++<context>
++    <name>PreviewConfigurationWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Print/Preview Configuration</source>
++        <translation>ການຕັ້ງຄ່າການພິມ/ການເບິ່ງລ່ວງໜ້າ</translation></message>
++    <message>
++        <source>Style</source>
++        <translation>ຮູບແບບ</translation></message>
++    <message>
++        <source>Style sheet</source>
++        <translation>ແບບຮູບແບບ</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>Device skin</source>
++        <translation>ຜິວຫນັງອຸປະກອນ</translation></message>
++</context>
++<context>
++    <name>PromotionModel</name>
++    <message>
++        <source>Not used</source>
++        <extracomment>Usage of promoted widgets</extracomment>
++        <translation>ບໍ່ໄດ້ໃຊ້</translation></message>
++</context>
++<context>
++    <name>QAbstractFormBuilder</name>
++    <message>
++        <source>The creation of a widget of the class '%1' failed.</source>
++        <translation>ການສ້າງ widget ຂອງຫ້ອງ '%1' ລົ້ມເຫລວ.</translation></message>
++    <message>
++        <source>Attempt to add child that is not of class QWizardPage to QWizard.</source>
++        <translation>ພະຍາຍາມເພີ່ມລູກທີ່ບໍ່ແມ່ນຂອງຫ້ອງ QWizardPage ໃສ່ QWizard.</translation></message>
++    <message>
++        <source>Attempt to add a layout to a widget '%1' (%2) which already has a layout of non-box type %3.
++This indicates an inconsistency in the ui-file.</source>
++        <translation>ພະຍາຍາມເພີ່ມລະບົບຈັດແຈງໃຫ້ກັບວິດເຈັດ '%1' (%2) ທີ່ມີລະບົບຈັດແຈງປະເພດທີ່ບໍ່ແມ່ນກ່ອງ %3 ຢູ່ແລ້ວ.
++ນີ້ຊີ້ບອກເຖິງຄວາມບໍ່ສອດຄ່ອງໃນໄຟລ໌ ui.</translation></message>
++    <message>
++        <source>Empty widget item in %1 '%2'.</source>
++        <translation>ລາຍການວິດເຈັດທີ່ຫວ່າງເປົ່າໃນ %1 '%2'.</translation></message>
++    <message>
++        <source>Flags property are not supported yet.</source>
++        <translation>ຄຸນສົມບັດຂອງທຸງຍັງບໍ່ຖືກສະຫນັບສະຫນູນ.</translation></message>
++    <message>
++        <source>While applying tab stops: The widget '%1' could not be found.</source>
++        <translation>ຂະນະທີ່ກຳລັງຕັ້ງຄ່າແຖບຢຸດ: ບໍ່ສາມາດພົບວິດເຈັດ '%1' ໄດ້.</translation></message>
++    <message>
++        <source>Invalid QButtonGroup reference '%1' referenced by '%2'.</source>
++        <translation>ການອ້າງອີງ QButtonGroup ບໍ່ຖືກຕ້ອງ '%1' ຖືກອ້າງອີງໂດຍ '%2'.</translation></message>
++    <message>
++        <source>An error has occurred while reading the UI file at line %1, column %2: %3</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນການອ່ານໄຟລ໌ UI ທີ່ແຖວ %1, ຖັນ %2: %3</translation></message>
++    <message>
++        <source>This file was created using Designer from Qt-%1 and cannot be read.</source>
++        <translation>ເອກະສານນີ້ຖືກສ້າງຂຶ້ນໂດຍໃຊ້ Designer ຈາກ Qt-%1 ແລະບໍ່ສາມາດອ່ານໄດ້.</translation></message>
++    <message>
++        <source>This file cannot be read because it was created using %1.</source>
++        <translation>ໄຟລ໌ນີ້ບໍ່ສາມາດອ່ານໄດ້ເພາະວ່າມັນຖືກສ້າງໂດຍໃຊ້ %1</translation></message>
++    <message>
++        <source>Invalid UI file: The root element &lt;ui&gt; is missing.</source>
++        <translation>ຟາຍ UI ບໍ່ຖືກຕ້ອງ: ອົງປະກອບຮາກ &lt;ui&gt; ຂາດຫາຍໄປ.</translation></message>
++    <message>
++        <source>Invalid UI file</source>
++        <translation>ຟາຍ UI ບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QAxWidgetPlugin</name>
++    <message>
++        <source>ActiveX control</source>
++        <translation>ຄວບຄຸມ ActiveX</translation></message>
++    <message>
++        <source>ActiveX control widget</source>
++        <translation>ActiveX ຄວບຄຸມ widget</translation></message>
++</context>
++<context>
++    <name>QAxWidgetTaskMenu</name>
++    <message>
++        <source>Set Control</source>
++        <translation>ຕັ້ງຄວບຄຸມ</translation></message>
++    <message>
++        <source>Reset Control</source>
++        <translation>ຣີເຊັດຄວບຄຸມ</translation></message>
++    <message>
++        <source>Licensed Control</source>
++        <translation>ການຄວບຄຸມທີ່ໄດ້ຮັບອະນຸຍາດ</translation></message>
++    <message>
++        <source>The control requires a design-time license</source>
++        <translation>ການຄວບຄຸມຕ້ອງການໃບອະນຸຍາດອອກແບບເວລາ</translation></message>
++</context>
++<context>
++    <name>QCoreApplication</name>
++    <message>
++        <source>%1 is not a promoted class.</source>
++        <translation>%1 ບໍ່ແມ່ນຫ້ອງຮຽນທີ່ໄດ້ຮັບການສົ່ງເສີມ.</translation></message>
++    <message>
++        <source>The base class %1 is invalid.</source>
++        <translation>ຫ້ອງຮຽນພື້ນຖານ %1 ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>The class %1 already exists.</source>
++        <translation>ຫ້ອງຮຽນ %1 ມີຢູ່ແລ້ວ.</translation></message>
++    <message>
++        <source>Promoted Widgets</source>
++        <translation>ວິດເຈັດທີ່ສົ່ງເສີມ</translation></message>
++    <message>
++        <source>The class %1 cannot be removed</source>
++        <translation>ບໍ່ສາມາດລຶບຊັ້ນ %1 ອອກໄດ້</translation></message>
++    <message>
++        <source>The class %1 cannot be removed because it is still referenced.</source>
++        <translation>ຫ້ອງຮຽນ %1 ບໍ່ສາມາດຖອດອອກໄດ້ເພາະວ່າຍັງຖືກອ້າງອີງ.</translation></message>
++    <message>
++        <source>The class %1 cannot be renamed</source>
++        <translation>ບໍ່ສາມາດປ່ຽນຊື່ຫ້ອງຮຽນ %1 ໄດ້</translation></message>
++    <message>
++        <source>The class %1 cannot be renamed to an empty name.</source>
++        <translation>ຫ້ອງຮຽນ %1 ບໍ່ສາມາດປ່ຽນຊື່ເປັນຊື່ຫວ່າງໄດ້.</translation></message>
++    <message>
++        <source>There is already a class named %1.</source>
++        <translation>ມີຫ້ອງຮຽນທີ່ມີຊື່ %1 ຢູ່ແລ້ວ.</translation></message>
++    <message>
++        <source>Cannot set an empty include file.</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າໄຟລ໌ລວມທີ່ຫວ່າງເປົ່າໄດ້.</translation></message>
++</context>
++<context>
++    <name>QDesigner</name>
++    <message>
++        <source>%1 - warning</source>
++        <translation>%1 - ຄຳເຕືອນ</translation></message>
++</context>
++<context>
++    <name>QDesignerActions</name>
++    <message>
++        <source>Saved %1.</source>
++        <translation>ບັນທຶກ %1 ແລ້ວ.</translation></message>
++    <message>
++        <source>%1 already exists.
++Do you want to replace it?</source>
++        <translation>%1 ໄດ້ມີຢູ່ແລ້ວ.
++ທ່ານຕ້ອງການທີ່ຈະແທນທີ່ມັນບໍ?</translation></message>
++    <message>
++        <source>Edit Widgets</source>
++        <translation>ແກ້ໄຂວິດເຈັດ</translation></message>
++    <message>
++        <source>&amp;New...</source>
++        <translation>&amp;ໃໝ່...</translation></message>
++    <message>
++        <source>&amp;Open...</source>
++        <translation>&amp;ເປີດ...</translation></message>
++    <message>
++        <source>&amp;Save</source>
++        <translation>&amp;ບັນທຶກ</translation></message>
++    <message>
++        <source>Save &amp;As...</source>
++        <translation>ບັນທຶກ &amp;As...</translation></message>
++    <message>
++        <source>Save A&amp;ll</source>
++        <translation>ບັນທຶກທັງໝົດ</translation></message>
++    <message>
++        <source>Save As &amp;Template...</source>
++        <translation>ບັນທຶກເປັນ &amp;ແມ່ແບບ...</translation></message>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;ປິດ</translation></message>
++    <message>
++        <source>Save &amp;Image...</source>
++        <translation>ບັນທຶກ &amp;ຮູບພາບ...</translation></message>
++    <message>
++        <source>&amp;Print...</source>
++        <translation>&amp;ພິມ...</translation></message>
++    <message>
++        <source>&amp;Quit</source>
++        <translation>&amp;ອອກ</translation></message>
++    <message>
++        <source>View &amp;Code...</source>
++        <translation>ເບິ່ງ &amp;Code...</translation></message>
++    <message>
++        <source>&amp;Minimize</source>
++        <translation>&amp;ຫຍໍ້</translation></message>
++    <message>
++        <source>Bring All to Front</source>
++        <translation>ນຳທຸກຢ່າງມາຢູ່ດ້ານຫນ້າ</translation></message>
++    <message>
++        <source>Preferences...</source>
++        <translation>ການຕັ້ງຄ່າ...</translation></message>
++    <message>
++        <source>Additional Fonts...</source>
++        <translation>ຟອນເພີ່ມເຕີມ...</translation></message>
++    <message>
++        <source>ALT+CTRL+S</source>
++        <translation>ALT+CTRL+S</translation></message>
++    <message>
++        <source>CTRL+SHIFT+S</source>
++        <translation>CTRL+SHIFT+S</translation></message>
++    <message>
++        <source>CTRL+R</source>
++        <translation>CTRL+R</translation></message>
++    <message>
++        <source>CTRL+M</source>
++        <translation>CTRL+M</translation></message>
++    <message>
++        <source>Qt Designer &amp;Help</source>
++        <translation>Qt Designer &amp; ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>Current Widget Help</source>
++        <translation>ຄຳແນະນຳວິດເຈັດປະຈຸບັນ</translation></message>
++    <message>
++        <source>About Plugins</source>
++        <translation>ກ່ຽວກັບປລັກອິນ</translation></message>
++    <message>
++        <source>About Qt Designer</source>
++        <translation>ກ່ຽວກັບ Qt Designer</translation></message>
++    <message>
++        <source>About Qt</source>
++        <translation>ກ່ຽວກັບ Qt</translation></message>
++    <message>
++        <source>Clear &amp;Menu</source>
++        <translation>ລ້າງ &amp;Menu</translation></message>
++    <message>
++        <source>&amp;Recent Forms</source>
++        <translation>&amp;ແບບຟອມຫຼ້າສຸດ</translation></message>
++    <message>
++        <source>Open Form</source>
++        <translation>ເປີດຟອມ</translation></message>
++    <message>
++        <source>Designer UI files (*.%1);;All Files (*)</source>
++        <translation>ຟາຍ UI ຂອງຜູ້ອອກແບບ (*.%1);;ຟາຍທັງໝົດ (*)</translation></message>
++    <message>
++        <source>Save Form As</source>
++        <translation>ບັນທຶກແບບຟອມເປັນ</translation></message>
++    <message>
++        <source>Designer</source>
++        <translation>ຜູ້ອອກແບບ</translation></message>
++    <message>
++        <source>Feature not implemented yet!</source>
++        <translation>ຄຸນສົມບັດຍັງບໍ່ໄດ້ຮັບການປະຕິບັດເທື່ອ!</translation></message>
++    <message>
++        <source>Code generation failed</source>
++        <translation>ການສ້າງລະຫັດລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Read error</source>
++        <translation>ອ່ານຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>%1
++Do you want to update the file location or generate a new form?</source>
++        <translation>%1
++ທ່ານຕ້ອງການອັບເດດສະຖານທີ່ໄຟລ໌ ຫຼື ສ້າງແບບຟອມໃໝ່?</translation></message>
++    <message>
++        <source>&amp;Update</source>
++        <translation>&amp;ອັບເດດ</translation></message>
++    <message>
++        <source>&amp;New Form</source>
++        <translation>&amp;ແບບຟອມໃໝ່</translation></message>
++    <message>
++        <source>Qt Designer</source>
++        <translation>Qt Designer</translation></message>
++    <message>
++        <source>Save Form?</source>
++        <translation>ບັນທຶກແບບຟອມ?</translation></message>
++    <message>
++        <source>Could not open file</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ໄດ້</translation></message>
++    <message>
++        <source>The file %1 could not be opened.
++Reason: %2
++Would you like to retry or select a different file?</source>
++        <translation>ຟາຍ %1 ບໍ່ສາມາດເປີດໄດ້.
++ເຫດຜົນ: %2
++ທ່ານຕ້ອງການລອງໃໝ່ ຫຼືເລືອກຟາຍອື່ນບໍ?</translation></message>
++    <message>
++        <source>Select New File</source>
++        <translation>ເລືອກເອກະສານໃໝ່</translation></message>
++    <message>
++        <source>Could not write file</source>
++        <translation>ບໍ່ສາມາດຂຽນໄຟລ໌ໄດ້</translation></message>
++    <message>
++        <source>It was not possible to write the entire file %1 to disk.
++Reason:%2
++Would you like to retry?</source>
++        <translation>ບໍ່ສາມາດຂຽນໄຟລ໌ %1 ທັງໝົດລົງໃນດິສເກດໄດ້.
++ເຫດຜົນ:%2
++ທ່ານຕ້ອງການລອງໃໝ່ບໍ?</translation></message>
++    <message>
++        <source>Assistant</source>
++        <translation>ຜູ້ຊ່ວຍ</translation></message>
++    <message>
++        <source>&amp;Close Preview</source>
++        <translation>&amp;ປິດການລອງເບິ່ງລ່ວງໜ້າ</translation></message>
++    <message>
++        <source>The backup file %1 could not be written.</source>
++        <translation>ໄຟລ໌ສຳຮອງ %1 ບໍ່ສາມາດຂຽນໄດ້.</translation></message>
++    <message>
++        <source>The backup directory %1 could not be created.</source>
++        <translation>ໂຟນເດີສຳຮອງ %1 ບໍ່ສາມາດສ້າງໄດ້.</translation></message>
++    <message>
++        <source>The temporary backup directory %1 could not be created.</source>
++        <translation>ໂຟນເດີສຳຮອງຊົ່ວຄາວ %1 ບໍ່ສາມາດສ້າງໄດ້.</translation></message>
++    <message>
++        <source>Preview failed</source>
++        <translation>ການຕົວຢ່າງລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Image files (*.%1)</source>
++        <translation>ຟາຍຮູບພາບ (*.%1)</translation></message>
++    <message>
++        <source>Save Image</source>
++        <translation>ບັນທຶກຮູບພາບ</translation></message>
++    <message>
++        <source>Saved image %1.</source>
++        <translation>ບັນທຶກຮູບພາບ %1 ແລ້ວ.</translation></message>
++    <message>
++        <source>The file %1 could not be written.</source>
++        <translation>ໄຟລ໌ %1 ບໍ່ສາມາດຂຽນໄດ້.</translation></message>
++    <message>
++        <source>Please close all forms to enable the loading of additional fonts.</source>
++        <translation>ກະລຸນາປິດແບບຟອມທັງໝົດເພື່ອເປີດໃຫ້ສາມາດໂຫຼດຟອນເພີ່ມເຕີມໄດ້.</translation></message>
++    <message>
++        <source>Printed %1.</source>
++        <translation>ພິມ %1.</translation></message>
++</context>
++<context>
++    <name>QDesignerAppearanceOptionsPage</name>
++    <message>
++        <source>Appearance</source>
++        <extracomment>Tab in preferences dialog</extracomment>
++        <translation>ຮູບລັກສະນະ</translation></message>
++</context>
++<context>
++    <name>QDesignerAppearanceOptionsWidget</name>
++    <message>
++        <source>Docked Window</source>
++        <translation>ຫນ້າຕ່າງທີ່ຕິດຢູ່</translation></message>
++    <message>
++        <source>Multiple Top-Level Windows</source>
++        <translation>ຫຼາຍຫນ້າຕ່າງລະດັບສູງ</translation></message>
++    <message>
++        <source>Toolwindow Font</source>
++        <translation>ຕົວໜັງສືຂອງປ່ອງຢ້ຽມເຄື່ອງມື</translation></message>
++</context>
++<context>
++    <name>QDesignerAxWidget</name>
++    <message>
++        <source>Reset control</source>
++        <translation>ຣີເຊັດຄວບຄຸມ</translation></message>
++    <message>
++        <source>Set control</source>
++        <translation>ຕັ້ງຄວບຄຸມ</translation></message>
++    <message>
++        <source>Control loaded</source>
++        <translation>ຄວບຄຸມຖືກໂຫຼດແລ້ວ</translation></message>
++    <message>
++        <source>A COM exception occurred when executing a meta call of type %1, index %2 of "%3".</source>
++        <translation>ມີຂໍ້ຜິດພາດ COM ເກີດຂຶ້ນເມື່ອດໍາເນີນການເອີ້ນໃຊ້ meta ປະເພດ %1, ດັດສະນີ %2 ຂອງ "%3".</translation></message>
++</context>
++<context>
++    <name>QDesignerFormBuilder</name>
++    <message>
++        <source>The preview failed to build.</source>
++        <translation>ການສ້າງຕົວຢ່າງລ່ວງໜ້າລົ້ມເຫລວ.</translation></message>
++    <message>
++        <source>Designer</source>
++        <translation>ຜູ້ອອກແບບ</translation></message>
++</context>
++<context>
++    <name>QDesignerFormWindow</name>
++    <message>
++        <source>%1 - %2[*]</source>
++        <translation>%1 - %2[*]</translation></message>
++    <message>
++        <source>Save Form?</source>
++        <translation>ບັນທຶກແບບຟອມ?</translation></message>
++    <message>
++        <source>Do you want to save the changes to this document before closing?</source>
++        <translation>ທ່ານຕ້ອງການບັນທຶກການປ່ຽນແປງໃນເອກະສານນີ້ກ່ອນປິດບໍ?</translation></message>
++    <message>
++        <source>If you don't save, your changes will be lost.</source>
++        <translation>ຖ້າທ່ານບໍ່ບັນທຶກ, ການປ່ຽນແປງຂອງທ່ານຈະສູນເສຍ.</translation></message>
++</context>
++<context>
++    <name>QDesignerMenu</name>
++    <message>
++        <source>Type Here</source>
++        <translation>ພິມທີ່ນີ້</translation></message>
++    <message>
++        <source>Add Separator</source>
++        <translation>ເພີ່ມເຄື່ອງແຍກ</translation></message>
++    <message>
++        <source>Insert separator</source>
++        <translation>ໃສ່ຕົວແຍກ</translation></message>
++    <message>
++        <source>Remove separator</source>
++        <translation>ລຶບເຄື່ອງໝາຍຄັດແຍກ</translation></message>
++    <message>
++        <source>Remove action '%1'</source>
++        <translation>ລຶບການກະທຳ '%1'</translation></message>
++    <message>
++        <source>Add separator</source>
++        <translation>ເພີ່ມແຍກ</translation></message>
++    <message>
++        <source>Insert action</source>
++        <translation>ເພີ່ມການກະທຳ</translation></message>
++</context>
++<context>
++    <name>QDesignerMenuBar</name>
++    <message>
++        <source>Type Here</source>
++        <translation>ພິມທີ່ນີ້</translation></message>
++    <message>
++        <source>Remove Menu '%1'</source>
++        <translation>ລຶບເມນູ '%1'</translation></message>
++    <message>
++        <source>Remove Menu Bar</source>
++        <translation>ລຶບແຖບເມນູ</translation></message>
++    <message>
++        <source>Menu</source>
++        <translation>ເມນູ</translation></message>
++</context>
++<context>
++    <name>QDesignerPluginManager</name>
++    <message>
++        <source>An XML error was encountered when parsing the XML of the custom widget %1: %2</source>
++        <translation>ມີຂໍ້ຜິດພາດ XML ເກີດຂຶ້ນເມື່ອວິເຄາະ XML ຂອງ widget ກຳນົດເອງ %1: %2</translation></message>
++    <message>
++        <source>A required attribute ('%1') is missing.</source>
++        <translation>ຄຸນສົມບັດທີ່ຕ້ອງການ ('%1') ຂາດຫາຍໄປ.</translation></message>
++    <message>
++        <source>'%1' is not a valid string property specification.</source>
++        <translation>'%1' ແມ່ນບໍ່ແມ່ນການກຳນົດຄຸນສົມບັດສະຕຣິງທີ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>An invalid property specification ('%1') was encountered. Supported types: %2</source>
++        <translation>ການກຳນົດຄຸນສົມບັດທີ່ບໍ່ຖືກຕ້ອງ ('%1') ໄດ້ຖືກພົບເຫັນ. ປະເພດທີ່ຮອງຮັບ: %2</translation></message>
++    <message>
++        <source>The XML of the custom widget %1 does not contain any of the elements &lt;widget&gt; or &lt;ui&gt;.</source>
++        <translation>XML ຂອງ widget ທີ່ກຳນົດເອງ %1 ບໍ່ມີອົງປະກອບ &lt;widget&gt; ຫຼື &lt;ui&gt; ໃດໆ.</translation></message>
++    <message>
++        <source>The class attribute for the class %1 is missing.</source>
++        <translation>ຄຸນລັກສະນະຂອງຫ້ອງຮຽນ %1 ຂາດຫາຍ.</translation></message>
++    <message>
++        <source>The class attribute for the class %1 does not match the class name %2.</source>
++        <translation>ຄຸນສົມບັດຂອງຫ້ອງຮຽນ %1 ບໍ່ກົງກັບຊື່ຫ້ອງຮຽນ %2.</translation></message>
++</context>
++<context>
++    <name>QDesignerPropertySheet</name>
++    <message>
++        <source>Dynamic Properties</source>
++        <translation>ຄຸນສົມບັດແບບເຄື່ອນໄຫວ</translation></message>
++</context>
++<context>
++    <name>QDesignerResource</name>
++    <message>
++        <source>The layout type '%1' is not supported, defaulting to grid.</source>
++        <translation>ປະເພດລະບຽບແບບ '%1' ບໍ່ຖືກຮອງຮັບ, ກຳລັງໃຊ້ຕາຕະລາງເລີ່ມຕົ້ນ.</translation></message>
++    <message>
++        <source>The container extension of the widget '%1' (%2) returned a widget not managed by Designer '%3' (%4) when queried for page #%5.
++Container pages should only be added by specifying them in XML returned by the domXml() method of the custom widget.</source>
++        <translation>ສ່ວນຂະຫຍາຍຂອງກ່ອງ '%1' (%2) ສົ່ງຄືນວິດເຈັດທີ່ບໍ່ຖືກຈັດການໂດຍ Designer '%3' (%4) ເມື່ອຖາມຫາໜ້າ #%5.
++ໜ້າຂອງກ່ອງຄວນຖືກເພີ່ມໂດຍການລະບຸໃນ XML ທີ່ສົ່ງຄືນໂດຍວິທີ domXml() ຂອງວິດເຈັດທີ່ກຳນົດເອງ.</translation></message>
++    <message>
++        <source>Unexpected element &lt;%1&gt;</source>
++        <extracomment>Parsing clipboard contents</extracomment>
++        <translation>ອົງປະກອບທີ່ບໍ່ຄາດຄິດ &lt;%1&gt;</translation></message>
++    <message>
++        <source>Error while pasting clipboard contents at line %1, column %2: %3</source>
++        <extracomment>Parsing clipboard contents</extracomment>
++        <translation>ຜິດພາດໃນການວາງເນື້ອຫາຈາກຄລິບບອດທີ່ເສັ້ນ %1, ຖັນ %2: %3</translation></message>
++    <message>
++        <source>Error while pasting clipboard contents: The root element &lt;ui&gt; is missing.</source>
++        <extracomment>Parsing clipboard contents</extracomment>
++        <translation>ຜິດພາດໃນຂະນະທີ່ວາງເນື້ອຫາຈາກຄລິບບອດ: ອົງປະກອບຮາກ &lt;ui&gt; ຂາດຫາຍ.</translation></message>
++</context>
++<context>
++    <name>QDesignerSharedSettings</name>
++    <message>
++        <source>The template path %1 could not be created.</source>
++        <translation>ເສັ້ນທາງແມ່ແບບ %1 ບໍ່ສາມາດສ້າງໄດ້.</translation></message>
++    <message>
++        <source>An error has been encountered while parsing device profile XML: %1</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ກຳລັງວິເຄາະໂປຣໄຟລ໌ XML ຂອງອຸປະກອນ: %1</translation></message>
++</context>
++<context>
++    <name>QDesignerTaskMenu</name>
++    <message>
++        <source>no signals available</source>
++        <translation>ບໍ່ມີສັນຍານທີ່ມີຢູ່</translation></message>
++</context>
++<context>
++    <name>QDesignerToolWindow</name>
++    <message>
++        <source>Property Editor</source>
++        <translation>ບັນຊີລາຍການຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>Action Editor</source>
++        <translation>ບັນຊີການດຳເນີນການ</translation></message>
++    <message>
++        <source>Object Inspector</source>
++        <translation>ກວດສອບວັດຖຸ</translation></message>
++    <message>
++        <source>Resource Browser</source>
++        <translation>ຕົວທ່ອງເບິ່ງຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>Signal/Slot Editor</source>
++        <translation>ຕັ້ງຄ່າສັນຍານ/ຊ່ອງສັນຍານ</translation></message>
++    <message>
++        <source>Widget Box</source>
++        <translation>ກ່ອງວິດເຈັດ</translation></message>
++</context>
++<context>
++    <name>QDesignerWorkbench</name>
++    <message>
++        <source>&amp;File</source>
++        <translation>&amp;ໄຟລ໌</translation></message>
++    <message>
++        <source>&amp;Edit</source>
++        <translation>&amp;ແກ້ໄຂ</translation></message>
++    <message>
++        <source>F&amp;orm</source>
++        <translation>F&amp;orm</translation></message>
++    <message>
++        <source>Preview in</source>
++        <translation>ລອກເບິ່ງລ່ວງໜ້າໃນ</translation></message>
++    <message>
++        <source>&amp;View</source>
++        <translation>&amp;ເບິ່ງ</translation></message>
++    <message>
++        <source>&amp;Settings</source>
++        <translation>&amp;ຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>&amp;Window</source>
++        <translation>&amp;ຫນ້າຕ່າງ</translation></message>
++    <message>
++        <source>&amp;Help</source>
++        <translation>&amp;ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>Toolbars</source>
++        <translation>ແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>Widget Box</source>
++        <translation>ກ່ອງວິດເຈັດ</translation></message>
++    <message>
++        <source>Save Forms?</source>
++        <translation>ບັນທຶກແບບຟອມ?</translation></message>
++    <message numerus="yes">
++        <source>There are %n forms with unsaved changes. Do you want to review these changes before quitting?</source>
++        <translation>
++            <numerusform>ມີ %n ຟອມທີ່ມີການປ່ຽນແປງທີ່ບໍ່ໄດ້ບັນທຶກ. ທ່ານຕ້ອງການກວດສອບການປ່ຽນແປງເຫຼົ່ານີ້ກ່ອນອອກບໍ?</numerusform>
++        </translation></message>
++    <message>
++        <source>If you do not review your documents, all your changes will be lost.</source>
++        <translation>ຖ້າທ່ານບໍ່ກວດສອບເອກະສານຂອງທ່ານ, ການປ່ຽນແປງທັງໝົດຂອງທ່ານຈະສູນເສຍ.</translation></message>
++    <message>
++        <source>Discard Changes</source>
++        <translation>ຍົກເລີກການປ່ຽນແປງ</translation></message>
++    <message>
++        <source>Review Changes</source>
++        <translation>ກວດສອບການປ່ຽນແປງ</translation></message>
++    <message>
++        <source>Backup Information</source>
++        <translation>ຂໍ້ມູນສໍາຮອງ</translation></message>
++    <message>
++        <source>The last session of Designer was not terminated correctly. Backup files were left behind. Do you want to load them?</source>
++        <translation>ເຊຊັນສຸດທ້າຍຂອງ Designer ບໍ່ໄດ້ສິ້ນສຸດຢ່າງຖືກຕ້ອງ. ໄຟລ໌ສຳຮອງຖືກປະໄວ້ຫຼັງ. ທ່ານຕ້ອງການໂຫຼດພວກມັນບໍ?</translation></message>
++    <message>
++        <source>The file &lt;b&gt;%1&lt;/b&gt; could not be opened: %2</source>
++        <translation>ຟາຍ &lt;b&gt;%1&lt;/b&gt; ບໍ່ສາມາດເປີດໄດ້: %2</translation></message>
++</context>
++<context>
++    <name>QFormBuilder</name>
++    <message>
++        <source>An empty class name was passed on to %1 (object name: '%2').</source>
++        <extracomment>Empty class name passed to widget factory method</extracomment>
++        <translation>ຊື່ຫ້ອງຮຽນທີ່ວ່າງເປົ່າໄດ້ຖືກສົ່ງຕໍ່ໄປຫາ %1 (ຊື່ວັດຖຸ: '%2').</translation></message>
++    <message>
++        <source>QFormBuilder was unable to create a custom widget of the class '%1'; defaulting to base class '%2'.</source>
++        <translation>QFormBuilder ບໍ່ສາມາດສ້າງ widget ທີ່ກຳນົດເອງຂອງຫ້ອງ '%1' ໄດ້; ກຳລັງໃຊ້ຫ້ອງພື້ນຖານ '%2' ແທນ.</translation></message>
++    <message>
++        <source>QFormBuilder was unable to create a widget of the class '%1'.</source>
++        <translation>QFormBuilder ບໍ່ສາມາດສ້າງ widget ຂອງຫ້ອງ '%1' ໄດ້.</translation></message>
++    <message>
++        <source>The layout type `%1' is not supported.</source>
++        <translation>ປະເພດຂອງແບບຈັດແຈງ `%1' ບໍ່ຖືກຮອງຮັບ.</translation></message>
++    <message>
++        <source>The set-type property %1 could not be read.</source>
++        <translation>ຄຸນສົມບັດປະເພດຊຸດ %1 ບໍ່ສາມາດອ່ານໄດ້.</translation></message>
++    <message>
++        <source>The enumeration-type property %1 could not be read.</source>
++        <translation>ຄຸນສົມບັດປະເພດການຈັດລຽງ %1 ບໍ່ສາມາດອ່ານໄດ້.</translation></message>
++    <message>
++        <source>Reading properties of the type %1 is not supported yet.</source>
++        <translation>ການອ່ານຄຸນສົມບັດຂອງປະເພດ %1 ຍັງບໍ່ຖືກຮອງຮັບ.</translation></message>
++    <message>
++        <source>The property %1 could not be written. The type %2 is not supported yet.</source>
++        <translation>ຄຸນສົມບັດ %1 ບໍ່ສາມາດຂຽນໄດ້. ປະເພດ %2 ຍັງບໍ່ຖືກຮອງຮັບ.</translation></message>
++    <message>
++        <source>The enumeration-value '%1' is invalid. The default value '%2' will be used instead.</source>
++        <translation>ຄ່າການສະແດງລາຍການ '%1' ບໍ່ຖືກຕ້ອງ. ຄ່າເລີ່ມຕົ້ນ '%2' ຈະຖືກນຳໃຊ້ແທນ.</translation></message>
++    <message>
++        <source>The flag-value '%1' is invalid. Zero will be used instead.</source>
++        <translation>ຄ່າທຸງ '%1' ບໍ່ຖືກຕ້ອງ. ຈະໃຊ້ຄ່າສູນແທນ.</translation></message>
++</context>
++<context>
++    <name>QStackedWidgetEventFilter</name>
++    <message>
++        <source>Previous Page</source>
++        <translation>ຫນ້າກ່ອນຫນ້າ</translation></message>
++    <message>
++        <source>Next Page</source>
++        <translation>ຫນ້າຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Before Current Page</source>
++        <translation>ກ່ອນຫນ້າປະຈຸບັນ</translation></message>
++    <message>
++        <source>After Current Page</source>
++        <translation>ຫຼັງຈາກໜ້າປະຈຸບັນ</translation></message>
++    <message>
++        <source>Change Page Order...</source>
++        <translation>ປ່ຽນລຳດັບໜ້າ...</translation></message>
++    <message>
++        <source>Change Page Order</source>
++        <translation>ປ່ຽນລຳດັບໜ້າ</translation></message>
++    <message>
++        <source>Page %1 of %2</source>
++        <translation>ໜ້າ %1 ຈາກ %2</translation></message>
++    <message>
++        <source>Insert Page</source>
++        <translation>ໃສ່ໜ້າ</translation></message>
++</context>
++<context>
++    <name>QStackedWidgetPreviewEventFilter</name>
++    <message>
++        <source>Go to previous page of %1 '%2' (%3/%4).</source>
++        <translation>ໄປຫາໜ້າກ່ອນໜ້ານີ້ຂອງ %1 '%2' (%3/%4).</translation></message>
++    <message>
++        <source>Go to next page of %1 '%2' (%3/%4).</source>
++        <translation>ໄປຫາໜ້າຕໍ່ໄປຂອງ %1 '%2' (%3/%4).</translation></message>
++</context>
++<context>
++    <name>QTabWidgetEventFilter</name>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Before Current Page</source>
++        <translation>ກ່ອນຫນ້າປະຈຸບັນ</translation></message>
++    <message>
++        <source>After Current Page</source>
++        <translation>ຫຼັງຈາກໜ້າປະຈຸບັນ</translation></message>
++    <message>
++        <source>Page %1 of %2</source>
++        <translation>ໜ້າ %1 ຈາກ %2</translation></message>
++    <message>
++        <source>Insert Page</source>
++        <translation>ໃສ່ໜ້າ</translation></message>
++</context>
++<context>
++    <name>QToolBoxHelper</name>
++    <message>
++        <source>Delete Page</source>
++        <translation>ລຶບໜ້າ</translation></message>
++    <message>
++        <source>Before Current Page</source>
++        <translation>ກ່ອນຫນ້າປະຈຸບັນ</translation></message>
++    <message>
++        <source>After Current Page</source>
++        <translation>ຫຼັງຈາກໜ້າປະຈຸບັນ</translation></message>
++    <message>
++        <source>Change Page Order...</source>
++        <translation>ປ່ຽນລຳດັບໜ້າ...</translation></message>
++    <message>
++        <source>Change Page Order</source>
++        <translation>ປ່ຽນລຳດັບໜ້າ</translation></message>
++    <message>
++        <source>Page %1 of %2</source>
++        <translation>ໜ້າ %1 ຈາກ %2</translation></message>
++    <message>
++        <source>Insert Page</source>
++        <translation>ໃສ່ໜ້າ</translation></message>
++</context>
++<context>
++    <name>QtBoolEdit</name>
++    <message>
++        <source>True</source>
++        <translation>ຈິງ</translation></message>
++    <message>
++        <source>False</source>
++        <translation>ບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QtBoolPropertyManager</name>
++    <message>
++        <source>True</source>
++        <translation>ຈິງ</translation></message>
++    <message>
++        <source>False</source>
++        <translation>ບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QtCharEdit</name>
++    <message>
++        <source>Clear Char</source>
++        <translation>ລຶບຕົວອັກສອນ</translation></message>
++</context>
++<context>
++    <name>QtColorEditWidget</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++</context>
++<context>
++    <name>QtColorPropertyManager</name>
++    <message>
++        <source>Red</source>
++        <translation>ສີແດງ</translation></message>
++    <message>
++        <source>Green</source>
++        <translation>ຂຽວ</translation></message>
++    <message>
++        <source>Blue</source>
++        <translation>ຟ້າ</translation></message>
++    <message>
++        <source>Alpha</source>
++        <translation>ອັລຟາ</translation></message>
++</context>
++<context>
++    <name>QtCursorDatabase</name>
++    <message>
++        <source>Arrow</source>
++        <translation>ລູກສອນ</translation></message>
++    <message>
++        <source>Up Arrow</source>
++        <translation>ລູກສອນຂຶ້ນ</translation></message>
++    <message>
++        <source>Cross</source>
++        <translation>ຂ້າມ</translation></message>
++    <message>
++        <source>Wait</source>
++        <translation>ລໍຖ້າ</translation></message>
++    <message>
++        <source>IBeam</source>
++        <translation>IBeam</translation></message>
++    <message>
++        <source>Size Vertical</source>
++        <translation>ຂະໜາດແນວຕັ້ງ</translation></message>
++    <message>
++        <source>Size Horizontal</source>
++        <translation>ຂະໜາດແນວນອນ</translation></message>
++    <message>
++        <source>Size Backslash</source>
++        <translation>ຂະໜາດ Backslash</translation></message>
++    <message>
++        <source>Size Slash</source>
++        <translation>ຂະໜາດຕັດ</translation></message>
++    <message>
++        <source>Size All</source>
++        <translation>ຂະໜາດທັງໝົດ</translation></message>
++    <message>
++        <source>Blank</source>
++        <translation>ຫວ່າງ</translation></message>
++    <message>
++        <source>Split Vertical</source>
++        <translation>ແບ່ງຕາມແນວຕັ້ງ</translation></message>
++    <message>
++        <source>Split Horizontal</source>
++        <translation>ແບ່ງອອກແນວນອນ</translation></message>
++    <message>
++        <source>Pointing Hand</source>
++        <translation>ມືຊີ້</translation></message>
++    <message>
++        <source>Forbidden</source>
++        <translation>ຫ້າມ</translation></message>
++    <message>
++        <source>Open Hand</source>
++        <translation>ເປີດມື</translation></message>
++    <message>
++        <source>Closed Hand</source>
++        <translation>ມືປິດ</translation></message>
++    <message>
++        <source>What's This</source>
++        <translation>ນີ້ແມ່ນຫຍັງ</translation></message>
++    <message>
++        <source>Busy</source>
++        <translation>ຄວາມຫຍຸ້ງຍາກ</translation></message>
++</context>
++<context>
++    <name>QtFontEditWidget</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>Select Font</source>
++        <translation>ເລືອກຟອນ</translation></message>
++</context>
++<context>
++    <name>QtFontPropertyManager</name>
++    <message>
++        <source>Family</source>
++        <translation>ຄອບຄົວ</translation></message>
++    <message>
++        <source>Point Size</source>
++        <translation>ຂະໜາດຈຸດ</translation></message>
++    <message>
++        <source>Bold</source>
++        <translation>ຕົວໜັງສືໜາ</translation></message>
++    <message>
++        <source>Italic</source>
++        <translation>ຕົວເລັກ</translation></message>
++    <message>
++        <source>Underline</source>
++        <translation>ຂີດຂີດລຸ່ມ</translation></message>
++    <message>
++        <source>Strikeout</source>
++        <translation>ຂີດຂ້າມ</translation></message>
++    <message>
++        <source>Kerning</source>
++        <translation>ການປັບຊ່ອງຫວ່າງລະຫວ່າງຕົວອັກສອນ</translation></message>
++</context>
++<context>
++    <name>QtGradientDialog</name>
++    <message>
++        <source>Edit Gradient</source>
++        <translation>ແກ້ໄຂກຣາດຽນ</translation></message>
++</context>
++<context>
++    <name>QtGradientEditor</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Gradient Editor</source>
++        <translation>ຕັດແກ້ເຄື່ອງມືການສ້າງລະດັບສີ</translation></message>
++    <message>
++        <source>This area shows a preview of the gradient being edited. It also allows you to edit parameters specific to the gradient's type such as start and final point, radius, etc. by drag &amp; drop.</source>
++        <translation>ພື້ນທີ່ນີ້ສະແດງການຕົວຢ່າງຂອງການປ່ຽນແປງສີທີ່ກຳລັງແກ້ໄຂ. ມັນຍັງອະນຸຍາດໃຫ້ທ່ານແກ້ໄຂພາຣາມີເຕີສະເພາະຂອງປະເພດການປ່ຽນແປງສີ ເຊັ່ນ ຈຸດເລີ່ມຕົ້ນ ແລະ ຈຸດສຸດທ້າຍ, ລັດສະໝີ, ແລະອື່ນໆ ໂດຍການລາກ ແລະ ວາງ.</translation></message>
++    <message>
++        <source>1</source>
++        <translation>1</translation></message>
++    <message>
++        <source>2</source>
++        <translation>2</translation></message>
++    <message>
++        <source>3</source>
++        <translation>3</translation></message>
++    <message>
++        <source>4</source>
++        <translation>4</translation></message>
++    <message>
++        <source>5</source>
++        <translation>5</translation></message>
++    <message>
++        <source>Gradient Stops Editor</source>
++        <translation>ບັນຊີລາຍຊື່ຈຸດຢຸດການປ່ຽນແປງສີ</translation></message>
++    <message>
++        <source>This area allows you to edit gradient stops. Double click on the existing stop handle to duplicate it. Double click outside of the existing stop handles to create a new stop. Drag &amp; drop the handle to reposition it. Use right mouse button to popup context menu with extra actions.</source>
++        <translation>ພື້ນທີ່ນີ້ອະນຸຍາດໃຫ້ທ່ານແກ້ໄຂຈຸດຢຸດກາດລຽນ. ກົດສອງຄັ້ງທີ່ຈຸດຈັບຢຸດທີ່ມີຢູ່ແລ້ວເພື່ອສໍາເນົາມັນ. ກົດສອງຄັ້ງນອກຈຸດຈັບຢຸດທີ່ມີຢູ່ແລ້ວເພື່ອສ້າງຈຸດຢຸດໃໝ່. ລາກ &amp; ວາງຈຸດຈັບເພື່ອປັບຕໍາແໜ່ງມັນ. ໃຊ້ປຸ່ມຂວາຂອງເມົາເພື່ອເປີດເມນູບໍລິບາຍດ້ວຍການກະທໍາເພີ່ມເຕີມ.</translation></message>
++    <message>
++        <source>Zoom</source>
++        <translation>ຊູມ</translation></message>
++    <message>
++        <source>Reset Zoom</source>
++        <translation>ຣີເຊັດຊູມ</translation></message>
++    <message>
++        <source>Position</source>
++        <translation>ຕຳແໜ່ງ</translation></message>
++    <message>
++        <source>Hue</source>
++        <translation>ຮູ້</translation></message>
++    <message>
++        <source>H</source>
++        <translation>ຮ</translation></message>
++    <message>
++        <source>Saturation</source>
++        <translation>ຄວາມອີ່ມຕົວ</translation></message>
++    <message>
++        <source>S</source>
++        <translation>ສ</translation></message>
++    <message>
++        <source>Sat</source>
++        <translation>ວັນເສົາ</translation></message>
++    <message>
++        <source>Value</source>
++        <translation>ມູນຄ່າ</translation></message>
++    <message>
++        <source>V</source>
++        <translation>ພ</translation></message>
++    <message>
++        <source>Val</source>
++        <translation>ຄ່າ</translation></message>
++    <message>
++        <source>Alpha</source>
++        <translation>ອັລຟາ</translation></message>
++    <message>
++        <source>A</source>
++        <translation>ອ</translation></message>
++    <message>
++        <source>Type</source>
++        <translation>ພິມ</translation></message>
++    <message>
++        <source>Spread</source>
++        <translation>ກະຈາຍ</translation></message>
++    <message>
++        <source>Color</source>
++        <translation>ສີ</translation></message>
++    <message>
++        <source>Current stop's color</source>
++        <translation>ສີຂອງປ່ຽງປັດຈຸບັນ</translation></message>
++    <message>
++        <source>Show HSV specification</source>
++        <translation>ສະແດງຂໍ້ມູນການກຳນົດ HSV</translation></message>
++    <message>
++        <source>HSV</source>
++        <translation>HSV</translation></message>
++    <message>
++        <source>Show RGB specification</source>
++        <translation>ສະແດງຂໍ້ມູນສະເພາະ RGB</translation></message>
++    <message>
++        <source>RGB</source>
++        <translation>ສີ RGB</translation></message>
++    <message>
++        <source>Current stop's position</source>
++        <translation>ຕຳແໜ່ງຂອງປ່ຽນປະຈຸບັນ</translation></message>
++    <message>
++        <source>%</source>
++        <translation>%</translation></message>
++    <message>
++        <source>Zoom In</source>
++        <translation>ຂະຫຍາຍຂະໜາດ</translation></message>
++    <message>
++        <source>Zoom Out</source>
++        <translation>ຂະຫຍາຍອອກ</translation></message>
++    <message>
++        <source>Toggle details extension</source>
++        <translation>ປ່ຽນສະຖານະການຂະຫຍາຍລາຍລະອຽດ</translation></message>
++    <message>
++        <source>&gt;</source>
++        <translation>&gt;</translation></message>
++    <message>
++        <source>Linear Type</source>
++        <translation>ປະເພດເສັ້ນຊື່</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>Radial Type</source>
++        <translation>ປະເພດຮູບວົງກົມ</translation></message>
++    <message>
++        <source>Conical Type</source>
++        <translation>ປະເພດຮູບກົມ</translation></message>
++    <message>
++        <source>Pad Spread</source>
++        <translation>ກະດານກະຈາຍ</translation></message>
++    <message>
++        <source>Repeat Spread</source>
++        <translation>ຊ້ຳຄືນການແຜ່ກະຈາຍ</translation></message>
++    <message>
++        <source>Reflect Spread</source>
++        <translation>ສະທ້ອນການແຜ່ກະຈາຍ</translation></message>
++    <message>
++        <source>Start X</source>
++        <translation>ເປີດ X</translation></message>
++    <message>
++        <source>Start Y</source>
++        <translation>ເປີດໃຊ້ Y</translation></message>
++    <message>
++        <source>Final X</source>
++        <translation>ສຸດທ້າຍ X</translation></message>
++    <message>
++        <source>Final Y</source>
++        <translation>ສຸດທ້າຍ Y</translation></message>
++    <message>
++        <source>Central X</source>
++        <translation>ສູນກາງ X</translation></message>
++    <message>
++        <source>Central Y</source>
++        <translation>ສູນກາງ Y</translation></message>
++    <message>
++        <source>Focal X</source>
++        <translation>Focal X</translation></message>
++    <message>
++        <source>Focal Y</source>
++        <translation>Focal Y</translation></message>
++    <message>
++        <source>Radius</source>
++        <translation>ລັດສະໝີ</translation></message>
++    <message>
++        <source>Angle</source>
++        <translation>ມຸມ</translation></message>
++    <message>
++        <source>Linear</source>
++        <translation>ລີນຽວ</translation></message>
++    <message>
++        <source>Radial</source>
++        <translation>ຮັດຽອດ</translation></message>
++    <message>
++        <source>Conical</source>
++        <translation>ຮູບກົມ</translation></message>
++    <message>
++        <source>Pad</source>
++        <translation>ແພດ</translation></message>
++    <message>
++        <source>Repeat</source>
++        <translation>ເຮັດຊ້ຳ</translation></message>
++    <message>
++        <source>Reflect</source>
++        <translation>ສະທ້ອນ</translation></message>
++</context>
++<context>
++    <name>QtGradientStopsWidget</name>
++    <message>
++        <source>New Stop</source>
++        <translation>ຢຸດໃໝ່</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Flip All</source>
++        <translation>ພິກທັງໝົດ</translation></message>
++    <message>
++        <source>Select All</source>
++        <translation>ເລືອກທັງໝົດ</translation></message>
++    <message>
++        <source>Zoom In</source>
++        <translation>ຂະຫຍາຍຂະໜາດ</translation></message>
++    <message>
++        <source>Zoom Out</source>
++        <translation>ຂະຫຍາຍອອກ</translation></message>
++    <message>
++        <source>Reset Zoom</source>
++        <translation>ຕັ້ງຄ່າການຂະຫຍາຍຄືນໃໝ່</translation></message>
++</context>
++<context>
++    <name>QtGradientView</name>
++    <message>
++        <source>Gradient View</source>
++        <translation>ມຸມມອງການເລື່ອນສີ</translation></message>
++    <message>
++        <source>New...</source>
++        <translation>ໃໝ່...</translation></message>
++    <message>
++        <source>Edit...</source>
++        <translation>ແກ້ໄຂ...</translation></message>
++    <message>
++        <source>Rename</source>
++        <translation>ປ່ຽນຊື່</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Grad</source>
++        <translation>ຈົບ</translation></message>
++    <message>
++        <source>Remove Gradient</source>
++        <translation>ລຶບການປະສົມສີ</translation></message>
++    <message>
++        <source>Are you sure you want to remove the selected gradient?</source>
++        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການລຶບກາດລຽນທີ່ເລືອກໄວ້?</translation></message>
++</context>
++<context>
++    <name>QtGradientViewDialog</name>
++    <message>
++        <source>Select Gradient</source>
++        <translation>ເລືອກກາດີເອັນ</translation></message>
++</context>
++<context>
++    <name>QtLocalePropertyManager</name>
++    <message>
++        <source>&lt;Invalid&gt;</source>
++        <translation>&lt;Invalid&gt;</translation></message>
++    <message>
++        <source>%1, %2</source>
++        <translation>%1, %2</translation></message>
++    <message>
++        <source>Language</source>
++        <translation>ພາສາ</translation></message>
++    <message>
++        <source>Country</source>
++        <translation>ປະເທດ</translation></message>
++</context>
++<context>
++    <name>QtPointFPropertyManager</name>
++    <message>
++        <source>(%1, %2)</source>
++        <translation>(%1, %2)</translation></message>
++    <message>
++        <source>X</source>
++        <translation>X</translation></message>
++    <message>
++        <source>Y</source>
++        <translation>ຢ</translation></message>
++</context>
++<context>
++    <name>QtPointPropertyManager</name>
++    <message>
++        <source>(%1, %2)</source>
++        <translation>(%1, %2)</translation></message>
++    <message>
++        <source>X</source>
++        <translation>X</translation></message>
++    <message>
++        <source>Y</source>
++        <translation>ຢ</translation></message>
++</context>
++<context>
++    <name>QtPropertyBrowserUtils</name>
++    <message>
++        <source>[%1, %2, %3] (%4)</source>
++        <translation>[%1, %2, %3] (%4)</translation></message>
++    <message>
++        <source>[%1, %2]</source>
++        <translation>[%1, %2]</translation></message>
++</context>
++<context>
++    <name>QtRectFPropertyManager</name>
++    <message>
++        <source>[(%1, %2), %3 x %4]</source>
++        <translation>[(%1, %2), %3 x %4]</translation></message>
++    <message>
++        <source>X</source>
++        <translation>X</translation></message>
++    <message>
++        <source>Y</source>
++        <translation>ຢ</translation></message>
++    <message>
++        <source>Width</source>
++        <translation>ກວ້າງ</translation></message>
++    <message>
++        <source>Height</source>
++        <translation>ຄວາມສູງ</translation></message>
++</context>
++<context>
++    <name>QtRectPropertyManager</name>
++    <message>
++        <source>[(%1, %2), %3 x %4]</source>
++        <translation>[(%1, %2), %3 x %4]</translation></message>
++    <message>
++        <source>X</source>
++        <translation>X</translation></message>
++    <message>
++        <source>Y</source>
++        <translation>ຢ</translation></message>
++    <message>
++        <source>Width</source>
++        <translation>ກວ້າງ</translation></message>
++    <message>
++        <source>Height</source>
++        <translation>ຄວາມສູງ</translation></message>
++</context>
++<context>
++    <name>QtResourceEditorDialog</name>
++    <message>
++        <source>Dialog</source>
++        <translation>ກ່ອງຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>New File</source>
++        <translation>ໄຟລ໌ໃໝ່</translation></message>
++    <message>
++        <source>N</source>
++        <translation>ນ</translation></message>
++    <message>
++        <source>Remove File</source>
++        <translation>ລຶບໄຟລ໌</translation></message>
++    <message>
++        <source>R</source>
++        <translation>ພາສາລາວ: ອ</translation></message>
++    <message>
++        <source>I</source>
++        <translation>ຂ້ອຍ</translation></message>
++    <message>
++        <source>New Resource</source>
++        <translation>ຊັບພະຍາກອນໃໝ່</translation></message>
++    <message>
++        <source>A</source>
++        <translation>ອ</translation></message>
++    <message>
++        <source>Remove Resource or File</source>
++        <translation>ລຶບຊັບພະຍາກອນ ຫຼື ໄຟລ໌</translation></message>
++    <message>
++        <source>%1 already exists.
++Do you want to replace it?</source>
++        <translation>%1 ແມ່ນມີຢູ່ແລ້ວ.
++ທ່ານຕ້ອງການທີ່ຈະແທນທີ່ມັນບໍ?</translation></message>
++    <message>
++        <source>The file does not appear to be a resource file; element '%1' was found where '%2' was expected.</source>
++        <translation>ຟາຍດັ່ງກ່າວບໍ່ໄດ້ປາກົດວ່າເປັນຟາຍຊັບພະຍາກອນ; ອົງປະກອບ '%1' ຖືກພົບເຫັນບ່ອນທີ່ '%2' ຖືກຄາດຫວັງ.</translation></message>
++    <message>
++        <source>%1 [read-only]</source>
++        <translation>%1 [ອ່ານໄດ້ຢ່າງດຽວ]</translation></message>
++    <message>
++        <source>%1 [missing]</source>
++        <translation>%1 [ບໍ່ມີ]</translation></message>
++    <message>
++        <source>&lt;no prefix&gt;</source>
++        <translation>&lt;no prefix&gt;</translation></message>
++    <message>
++        <source>New Resource File</source>
++        <translation>ເອກະສານຊັບພະຍາກອນໃໝ່</translation></message>
++    <message>
++        <source>Resource files (*.qrc)</source>
++        <translation>ໄຟລ໌ຊັບພະຍາກອນ (*.qrc)</translation></message>
++    <message>
++        <source>Import Resource File</source>
++        <translation>ນຳເຂົ້າໄຟລ໌ຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>newPrefix</source>
++        <translation>ຄຳນຳໜ້າໃໝ່</translation></message>
++    <message>
++        <source>&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; The file&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;is outside of the current resource file's parent directory.&lt;/p&gt;</source>
++        <translation>&lt;p&gt;&lt;b&gt;ຄຳເຕືອນ:&lt;/b&gt; ໄຟລ໌&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;ຢູ່ນອກໂຟນເດີຂອງໄຟລ໌ຊັບພະຍາກອນປະຈຸບັນ.&lt;/p&gt;</translation></message>
++    <message>
++        <source>&lt;p&gt;To resolve the issue, press:&lt;/p&gt;&lt;table&gt;&lt;tr&gt;&lt;th align="left"&gt;Copy&lt;/th&gt;&lt;td&gt;to copy the file to the resource file's parent directory.&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;th align="left"&gt;Copy As...&lt;/th&gt;&lt;td&gt;to copy the file into a subdirectory of the resource file's parent directory.&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;th align="left"&gt;Keep&lt;/th&gt;&lt;td&gt;to use its current location.&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
++        <translation>&lt;p&gt;ເພື່ອແກ້ໄຂບັນຫາ, ກົດ:&lt;/p&gt;&lt;table&gt;&lt;tr&gt;&lt;th align="left"&gt;ສຳເນົາ&lt;/th&gt;&lt;td&gt;ເພື່ອສຳເນົາໄຟລ໌ໄປຍັງໂຟນເດີແມ່ຂອງໄຟລ໌ຊັບພະຍາກອນ.&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;th align="left"&gt;ສຳເນົາເປັນ...&lt;/th&gt;&lt;td&gt;ເພື່ອສຳເນົາໄຟລ໌ເຂົ້າໄປໃນໂຟນເດີຍ່ອຍຂອງໂຟນເດີແມ່ຂອງໄຟລ໌ຊັບພະຍາກອນ.&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;th align="left"&gt;ຮັກສາ&lt;/th&gt;&lt;td&gt;ເພື່ອໃຊ້ສະຖານທີ່ປະຈຸບັນຂອງມັນ.&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</translation></message>
++    <message>
++        <source>Add Files</source>
++        <translation>ເພີ່ມໄຟລ໌</translation></message>
++    <message>
++        <source>Incorrect Path</source>
++        <translation>ເສັ້ນທາງບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Copy</source>
++        <translation>ສຳເນົາ</translation></message>
++    <message>
++        <source>Copy As...</source>
++        <translation>ສຳເນົາເປັນ...</translation></message>
++    <message>
++        <source>Keep</source>
++        <translation>ຮັກສາ</translation></message>
++    <message>
++        <source>Skip</source>
++        <translation>ຂ້າມ</translation></message>
++    <message>
++        <source>Clone Prefix</source>
++        <translation>ສໍາເນົາຄໍານໍາຫນ້າ</translation></message>
++    <message>
++        <source>Enter the suffix which you want to add to the names of the cloned files.
++This could for example be a language extension like "_de".</source>
++        <translation>ປ້ອນ suffix ທີ່ທ່ານຕ້ອງການເພີ່ມໃສ່ຊື່ຂອງໄຟລ໌ທີ່ຖືກສໍາເນົາ.
++ນີ້ອາດຈະເປັນຕົວຢ່າງເຊັ່ນ: ສ່ວນຂະຫຍາຍພາສາເຊັ່ນ "_de".</translation></message>
++    <message>
++        <source>Copy As</source>
++        <translation>ສຳເນົາເປັນ</translation></message>
++    <message>
++        <source>&lt;p&gt;The selected file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;is outside of the current resource file's directory:&lt;/p&gt;&lt;p&gt;%2&lt;/p&gt;&lt;p&gt;Please select another path within this directory.&lt;p&gt;</source>
++        <translation>&lt;p&gt;ເອກະສານທີ່ເລືອກ:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;ຢູ່ນອກໂຟນເດີຂອງເອກະສານຊັບພະຍາກອນປະຈຸບັນ:&lt;/p&gt;&lt;p&gt;%2&lt;/p&gt;&lt;p&gt;ກະລຸນາເລືອກເສັ້ນທາງອື່ນພາຍໃນໂຟນເດີນີ້.&lt;p&gt;</translation></message>
++    <message>
++        <source>Could not overwrite %1.</source>
++        <translation>ບໍ່ສາມາດທົດແທນ %1 ໄດ້.</translation></message>
++    <message>
++        <source>Could not copy
++%1
++to
++%2</source>
++        <translation>ບໍ່ສາມາດສຳເນົາ
++%1
++ໄປຫາ
++%2</translation></message>
++    <message>
++        <source>A parse error occurred at line %1, column %2 of %3:
++%4</source>
++        <translation>ຂໍ້ຜິດພາດການວິເຄາະເກີດຂຶ້ນທີ່ເສັ້ນ %1, ຖັນ %2 ຂອງ %3:
++%4</translation></message>
++    <message>
++        <source>Save Resource File</source>
++        <translation>ບັນທຶກໄຟລ໌ຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>Could not write %1: %2</source>
++        <translation>ບໍ່ສາມາດຂຽນ %1: %2</translation></message>
++    <message>
++        <source>Edit Resources</source>
++        <translation>ແກ້ໄຂຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>New...</source>
++        <translation>ໃໝ່...</translation></message>
++    <message>
++        <source>Open...</source>
++        <translation>ເປີດ...</translation></message>
++    <message>
++        <source>Open Resource File</source>
++        <translation>ເປີດໄຟລ໌ຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Move Up</source>
++        <translation>ຍ້າຍຂຶ້ນ</translation></message>
++    <message>
++        <source>Move Down</source>
++        <translation>ຍ້າຍລົງ</translation></message>
++    <message>
++        <source>Add Prefix</source>
++        <translation>ເພີ່ມຄຳນຳໜ້າ</translation></message>
++    <message>
++        <source>Add Files...</source>
++        <translation>ເພີ່ມໄຟລ໌...</translation></message>
++    <message>
++        <source>Change Prefix</source>
++        <translation>ປ່ຽນຄຳນຳໜ້າ</translation></message>
++    <message>
++        <source>Change Language</source>
++        <translation>ປ່ຽນພາສາ</translation></message>
++    <message>
++        <source>Change Alias</source>
++        <translation>ປ່ຽນຊື່ຫຍໍ້</translation></message>
++    <message>
++        <source>Clone Prefix...</source>
++        <translation>ສໍາເນົາຄໍານໍາຫນ້າ...</translation></message>
++    <message>
++        <source>Prefix / Path</source>
++        <translation>ຄຳນຳໜ້າ / ເສັ້ນທາງ</translation></message>
++    <message>
++        <source>Language / Alias</source>
++        <translation>ພາສາ / ຊື່ຫຍໍ້</translation></message>
++    <message>
++        <source>&lt;html&gt;&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; There have been problems while reloading the resources:&lt;/p&gt;&lt;pre&gt;%1&lt;/pre&gt;&lt;/html&gt;</source>
++        <translation>&lt;html&gt;&lt;p&gt;&lt;b&gt;ຄຳເຕືອນ:&lt;/b&gt; ມີບັນຫາໃນການໂຫຼດຊັບພະຍາກອນຄືນໃໝ່:&lt;/p&gt;&lt;pre&gt;%1&lt;/pre&gt;&lt;/html&gt;</translation></message>
++    <message>
++        <source>Resource Warning</source>
++        <translation>ຄຳເຕືອນດ້ານຊັບພະຍາກອນ</translation></message>
++</context>
++<context>
++    <name>QtResourceView</name>
++    <message>
++        <source>Size: %1 x %2
++%3</source>
++        <translation>ຂະໜາດ: %1 x %2
++%3</translation></message>
++    <message>
++        <source>Edit Resources...</source>
++        <translation>ແກ້ໄຂຊັບພະຍາກອນ...</translation></message>
++    <message>
++        <source>Reload</source>
++        <translation>ໂຫຼດຄືນໃໝ່</translation></message>
++    <message>
++        <source>Copy Path</source>
++        <translation>ສຳເນົາເສັ້ນທາງ</translation></message>
++    <message>
++        <source>Filter</source>
++        <translation>ກັ່ນຕອງ</translation></message>
++</context>
++<context>
++    <name>QtResourceViewDialog</name>
++    <message>
++        <source>Select Resource</source>
++        <translation>ເລືອກຊັບພະຍາກອນ</translation></message>
++</context>
++<context>
++    <name>QtSizeFPropertyManager</name>
++    <message>
++        <source>%1 x %2</source>
++        <translation>%1 x %2</translation></message>
++    <message>
++        <source>Width</source>
++        <translation>ກວ້າງ</translation></message>
++    <message>
++        <source>Height</source>
++        <translation>ຄວາມສູງ</translation></message>
++</context>
++<context>
++    <name>QtSizePolicyPropertyManager</name>
++    <message>
++        <source>&lt;Invalid&gt;</source>
++        <translation>&lt;Invalid&gt;</translation></message>
++    <message>
++        <source>[%1, %2, %3, %4]</source>
++        <translation>[%1, %2, %3, %4]</translation></message>
++    <message>
++        <source>Horizontal Policy</source>
++        <translation>ນະໂຍບາຍແນວນອນ</translation></message>
++    <message>
++        <source>Vertical Policy</source>
++        <translation>ນະໂຍບາຍແນວຕັ້ງ</translation></message>
++    <message>
++        <source>Horizontal Stretch</source>
++        <translation>ການຂະຫຍາຍແນວນອນ</translation></message>
++    <message>
++        <source>Vertical Stretch</source>
++        <translation>ການຍືດແນວຕັ້ງ</translation></message>
++</context>
++<context>
++    <name>QtSizePropertyManager</name>
++    <message>
++        <source>%1 x %2</source>
++        <translation>%1 x %2</translation></message>
++    <message>
++        <source>Width</source>
++        <translation>ກວ້າງ</translation></message>
++    <message>
++        <source>Height</source>
++        <translation>ຄວາມສູງ</translation></message>
++</context>
++<context>
++    <name>QtToolBarDialog</name>
++    <message>
++        <source>Customize Toolbars</source>
++        <translation>ປັບແຕ່ງແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>1</source>
++        <translation>1</translation></message>
++    <message>
++        <source>Actions</source>
++        <translation>ການປະຕິບັດ</translation></message>
++    <message>
++        <source>Toolbars</source>
++        <translation>ແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>Add new toolbar</source>
++        <translation>ເພີ່ມແຖບເຄື່ອງມືໃໝ່</translation></message>
++    <message>
++        <source>New</source>
++        <translation>ໃໝ່</translation></message>
++    <message>
++        <source>Remove selected toolbar</source>
++        <translation>ລຶບແຖບເຄື່ອງມືທີ່ເລືອກໄວ້</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Rename toolbar</source>
++        <translation>ປ່ຽນຊື່ແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>Rename</source>
++        <translation>ປ່ຽນຊື່</translation></message>
++    <message>
++        <source>Move action up</source>
++        <translation>ຍ້າຍການກະທຳຂຶ້ນ</translation></message>
++    <message>
++        <source>Up</source>
++        <translation>ຂຶ້ນ</translation></message>
++    <message>
++        <source>Remove action from toolbar</source>
++        <translation>ລຶບການກະທຳອອກຈາກແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>&lt;-</source>
++        <translation>&lt;-</translation></message>
++    <message>
++        <source>Add action to toolbar</source>
++        <translation>ເພີ່ມການກະທຳໃສ່ແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>-&gt;</source>
++        <translation>-&gt;</translation></message>
++    <message>
++        <source>Move action down</source>
++        <translation>ຍ້າຍການກະທຳລົງ</translation></message>
++    <message>
++        <source>Down</source>
++        <translation>ລົງ</translation></message>
++    <message>
++        <source>Current Toolbar Actions</source>
++        <translation>ການກະທຳແຖບເຄື່ອງມືປະຈຸບັນ</translation></message>
++    <message>
++        <source>Custom Toolbar</source>
++        <translation>ແຖບເຄື່ອງມືທີ່ກຳນົດເອງ</translation></message>
++    <message>
++        <source>&lt; S E P A R A T O R &gt;</source>
++        <translation>&lt; S E P A R A T O R &gt;</translation></message>
++</context>
++<context>
++    <name>QtTreePropertyBrowser</name>
++    <message>
++        <source>Property</source>
++        <translation>ຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>Value</source>
++        <translation>ມູນຄ່າ</translation></message>
++</context>
++<context>
++    <name>SaveFormAsTemplate</name>
++    <message>
++        <source>Save Form As Template</source>
++        <translation>ບັນທຶກແບບຟອມເປັນແມ່ແບບ</translation></message>
++    <message>
++        <source>&amp;Name:</source>
++        <translation>&amp;ຊື່:</translation></message>
++    <message>
++        <source>&amp;Category:</source>
++        <translation>&amp;ໝວດ:</translation></message>
++    <message>
++        <source>Add path...</source>
++        <translation>ເພີ່ມເສັ້ນທາງ...</translation></message>
++    <message>
++        <source>Template Exists</source>
++        <translation>ແມ່ແບບມີຢູ່ແລ້ວ</translation></message>
++    <message>
++        <source>A template with the name %1 already exists.
++Do you want overwrite the template?</source>
++        <translation>ແມ່ແບບທີ່ມີຊື່ %1 ໄດ້ມີຢູ່ແລ້ວ.
++ທ່ານຕ້ອງການທົດແທນແມ່ແບບນີ້ບໍ?</translation></message>
++    <message>
++        <source>Overwrite Template</source>
++        <translation>ຂຽນທັບແມ່ແບບ</translation></message>
++    <message>
++        <source>Open Error</source>
++        <translation>ເປີດຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>There was an error opening template %1 for writing. Reason: %2</source>
++        <translation>ມີຂໍ້ຜິດພາດໃນການເປີດແມ່ແບບ %1 ສຳລັບການຂຽນ. ເຫດຜົນ: %2</translation></message>
++    <message>
++        <source>Write Error</source>
++        <translation>ຂຽນຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>There was an error writing the template %1 to disk. Reason: %2</source>
++        <translation>ມີຂໍ້ຜິດພາດໃນການຂຽນແມ່ແບບ %1 ລົງໃນດິສ. ເຫດຜົນ: %2</translation></message>
++    <message>
++        <source>Pick a directory to save templates in</source>
++        <translation>ເລືອກໂຟນເດີເພື່ອບັນທຶກແມ່ແບບໃນ</translation></message>
++</context>
++<context>
++    <name>SelectSignalDialog</name>
++    <message>
++        <source>Go to slot</source>
++        <translation>ໄປຫາຊ່ອງ</translation></message>
++    <message>
++        <source>Select signal</source>
++        <translation>ເລືອກສັນຍານ</translation></message>
++    <message>
++        <source>signal</source>
++        <translation>ສັນຍານ</translation></message>
++    <message>
++        <source>class</source>
++        <translation>ຊັ້ນ</translation></message>
++</context>
++<context>
++    <name>SignalSlotConnection</name>
++    <message>
++        <source>SENDER(%1), SIGNAL(%2), RECEIVER(%3), SLOT(%4)</source>
++        <translation>ຜູ້ສົ່ງ(%1), ສັນຍານ(%2), ຜູ້ຮັບ(%3), ຊ່ອງ(%4)</translation></message>
++</context>
++<context>
++    <name>SignalSlotDialogClass</name>
++    <message>
++        <source>Signals and slots</source>
++        <translation>ສັນຍານແລະຊ່ອງ</translation></message>
++    <message>
++        <source>Slots</source>
++        <translation>ສະລັອດ</translation></message>
++    <message>
++        <source>Add</source>
++        <translation>ເພີ່ມ</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Signals</source>
++        <translation>ສັນຍານ</translation></message>
++</context>
++<context>
++    <name>Spacer</name>
++    <message>
++        <source>Horizontal Spacer '%1', %2 x %3</source>
++        <translation>ຊ່ອງຫວ່າງແນວນອນ '%1', %2 x %3</translation></message>
++    <message>
++        <source>Vertical Spacer '%1', %2 x %3</source>
++        <translation>ຊ່ອງຫວ່າງແນວຕັ້ງ '%1', %2 x %3</translation></message>
++</context>
++<context>
++    <name>TemplateOptionsPage</name>
++    <message>
++        <source>Template Paths</source>
++        <extracomment>Tab in preferences dialog</extracomment>
++        <translation>ເສັ້ນທາງແມ່ແບບ</translation></message>
++</context>
++<context>
++    <name>ToolBarManager</name>
++    <message>
++        <source>Configure Toolbars...</source>
++        <translation>ຕັ້ງຄ່າແຖບເຄື່ອງມື...</translation></message>
++    <message>
++        <source>Window</source>
++        <translation>ຫນ້າຕ່າງ</translation></message>
++    <message>
++        <source>Help</source>
++        <translation>ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>Style</source>
++        <translation>ຮູບແບບ</translation></message>
++    <message>
++        <source>Dock views</source>
++        <translation>ມຸມມອງທີ່ຕັ້ງຢູ່ເທິງທ່າ</translation></message>
++    <message>
++        <source>File</source>
++        <translation>ໄຟລ໌</translation></message>
++    <message>
++        <source>Edit</source>
++        <translation>ແກ້ໄຂ</translation></message>
++    <message>
++        <source>Tools</source>
++        <translation>ເຄື່ອງມື</translation></message>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Toolbars</source>
++        <translation>ແຖບເຄື່ອງມື</translation></message>
++</context>
++<context>
++    <name>VersionDialog</name>
++    <message>
++        <source>&lt;h3&gt;%1&lt;/h3&gt;&lt;br/&gt;&lt;br/&gt;Version %2</source>
++        <translation>&lt;h3&gt;%1&lt;/h3&gt;&lt;br/&gt;&lt;br/&gt;ສະບັບ %2</translation></message>
++    <message>
++        <source>Qt Designer</source>
++        <translation>Qt Designer</translation></message>
++    <message>
++        <source>&lt;br/&gt;Qt Designer is a graphical user interface designer for Qt applications.&lt;br/&gt;</source>
++        <translation>&lt;br/&gt;Qt Designer ແມ່ນໂປຣແກຣມອອກແບບກຣາຟິກສໍາລັບອິນເຕີເຟດຜູ້ໃຊ້ຂອງແອັບພລິເຄຊັນ Qt.&lt;br/&gt;</translation></message>
++    <message>
++        <source>%1&lt;br/&gt;Copyright (C) %2 The Qt Company Ltd.</source>
++        <translation>%1&lt;br/&gt;ລິຂະສິດ (C) %2 ບໍລິສັດ Qt ຈຳກັດ</translation></message>
++</context>
++<context>
++    <name>WidgetDataBase</name>
++    <message>
++        <source>The file contains a custom widget '%1' whose base class (%2) differs from the current entry in the widget database (%3). The widget database is left unchanged.</source>
++        <translation>ໄຟລ໌ດັ່ງກ່າວປະກອບດ້ວຍວິດເຈັດທີ່ກຳນົດເອງ '%1' ທີ່ມີຊັ້ນພື້ນຖານ (%2) ແຕກຕ່າງຈາກລາຍການປະຈຸບັນໃນຖານຂໍ້ມູນວິດເຈັດ (%3). ຖານຂໍ້ມູນວິດເຈັດຖືກປະໄວ້ໂດຍບໍ່ມີການປ່ຽນແປງ.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal</name>
++    <message>
++        <source>%1 Widget</source>
++        <translation>%1 ວິດເຈັດ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ActionEditor</name>
++    <message>
++        <source>New...</source>
++        <translation>ໃໝ່...</translation></message>
++    <message>
++        <source>Edit...</source>
++        <translation>ແກ້ໄຂ...</translation></message>
++    <message>
++        <source>Go to slot...</source>
++        <translation>ໄປຫາຊ່ອງ...</translation></message>
++    <message>
++        <source>Copy</source>
++        <translation>ສຳເນົາ</translation></message>
++    <message>
++        <source>Cut</source>
++        <translation>ຕັດ</translation></message>
++    <message>
++        <source>Paste</source>
++        <translation>ວາງ</translation></message>
++    <message>
++        <source>Select all</source>
++        <translation>ເລືອກທັງໝົດ</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Actions</source>
++        <translation>ການປະຕິບັດ</translation></message>
++    <message>
++        <source>Configure Action Editor</source>
++        <translation>ຕັ້ງຄ່າຕົວແກ້ໄຂການດຳເນີນການ</translation></message>
++    <message>
++        <source>Icon View</source>
++        <translation>ມຸມມອງໄອຄອນ</translation></message>
++    <message>
++        <source>Detailed View</source>
++        <translation>ມຸມມອງແບບລະອຽດ</translation></message>
++    <message>
++        <source>Filter</source>
++        <translation>ກັ່ນຕອງ</translation></message>
++    <message>
++        <source>New action</source>
++        <translation>ການປະຕິບັດໃໝ່</translation></message>
++    <message>
++        <source>Edit action</source>
++        <translation>ແກ້ໄຂການກະທຳ</translation></message>
++    <message>
++        <source>Remove action '%1'</source>
++        <translation>ລຶບການກະທຳ '%1'</translation></message>
++    <message>
++        <source>Remove actions</source>
++        <translation>ລຶບການກະທຳ</translation></message>
++    <message>
++        <source>Used In</source>
++        <translation>ນຳໃຊ້ໃນ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ActionModel</name>
++    <message>
++        <source>Name</source>
++        <translation>ຊື່</translation></message>
++    <message>
++        <source>Used</source>
++        <translation>ໃຊ້ແລ້ວ</translation></message>
++    <message>
++        <source>Text</source>
++        <translation>ຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Shortcut</source>
++        <translation>ທາງລັດ</translation></message>
++    <message>
++        <source>Checkable</source>
++        <translation>ກວດສອບໄດ້</translation></message>
++    <message>
++        <source>ToolTip</source>
++        <translation>ຄຳແນະນຳເຄື່ອງມື</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::BuddyEditor</name>
++    <message>
++        <source>Add buddy</source>
++        <translation>ເພີ່ມຫມູ່</translation></message>
++    <message>
++        <source>Remove buddies</source>
++        <translation>ລຶບລຽງໝູ່</translation></message>
++    <message numerus="yes">
++        <source>Remove %n buddies</source>
++        <translation>
++            <numerusform>ລຶບ %n ຫມູ່</numerusform>
++        </translation></message>
++    <message numerus="yes">
++        <source>Add %n buddies</source>
++        <translation>
++            <numerusform>ເພີ່ມ %n ຫມູ່</numerusform>
++        </translation></message>
++    <message>
++        <source>Set automatically</source>
++        <translation>ຕັ້ງຄ່າໂດຍອັດຕະໂນມັດ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::BuddyEditorPlugin</name>
++    <message>
++        <source>Edit Buddies</source>
++        <translation>ແກ້ໄຂຫມູ່</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::BuddyEditorTool</name>
++    <message>
++        <source>Edit Buddies</source>
++        <translation>ແກ້ໄຂຫມູ່</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ButtonGroupMenu</name>
++    <message>
++        <source>Select members</source>
++        <translation>ເລືອກສະມາຊິກ</translation></message>
++    <message>
++        <source>Break</source>
++        <translation>ພັກ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ButtonTaskMenu</name>
++    <message>
++        <source>Assign to button group</source>
++        <translation>ກຳນົດໃຫ້ກຸ່ມປຸ່ມ</translation></message>
++    <message>
++        <source>Button group</source>
++        <translation>ກຸ່ມປຸ່ມ</translation></message>
++    <message>
++        <source>New button group</source>
++        <translation>ກຸ່ມປຸ່ມໃໝ່</translation></message>
++    <message>
++        <source>Change text...</source>
++        <translation>ປ່ຽນຂໍ້ຄວາມ...</translation></message>
++    <message>
++        <source>None</source>
++        <translation>ບໍ່ມີ</translation></message>
++    <message>
++        <source>Button group '%1'</source>
++        <translation>ກຸ່ມປຸ່ມ '%1'</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::CodeDialog</name>
++    <message>
++        <source>Save...</source>
++        <translation>ບັນທຶກ...</translation></message>
++    <message>
++        <source>Copy All</source>
++        <translation>ຄັດລອກທັງໝົດ</translation></message>
++    <message>
++        <source>&amp;Find in Text...</source>
++        <translation>&amp;ຊອກຫາໃນຂໍ້ຄວາມ...</translation></message>
++    <message>
++        <source>A temporary form file could not be created in %1.</source>
++        <translation>ໄຟລ໌ຟອມຊົ່ວຄາວບໍ່ສາມາດສ້າງໄດ້ໃນ %1.</translation></message>
++    <message>
++        <source>The temporary form file %1 could not be written.</source>
++        <translation>ໄຟລ໌ຮູບແບບຊົ່ວຄາວ %1 ບໍ່ສາມາດຂຽນໄດ້.</translation></message>
++    <message>
++        <source>%1 - [Code]</source>
++        <translation>%1 - [ລະຫັດ]</translation></message>
++    <message>
++        <source>Save Code</source>
++        <translation>ບັນທຶກລະຫັດ</translation></message>
++    <message>
++        <source>Header Files (*.%1)</source>
++        <translation>ໄຟລ໌ຫົວຂໍ້ (*.%1)</translation></message>
++    <message>
++        <source>The file %1 could not be opened: %2</source>
++        <translation>ຟາຍ %1 ບໍ່ສາມາດເປີດໄດ້: %2</translation></message>
++    <message>
++        <source>The file %1 could not be written: %2</source>
++        <translation>ຟາຍ %1 ບໍ່ສາມາດຂຽນໄດ້: %2</translation></message>
++    <message>
++        <source>%1 - Error</source>
++        <translation>%1 - ຜິດພາດ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ColorAction</name>
++    <message>
++        <source>Text Color</source>
++        <translation>ສີຂໍ້ຄວາມ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ComboBoxTaskMenu</name>
++    <message>
++        <source>Edit Items...</source>
++        <translation>ແກ້ໄຂລາຍການ...</translation></message>
++    <message>
++        <source>Change Combobox Contents</source>
++        <translation>ປ່ຽນເນື້ອໃນຂອງກ່ອງລາຍການ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::CommandLinkButtonTaskMenu</name>
++    <message>
++        <source>Change description...</source>
++        <translation>ປ່ຽນຄຳອະທິບາຍ...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ConnectionEdit</name>
++    <message>
++        <source>Select All</source>
++        <translation>ເລືອກທັງໝົດ</translation></message>
++    <message>
++        <source>Deselect All</source>
++        <translation>ຍົກເລີກການເລືອກທັງໝົດ</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ConnectionModel</name>
++    <message>
++        <source>Sender</source>
++        <translation>ຜູ້ສົ່ງ</translation></message>
++    <message>
++        <source>Signal</source>
++        <translation>ສັນຍານ</translation></message>
++    <message>
++        <source>Receiver</source>
++        <translation>ຜູ້ຮັບ</translation></message>
++    <message>
++        <source>Slot</source>
++        <translation>ຊ່ອງ</translation></message>
++    <message>
++        <source>&lt;sender&gt;</source>
++        <translation>&lt;sender&gt;</translation></message>
++    <message>
++        <source>&lt;signal&gt;</source>
++        <translation>&lt;signal&gt;</translation></message>
++    <message>
++        <source>&lt;receiver&gt;</source>
++        <translation>&lt;receiver&gt;</translation></message>
++    <message>
++        <source>&lt;slot&gt;</source>
++        <translation>&lt;slot&gt;</translation></message>
++    <message>
++        <source>The connection already exists!&lt;br&gt;%1</source>
++        <translation>ການເຊື່ອມຕໍ່ມີຢູ່ແລ້ວ!&lt;br&gt;%1</translation></message>
++    <message>
++        <source>Signal and Slot Editor</source>
++        <translation>ບັນຊີລາຍຊື່ສັນຍານ ແລະ ຊ່ອງສັນຍາ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ContainerWidgetTaskMenu</name>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Insert</source>
++        <translation>ໃສ່</translation></message>
++    <message>
++        <source>Insert Page Before Current Page</source>
++        <translation>ໃສ່ໜ້າກ່ອນໜ້າປະຈຸບັນ</translation></message>
++    <message>
++        <source>Insert Page After Current Page</source>
++        <translation>ໃສ່ໜ້າຫຼັງຈາກໜ້າປະຈຸບັນ</translation></message>
++    <message>
++        <source>Add Subwindow</source>
++        <translation>ເພີ່ມຫນ້າຕ່າງຍ່ອຍ</translation></message>
++    <message>
++        <source>Subwindow</source>
++        <translation>ຫນ້າຕ່າງຍ່ອຍ</translation></message>
++    <message>
++        <source>Page</source>
++        <translation>ໜ້າ</translation></message>
++    <message>
++        <source>Page %1 of %2</source>
++        <translation>ໜ້າ %1 ຈາກ %2</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::DPI_Chooser</name>
++    <message>
++        <source>System (%1 x %2)</source>
++        <extracomment>System resolution</extracomment>
++        <translation>ລະບົບ (%1 x %2)</translation></message>
++    <message>
++        <source>User defined</source>
++        <translation>ຜູ້ໃຊ້ກຳນົດ</translation></message>
++    <message>
++        <source> x </source>
++        <extracomment>DPI X/Y separator</extracomment>
++        <translation>x</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::DesignerPropertyManager</name>
++    <message>
++        <source>translatable</source>
++        <translation>ປ່ຽນເປັນພາສາລາວ</translation></message>
++    <message>
++        <source>disambiguation</source>
++        <translation>ການປະກອບຄວາມ</translation></message>
++    <message>
++        <source>comment</source>
++        <translation>ຄຳເຫັນ</translation></message>
++    <message>
++        <source>id</source>
++        <translation>ລະຫັດ</translation></message>
++    <message>
++        <source>AlignLeft</source>
++        <translation>ຊື່ຊ້າຍ</translation></message>
++    <message>
++        <source>AlignHCenter</source>
++        <translation>ຈັດຕຳແໜ່ງກາງແນວນອນ</translation></message>
++    <message>
++        <source>AlignRight</source>
++        <translation>ຈັດຊື່ຊ້າຍ</translation></message>
++    <message>
++        <source>AlignJustify</source>
++        <translation>ຈັດຊື່ຊອບຊື່</translation></message>
++    <message>
++        <source>AlignTop</source>
++        <translation>ຈັດວາງດ້ານເທິງ</translation></message>
++    <message>
++        <source>AlignVCenter</source>
++        <translation>ຈັດຕຳແໜ່ງຕັ້ງກາງແນວຕັ້ງ</translation></message>
++    <message>
++        <source>AlignBottom</source>
++        <translation>ຈັດຊື່ລຸ່ມ</translation></message>
++    <message>
++        <source>%1, %2</source>
++        <translation>%1, %2</translation></message>
++    <message numerus="yes">
++        <source>Customized (%n roles)</source>
++        <translation>
++            <numerusform>ປັບແຕ່ງ (%n ບົດບາດ)</numerusform>
++        </translation></message>
++    <message>
++        <source>Inherited</source>
++        <translation>ສືບທອດ</translation></message>
++    <message>
++        <source>[Theme] %1</source>
++        <translation>[ຫົວຂໍ້] %1</translation></message>
++    <message>
++        <source>Horizontal</source>
++        <translation>ອອກນອນ</translation></message>
++    <message>
++        <source>Vertical</source>
++        <translation>ຕັ້ງຕົວ</translation></message>
++    <message>
++        <source>Theme</source>
++        <translation>ຫົວຂໍ້</translation></message>
++    <message>
++        <source>Normal Off</source>
++        <translation>ປົກກະຕິ ປິດ</translation></message>
++    <message>
++        <source>Normal On</source>
++        <translation>ປົກກະຕິ ເປີດ</translation></message>
++    <message>
++        <source>Disabled Off</source>
++        <translation>ປິດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Disabled On</source>
++        <translation>ປິດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Active Off</source>
++        <translation>ເປີດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Active On</source>
++        <translation>ເປີດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Selected Off</source>
++        <translation>ເລືອກປິດ</translation></message>
++    <message>
++        <source>Selected On</source>
++        <translation>ເລືອກແລ້ວ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::DeviceProfileDialog</name>
++    <message>
++        <source>Device Profiles (*.%1)</source>
++        <translation>ໂປຣໄຟລ໌ອຸປະກອນ (*.%1)</translation></message>
++    <message>
++        <source>Default</source>
++        <translation>ຄ່າເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Save Profile</source>
++        <translation>ບັນທຶກໂປຣໄຟລ໌</translation></message>
++    <message>
++        <source>Save Profile - Error</source>
++        <translation>ບັນທຶກໂປຣໄຟລ໌ - ຜິດພາດ</translation></message>
++    <message>
++        <source>Unable to open the file '%1' for writing: %2</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ '%1' ເພື່ອຂຽນໄດ້: %2</translation></message>
++    <message>
++        <source>Open profile</source>
++        <translation>ເປີດໂປຣໄຟລ໌</translation></message>
++    <message>
++        <source>Open Profile - Error</source>
++        <translation>ເປີດໂປຣໄຟລ໌ - ຜິດພາດ</translation></message>
++    <message>
++        <source>Unable to open the file '%1' for reading: %2</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ '%1' ເພື່ອອ່ານໄດ້: %2</translation></message>
++    <message>
++        <source>'%1' is not a valid profile: %2</source>
++        <translation>'%1' ບໍ່ແມ່ນໂປຣໄຟລ໌ທີ່ຖືກຕ້ອງ: %2</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::Dialog</name>
++    <message>
++        <source>Dialog</source>
++        <translation>ກ່ອງຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>StringList</source>
++        <translation>ລາຍການສະຕຣິງ</translation></message>
++    <message>
++        <source>New String</source>
++        <translation>ສະຕຣິງໃໝ່</translation></message>
++    <message>
++        <source>&amp;New</source>
++        <translation>&amp;ໃໝ່</translation></message>
++    <message>
++        <source>Delete String</source>
++        <translation>ລຶບສະຕຣິງ</translation></message>
++    <message>
++        <source>&amp;Delete</source>
++        <translation>&amp;ລຶບ</translation></message>
++    <message>
++        <source>&amp;Value:</source>
++        <translation>&amp;ມູນຄ່າ:</translation></message>
++    <message>
++        <source>Move String Up</source>
++        <translation>ຍ້າຍສະຕຣິງຂຶ້ນ</translation></message>
++    <message>
++        <source>Up</source>
++        <translation>ຂຶ້ນ</translation></message>
++    <message>
++        <source>Move String Down</source>
++        <translation>ຍ້າຍສະຕຣິງລົງ</translation></message>
++    <message>
++        <source>Down</source>
++        <translation>ລົງ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::EmbeddedOptionsControl</name>
++    <message>
++        <source>None</source>
++        <translation>ບໍ່ມີ</translation></message>
++    <message>
++        <source>Add a profile</source>
++        <translation>ເພີ່ມໂປຣໄຟລ໌</translation></message>
++    <message>
++        <source>Edit the selected profile</source>
++        <translation>ແກ້ໄຂໂປຣໄຟລທີ່ເລືອກ</translation></message>
++    <message>
++        <source>Delete the selected profile</source>
++        <translation>ລຶບໂປຣໄຟລທີ່ເລືອກໄວ້</translation></message>
++    <message>
++        <source>Add Profile</source>
++        <translation>ເພີ່ມໂປຣໄຟລ໌</translation></message>
++    <message>
++        <source>New profile</source>
++        <translation>ໂປຣໄຟລ໌ໃໝ່</translation></message>
++    <message>
++        <source>Edit Profile</source>
++        <translation>ແກ້ໄຂໂປຣໄຟລ໌</translation></message>
++    <message>
++        <source>Delete Profile</source>
++        <translation>ລຶບໂປຣໄຟລ໌</translation></message>
++    <message>
++        <source>Would you like to delete the profile '%1'?</source>
++        <translation>ທ່ານຕ້ອງການລຶບໂປຣໄຟລ໌ '%1' ບໍ?</translation></message>
++    <message>
++        <source>Default</source>
++        <translation>ຄ່າເລີ່ມຕົ້ນ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::FormEditor</name>
++    <message>
++        <source>Resource File Changed</source>
++        <translation>ໄຟລ໌ຊັບພະຍາກອນປ່ຽນແປງແລ້ວ</translation></message>
++    <message>
++        <source>The file "%1" has changed outside Designer. Do you want to reload it?</source>
++        <translation>ໄຟລ໌ "%1" ມີການປ່ຽນແປງນອກຈາກ Designer. ທ່ານຕ້ອງການໂຫຼດມັນໃໝ່ບໍ?</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::FormLayoutMenu</name>
++    <message>
++        <source>Add form layout row...</source>
++        <translation>ເພີ່ມແຖວຮູບແບບຟອມ...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::FormWindow</name>
++    <message>
++        <source>Edit contents</source>
++        <translation>ແກ້ໄຂເນື້ອຫາ</translation></message>
++    <message>
++        <source>F2</source>
++        <translation>F2</translation></message>
++    <message>
++        <source>Insert widget '%1'</source>
++        <translation>ໃສ່ widget '%1'</translation></message>
++    <message>
++        <source>Resize</source>
++        <translation>ປັບຂະຫນາດ</translation></message>
++    <message>
++        <source>Key Resize</source>
++        <translation>ປຸ່ມປັບຂະຫນາດ</translation></message>
++    <message>
++        <source>Key Move</source>
++        <translation>ການເຄື່ອນໄຫວທີ່ສຳຄັນ</translation></message>
++    <message numerus="yes">
++        <source>Paste %n action(s)</source>
++        <translation>
++            <numerusform>ວາງການປະຕິບັດ %n ລາຍການ</numerusform>
++        </translation></message>
++    <message numerus="yes">
++        <source>Paste %n widget(s)</source>
++        <translation>
++            <numerusform>ວາງ %n ວິດເຈັດ</numerusform>
++        </translation></message>
++    <message>
++        <source>Paste (%1 widgets, %2 actions)</source>
++        <translation>ວາງ (%1 ວິດເຈັດ, %2 ການກະທຳ)</translation></message>
++    <message>
++        <source>Cannot paste widgets. Designer could not find a container without a layout to paste into.</source>
++        <translation>ບໍ່ສາມາດວາງເຄື່ອງມືໄດ້. ຜູ້ອອກແບບບໍ່ສາມາດຊອກຫາພາຊະນະທີ່ບໍ່ມີລະບຽງເພື່ອວາງເຂົ້າໄດ້.</translation></message>
++    <message>
++        <source>Break the layout of the container you want to paste into, select this container and then paste again.</source>
++        <translation>ທໍາລາຍການຈັດແບບຂອງພາຊະນະທີ່ທ່ານຕ້ອງການວາງເຂົ້າ, ເລືອກພາຊະນະນີ້ແລະຈາກນັ້ນວາງອີກຄັ້ງ.</translation></message>
++    <message>
++        <source>Paste error</source>
++        <translation>ຜິດພາດໃນການວາງ</translation></message>
++    <message>
++        <source>Raise widgets</source>
++        <translation>ຍົກວິດເຈັດຂຶ້ນ</translation></message>
++    <message>
++        <source>Lower widgets</source>
++        <translation>ວິດເຈັດຕ່ໍາ</translation></message>
++    <message>
++        <source>Select Ancestor</source>
++        <translation>ເລືອກບັນພະບຸລຸດ</translation></message>
++    <message>
++        <source>Lay out</source>
++        <translation>ຈັດແຈງ</translation></message>
++    <message>
++        <source>Drop widget</source>
++        <translation>ວິດເຈັດລົງ</translation></message>
++    <message>
++        <source>A QMainWindow-based form does not contain a central widget.</source>
++        <translation>ແບບຟອມທີ່ອີງໃສ່ QMainWindow ບໍ່ມີວິດເຈັດສູນກາງ.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::FormWindowBase</name>
++    <message>
++        <source>Delete '%1'</source>
++        <translation>ລຶບ '%1'</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Invalid form</source>
++        <translation>ແບບຟອມບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>&lt;p&gt;This file contains top level spacers.&lt;br/&gt;They will &lt;b&gt;not&lt;/b&gt; be saved.&lt;/p&gt;&lt;p&gt;Perhaps you forgot to create a layout?&lt;/p&gt;</source>
++        <translation>&lt;p&gt;ໄຟລ໌ນີ້ມີຊ່ອງຫວ່າງລະດັບສູງສຸດ.&lt;br/&gt;ພວກມັນຈະ&lt;b&gt;ບໍ່&lt;/b&gt;ຖືກບັນທຶກ.&lt;/p&gt;&lt;p&gt;ບາງທີທ່ານອາດລືມສ້າງຮູບແບບການຈັດແຈງ?&lt;/p&gt;</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::FormWindowManager</name>
++    <message>
++        <source>Cu&amp;t</source>
++        <translation>ຕັດ</translation></message>
++    <message>
++        <source>Cuts the selected widgets and puts them on the clipboard</source>
++        <translation>ຕັດວິດເຈັດທີ່ເລືອກໄວ້ ແລະ ເອົາໄປໃສ່ໃນຄລິບບອດ</translation></message>
++    <message>
++        <source>&amp;Copy</source>
++        <translation>&amp;ສຳເນົາ</translation></message>
++    <message>
++        <source>Copies the selected widgets to the clipboard</source>
++        <translation>ສຳເນົາເວັບເຈັດທີ່ເລືອກໄວ້ໃສ່ຄລິບບອດ</translation></message>
++    <message>
++        <source>&amp;Paste</source>
++        <translation>&amp;ວາງ</translation></message>
++    <message>
++        <source>Pastes the clipboard's contents</source>
++        <translation>ວາງເນື້ອຫາຈາກຄລິບບອດ</translation></message>
++    <message>
++        <source>&amp;Delete</source>
++        <translation>&amp;ລຶບ</translation></message>
++    <message>
++        <source>Deletes the selected widgets</source>
++        <translation>ລຶບວິດເຈັດທີ່ເລືອກໄວ້</translation></message>
++    <message>
++        <source>Select &amp;All</source>
++        <translation>ເລືອກ &amp;ທັງໝົດ</translation></message>
++    <message>
++        <source>Selects all widgets</source>
++        <translation>ເລືອກວິດເຈັດທັງໝົດ</translation></message>
++    <message>
++        <source>Bring to &amp;Front</source>
++        <translation>ນຳສະເໜີໄປທາງ &amp;ຫນ້າ</translation></message>
++    <message>
++        <source>Raises the selected widgets</source>
++        <translation>ຍົກລະດັບວິດເຈັດທີ່ເລືອກໄວ້</translation></message>
++    <message>
++        <source>Send to &amp;Back</source>
++        <translation>ສົ່ງໄປຫາ &amp;Back</translation></message>
++    <message>
++        <source>Lowers the selected widgets</source>
++        <translation>ຫຼຸດລົງວິດເຈັດທີ່ເລືອກໄວ້</translation></message>
++    <message>
++        <source>Adjust &amp;Size</source>
++        <translation>ປັບ &amp;ຂະໜາດ</translation></message>
++    <message>
++        <source>Adjusts the size of the selected widget</source>
++        <translation>ປັບຂະໜາດຂອງວິດເຈັດທີ່ເລືອກໄວ້</translation></message>
++    <message>
++        <source>Lay Out &amp;Horizontally</source>
++        <translation>ຈັດແຈງແນວນອນ &amp;Horizontally</translation></message>
++    <message>
++        <source>Lays out the selected widgets horizontally</source>
++        <translation>ຈັດແຈງ widget ທີ່ເລືອກໄວ້ໃນແນວນອນ</translation></message>
++    <message>
++        <source>Lay Out &amp;Vertically</source>
++        <translation>ຈັດແຈງແບບຕັ້ງ &amp;Vertically</translation></message>
++    <message>
++        <source>Lays out the selected widgets vertically</source>
++        <translation>ຈັດແຈງວິດເຈັດທີ່ເລືອກໄວ້ໃນແນວຕັ້ງ</translation></message>
++    <message>
++        <source>Lay Out in a &amp;Form Layout</source>
++        <translation>ຈັດແຈງໃນ &amp;ຮູບແບບແບບຟອມ</translation></message>
++    <message>
++        <source>Lays out the selected widgets in a form layout</source>
++        <translation>ຈັດແຈງ widget ທີ່ເລືອກໄວ້ໃນຮູບແບບຟອມ</translation></message>
++    <message>
++        <source>Lay Out in a &amp;Grid</source>
++        <translation>ຈັດແຈງໃນ &amp;Grid</translation></message>
++    <message>
++        <source>Lays out the selected widgets in a grid</source>
++        <translation>ຈັດແຈງວິດເຈັດທີ່ເລືອກໄວ້ໃນຕາຕະລາງ</translation></message>
++    <message>
++        <source>Lay Out Horizontally in S&amp;plitter</source>
++        <translation>ຈັດແຈງແນວນອນໃນຕົວແບ່ງ &amp;</translation></message>
++    <message>
++        <source>Lays out the selected widgets horizontally in a splitter</source>
++        <translation>ຈັດແຈງວິດເຈັດທີ່ເລືອກໄວ້ໃນແນວນອນໃນຕົວແບ່ງ</translation></message>
++    <message>
++        <source>Lay Out Vertically in Sp&amp;litter</source>
++        <translation>ຈັດແຈງແນວຕັ້ງໃນ Sp&amp;lt;litter</translation></message>
++    <message>
++        <source>Lays out the selected widgets vertically in a splitter</source>
++        <translation>ຈັດແຈງ widget ທີ່ເລືອກໄວ້ໃນແບບແນວຕັ້ງໃນ splitter</translation></message>
++    <message>
++        <source>&amp;Break Layout</source>
++        <translation>&amp;lt;ທຳລາຍໂຄງຮ່າງ&amp;gt;</translation></message>
++    <message>
++        <source>Breaks the selected layout</source>
++        <translation>ຂັດຂວາງການຈັດແບບທີ່ເລືອກ</translation></message>
++    <message>
++        <source>Si&amp;mplify Grid Layout</source>
++        <translation>ປັບປຸງຮູບແບບຕາຕະລາງໃຫ້ງ່າຍຂຶ້ນ</translation></message>
++    <message>
++        <source>Removes empty columns and rows</source>
++        <translation>ລຶບຖັນແລະແຖວທີ່ຫວ່າງເປົ່າ</translation></message>
++    <message>
++        <source>&amp;Preview...</source>
++        <translation>&amp;lt;ກວດເບິ່ງລ່ວງໜ້າ...</translation></message>
++    <message>
++        <source>Preview current form</source>
++        <translation>ພາບລວມຂອງແບບຟອມປະຈຸບັນ</translation></message>
++    <message>
++        <source>Form &amp;Settings...</source>
++        <translation>ແບບຟອມ &amp;ການຕັ້ງຄ່າ...</translation></message>
++    <message>
++        <source>Break Layout</source>
++        <translation>ຂັດຂວາງການຈັດແບບ</translation></message>
++    <message>
++        <source>Adjust Size</source>
++        <translation>ປັບຂະໜາດ</translation></message>
++    <message>
++        <source>Could not create form preview</source>
++        <comment>Title of warning message box</comment>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງກ່ອນຟອມໄດ້</translation></message>
++    <message>
++        <source>Form Settings - %1</source>
++        <translation>ການຕັ້ງຄ່າແບບຟອມ - %1</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::FormWindowSettings</name>
++    <message>
++        <source>None</source>
++        <translation>ບໍ່ມີ</translation></message>
++    <message>
++        <source>Device Profile: %1</source>
++        <translation>ໂປຣໄຟລ໌ອຸປະກອນ: %1</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::GridPanel</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Grid</source>
++        <translation>ຕາຕະລາງ</translation></message>
++    <message>
++        <source>Visible</source>
++        <translation>ເບິ່ງເຫັນໄດ້</translation></message>
++    <message>
++        <source>Grid &amp;X</source>
++        <translation>ຕາຕະລາງ &amp;X</translation></message>
++    <message>
++        <source>Snap</source>
++        <translation>ຈັບພາບ</translation></message>
++    <message>
++        <source>Reset</source>
++        <translation>ຣີເຊັດ</translation></message>
++    <message>
++        <source>Grid &amp;Y</source>
++        <translation>Grid &amp;Y</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::GroupBoxTaskMenu</name>
++    <message>
++        <source>Change title...</source>
++        <translation>ປ່ຽນຫົວຂໍ້...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::HtmlTextEdit</name>
++    <message>
++        <source>Insert HTML entity</source>
++        <translation>ໃສ່ຕົວເລກ HTML</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::IconThemeDialog</name>
++    <message>
++        <source>Set Icon From Theme</source>
++        <translation>ຕັ້ງຄ່າໄອຄອນຈາກຫົວຂໍ້</translation></message>
++    <message>
++        <source>Input icon name from the current theme:</source>
++        <translation>ປ້ອນຊື່ໄອຄອນຈາກຮູບແບບປະຈຸບັນ:</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ItemListEditor</name>
++    <message>
++        <source>Items List</source>
++        <translation>ລາຍການລາຍການ</translation></message>
++    <message>
++        <source>New Item</source>
++        <translation>ລາຍການໃໝ່</translation></message>
++    <message>
++        <source>&amp;New</source>
++        <translation>&amp;ໃໝ່</translation></message>
++    <message>
++        <source>Delete Item</source>
++        <translation>ລຶບລາຍການ</translation></message>
++    <message>
++        <source>&amp;Delete</source>
++        <translation>&amp;ລຶບ</translation></message>
++    <message>
++        <source>Move Item Up</source>
++        <translation>ຍ້າຍລາຍການຂຶ້ນ</translation></message>
++    <message>
++        <source>U</source>
++        <translation>ຍ</translation></message>
++    <message>
++        <source>Move Item Down</source>
++        <translation>ຍ້າຍລາຍການລົງ</translation></message>
++    <message>
++        <source>D</source>
++        <translation>ດ</translation></message>
++    <message>
++        <source>Properties &amp;&gt;&gt;</source>
++        <translation>ຄຸນສົມບັດ &amp;&gt;&gt;</translation></message>
++    <message>
++        <source>Properties &amp;&lt;&lt;</source>
++        <translation>ຄຸນສົມບັດ &amp;&lt;&lt;</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::LabelTaskMenu</name>
++    <message>
++        <source>Change rich text...</source>
++        <translation>ປ່ຽນຂໍ້ຄວາມອຸດົມສົມບູນ...</translation></message>
++    <message>
++        <source>Change plain text...</source>
++        <translation>ປ່ຽນຂໍ້ຄວາມທຳມະດາ...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::LanguageResourceDialog</name>
++    <message>
++        <source>Choose Resource</source>
++        <translation>ເລືອກຊັບພະຍາກອນ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::LineEditTaskMenu</name>
++    <message>
++        <source>Change text...</source>
++        <translation>ປ່ຽນຂໍ້ຄວາມ...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ListWidgetEditor</name>
++    <message>
++        <source>New Item</source>
++        <translation>ລາຍການໃໝ່</translation></message>
++    <message>
++        <source>Edit List Widget</source>
++        <translation>ແກ້ໄຂວິດເຈັດລາຍການ</translation></message>
++    <message>
++        <source>Edit Combobox</source>
++        <translation>ແກ້ໄຂ Combobox</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ListWidgetTaskMenu</name>
++    <message>
++        <source>Edit Items...</source>
++        <translation>ແກ້ໄຂລາຍການ...</translation></message>
++    <message>
++        <source>Change List Contents</source>
++        <translation>ແປງເນື້ອໃນລາຍການ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::MdiContainerWidgetTaskMenu</name>
++    <message>
++        <source>Next Subwindow</source>
++        <translation>ວິນໂດຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Previous Subwindow</source>
++        <translation>ຫນ້າຕ່າງຍ່ອຍກ່ອນຫນ້າ</translation></message>
++    <message>
++        <source>Tile</source>
++        <translation>ເກັດ</translation></message>
++    <message>
++        <source>Cascade</source>
++        <translation>Cascade</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::MenuTaskMenu</name>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::MorphMenu</name>
++    <message>
++        <source>Morph into</source>
++        <translation>ປ່ຽນເປັນ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::NewActionDialog</name>
++    <message>
++        <source>New Action...</source>
++        <translation>ການປະຕິບັດໃໝ່...</translation></message>
++    <message>
++        <source>&amp;Text:</source>
++        <translation>&amp;lt;Text:</translation></message>
++    <message>
++        <source>Object &amp;name:</source>
++        <translation>ວັດຖຸ &amp;name:</translation></message>
++    <message>
++        <source>T&amp;oolTip:</source>
++        <translation>T&amp;oolTip:</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>Icon th&amp;eme:</source>
++        <translation>ໄອຄອນ ຫົວຂໍ້:</translation></message>
++    <message>
++        <source>&amp;Icon:</source>
++        <translation>&amp;Icon:</translation></message>
++    <message>
++        <source>&amp;Checkable:</source>
++        <translation>&amp;ກວດສອບໄດ້:</translation></message>
++    <message>
++        <source>&amp;Shortcut:</source>
++        <translation>&amp;ທາງລັດ:</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::NewDynamicPropertyDialog</name>
++    <message>
++        <source>Create Dynamic Property</source>
++        <translation>ສ້າງຄຸນສົມບັດແບບໄດນາມິກ</translation></message>
++    <message>
++        <source>Property Name</source>
++        <translation>ຊື່ຊັບສິນ</translation></message>
++    <message>
++        <source>horizontalSpacer</source>
++        <translation>ຊ່ອງຫວ່າງແນວນອນ</translation></message>
++    <message>
++        <source>Property Type</source>
++        <translation>ປະເພດຊັບສິນ</translation></message>
++    <message>
++        <source>Set Property Name</source>
++        <translation>ຕັ້ງຊື່ຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>The current object already has a property named '%1'.
++Please select another, unique one.</source>
++        <translation>ວັດຖຸປະຈຸບັນມີຄຸນສົມບັດຊື່ '%1' ແລ້ວ.
++ກະລຸນາເລືອກຊື່ອື່ນທີ່ເປັນເອກະລັກ.</translation></message>
++    <message>
++        <source>The '_q_' prefix is reserved for the Qt library.
++Please select another name.</source>
++        <translation>'_q_' ຄຳນຳໜ້າແມ່ນຈັດໄວ້ສຳລັບຫ້ອງສະໝຸດ Qt.
++ກະລຸນາເລືອກຊື່ອື່ນ.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::NewFormWidget</name>
++    <message>
++        <source>0</source>
++        <translation>0</translation></message>
++    <message>
++        <source>Choose a template for a preview</source>
++        <translation>ເລືອກແມ່ແບບສຳລັບການເບິ່ງລ່ວງໜ້າ</translation></message>
++    <message>
++        <source>Embedded Design</source>
++        <translation>ການອອກແບບທີ່ຝັງເຂົ້າ</translation></message>
++    <message>
++        <source>Device:</source>
++        <translation>ອຸປະກອນ:</translation></message>
++    <message>
++        <source>Screen Size:</source>
++        <translation>ຂະໜາດຫນ້າຈໍ:</translation></message>
++    <message>
++        <source>Default size</source>
++        <translation>ຂະໜາດເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>QVGA portrait (240x320)</source>
++        <translation>QVGA ພາບຕັ້ງ (240x320)</translation></message>
++    <message>
++        <source>QVGA landscape (320x240)</source>
++        <translation>QVGA ພື້ນທີ່ນອນ (320x240)</translation></message>
++    <message>
++        <source>VGA portrait (480x640)</source>
++        <translation>VGA ພາບຕັ້ງ (480x640)</translation></message>
++    <message>
++        <source>VGA landscape (640x480)</source>
++        <translation>VGA ພູມສັນຖານ (640x480)</translation></message>
++    <message>
++        <source>Widgets</source>
++        <extracomment>New Form Dialog Categories</extracomment>
++        <translation>ວິດເຈັດ</translation></message>
++    <message>
++        <source>Custom Widgets</source>
++        <translation>ວິດເຈັດທີ່ປັບແຕ່ງເອງ</translation></message>
++    <message>
++        <source>None</source>
++        <translation>ບໍ່ມີ</translation></message>
++    <message>
++        <source>Error loading form</source>
++        <translation>ຜິດພາດໃນການໂຫຼດແບບຟອມ</translation></message>
++    <message>
++        <source>Unable to open the form template file '%1': %2</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ແບບຟອມ '%1': %2</translation></message>
++    <message>
++        <source>Internal error: No template selected.</source>
++        <translation>ຜິດພາດພາຍໃນ: ບໍ່ມີແມ່ແບບທີ່ເລືອກ.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::NewPromotedClassPanel</name>
++    <message>
++        <source>Add</source>
++        <translation>ເພີ່ມ</translation></message>
++    <message>
++        <source>New Promoted Class</source>
++        <translation>ຫ້ອງຮຽນທີ່ສົ່ງເສີມໃໝ່</translation></message>
++    <message>
++        <source>Base class name:</source>
++        <translation>ຊື່ຫ້ອງພື້ນຖານ:</translation></message>
++    <message>
++        <source>Promoted class name:</source>
++        <translation>ຊື່ຫ້ອງຮຽນທີ່ສົ່ງເສີມ:</translation></message>
++    <message>
++        <source>Header file:</source>
++        <translation>Header file:</translation></message>
++    <message>
++        <source>Global include</source>
++        <translation>ລວມທົ່ວໂລກ</translation></message>
++    <message>
++        <source>Reset</source>
++        <translation>ລີເຊັດ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ObjectInspector</name>
++    <message>
++        <source>Change Current Page</source>
++        <translation>ປ່ຽນໜ້າປັດຈຸບັນ</translation></message>
++    <message>
++        <source>&amp;Find in Text...</source>
++        <translation>&amp;ຊອກຫາໃນຂໍ້ຄວາມ...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::OrderDialog</name>
++    <message>
++        <source>Change Page Order</source>
++        <translation>ປ່ຽນລຳດັບໜ້າ</translation></message>
++    <message>
++        <source>Page Order</source>
++        <translation>ລຳດັບໜ້າ</translation></message>
++    <message>
++        <source>Move page up</source>
++        <translation>ຍ້າຍໜ້າຂຶ້ນ</translation></message>
++    <message>
++        <source>Move page down</source>
++        <translation>ເລື່ອນໜ້າລົງ</translation></message>
++    <message>
++        <source>Index %1 (%2)</source>
++        <translation>ດັດສະນີ %1 (%2)</translation></message>
++    <message>
++        <source>%1 %2</source>
++        <translation>%1 %2</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PaletteEditor</name>
++    <message>
++        <source>Edit Palette</source>
++        <translation>ແກ້ໄຂພາເລດ</translation></message>
++    <message>
++        <source>Tune Palette</source>
++        <translation>ປັບປ່ຽນພາເລດ</translation></message>
++    <message>
++        <source>Show Details</source>
++        <translation>ສະແດງລາຍລະອຽດ</translation></message>
++    <message>
++        <source>Compute Details</source>
++        <translation>ລາຍລະອຽດການຄຳນວນ</translation></message>
++    <message>
++        <source>Quick</source>
++        <translation>ໄວ</translation></message>
++    <message>
++        <source>Preview</source>
++        <translation>ການລອງເບິ່ງ</translation></message>
++    <message>
++        <source>Disabled</source>
++        <translation>ປິດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Inactive</source>
++        <translation>ບໍ່ເຄື່ອນໄຫວ</translation></message>
++    <message>
++        <source>Active</source>
++        <translation>ກິດຈະກໍາ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PaletteEditorButton</name>
++    <message>
++        <source>Change Palette</source>
++        <translation>ປ່ຽນພາເລດ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PaletteModel</name>
++    <message>
++        <source>Color Role</source>
++        <translation>ບົດບາດສີ</translation></message>
++    <message>
++        <source>Active</source>
++        <translation>ກິດຈະກໍາ</translation></message>
++    <message>
++        <source>Inactive</source>
++        <translation>ບໍ່ເຄື່ອນໄຫວ</translation></message>
++    <message>
++        <source>Disabled</source>
++        <translation>ປິດການໃຊ້ງານ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PixmapEditor</name>
++    <message>
++        <source>Choose Resource...</source>
++        <translation>ເລືອກຊັບພະຍາກອນ...</translation></message>
++    <message>
++        <source>Choose File...</source>
++        <translation>ເລືອກໄຟລ໌...</translation></message>
++    <message>
++        <source>Set Icon From Theme...</source>
++        <translation>ຕັ້ງຄ່າໄອຄອນຈາກຮູບແບບ...</translation></message>
++    <message>
++        <source>Copy Path</source>
++        <translation>ສຳເນົາເສັ້ນທາງ</translation></message>
++    <message>
++        <source>Paste Path</source>
++        <translation>ວາງເສັ້ນທາງ</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>[Theme] %1</source>
++        <translation>[ຫົວຂໍ້] %1</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PlainTextEditorDialog</name>
++    <message>
++        <source>Edit text</source>
++        <translation>ແກ້ໄຂຂໍ້ຄວາມ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PluginDialog</name>
++    <message>
++        <source>Components</source>
++        <translation>ສ່ວນປະກອບ</translation></message>
++    <message>
++        <source>Plugin Information</source>
++        <translation>ຂໍ້ມູນປລັອກອິນ</translation></message>
++    <message>
++        <source>Refresh</source>
++        <translation>ຟື້ນຟູ</translation></message>
++    <message>
++        <source>Scan for newly installed custom widget plugins.</source>
++        <translation>ສະແກນຫາແພລກອິນວິດເຈັດທີ່ຕິດຕັ້ງໃໝ່.</translation></message>
++    <message>
++        <source>Loaded Plugins</source>
++        <translation>ປັກອິນທີ່ໂຫຼດແລ້ວ</translation></message>
++    <message>
++        <source>Failed Plugins</source>
++        <translation>ປລັກອິນທີ່ລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Qt Designer couldn't find any plugins</source>
++        <translation>Qt Designer ບໍ່ສາມາດຊອກຫາ plugins ໃດໆ</translation></message>
++    <message>
++        <source>Qt Designer found the following plugins</source>
++        <translation>Qt Designer ໄດ້ພົບປລັກອິນດັ່ງຕໍ່ໄປນີ້</translation></message>
++    <message>
++        <source>New custom widget plugins have been found.</source>
++        <translation>ປລັກອິນວິດເຈັດທີ່ກຳນົດເອງໃໝ່ໄດ້ຖືກພົບເຫັນ.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PreviewActionGroup</name>
++    <message>
++        <source>%1 Style</source>
++        <translation>%1 ຮູບແບບ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PreviewConfigurationWidget</name>
++    <message>
++        <source>Default</source>
++        <translation>ຄ່າເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>None</source>
++        <translation>ບໍ່ມີ</translation></message>
++    <message>
++        <source>Browse...</source>
++        <translation>ທ່ອງເວັບ...</translation></message>
++    <message>
++        <source>Load Custom Device Skin</source>
++        <translation>ໂຫຼດຜິວອຸປະກອນທີ່ກຳນົດເອງ</translation></message>
++    <message>
++        <source>All QVFB Skins (*.%1)</source>
++        <translation>QVFB ຜິວທັງໝົດ (*.%1)</translation></message>
++    <message>
++        <source>%1 - Duplicate Skin</source>
++        <translation>%1 - ສະກິນຊໍ້າ</translation></message>
++    <message>
++        <source>The skin '%1' already exists.</source>
++        <translation>ຜິວ '%1' ມີຢູ່ແລ້ວ.</translation></message>
++    <message>
++        <source>%1 - Error</source>
++        <translation>%1 - ຜິດພາດ</translation></message>
++    <message>
++        <source>%1 is not a valid skin directory:
++%2</source>
++        <translation>%1 ແມ່ນໄດເລັກໂທຣີຜິວທີ່ບໍ່ຖືກຕ້ອງ:
++%2</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PreviewDeviceSkin</name>
++    <message>
++        <source>&amp;Portrait</source>
++        <translation>&amp;ພາບພົດ</translation></message>
++    <message>
++        <source>Landscape (&amp;CCW)</source>
++        <extracomment>Rotate form preview counter-clockwise</extracomment>
++        <translation>ພູມສັນຖານ (&amp;CCW)</translation></message>
++    <message>
++        <source>&amp;Landscape (CW)</source>
++        <extracomment>Rotate form preview clockwise</extracomment>
++        <translation>&amp;ພູມສັນຖານ (CW)</translation></message>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;ປິດ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PreviewManager</name>
++    <message>
++        <source>%1 - [Preview]</source>
++        <translation>%1 - [ການສະແດງຕົວຢ່າງ]</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PreviewMdiArea</name>
++    <message>
++        <source>The moose in the noose
++ate the goose who was loose.</source>
++        <extracomment>Palette editor background</extracomment>
++        <translation>ກວາງໃນຫວຍ
++ກິນຫ່ານທີ່ຫຼົງ.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PreviewWidget</name>
++    <message>
++        <source>Preview Window</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ຫນ້າຕ່າງຕົວຢ່າງ</translation></message>
++    <message>
++        <source>LineEdit</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ບັນທຶກບັນຊີ</translation></message>
++    <message>
++        <source>ComboBox</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ComboBox</translation></message>
++    <message>
++        <source>PushButton</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ກົດປຸ່ມ</translation></message>
++    <message>
++        <source>ButtonGroup2</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ກຸ່ມປຸ່ມ 2</translation></message>
++    <message>
++        <source>CheckBox1</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>CheckBox1</translation></message>
++    <message>
++        <source>CheckBox2</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>CheckBox2</translation></message>
++    <message>
++        <source>ButtonGroup</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ກຸ່ມປຸ່ມ</translation></message>
++    <message>
++        <source>RadioButton1</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ປຸ່ມລາດີໂອ 1</translation></message>
++    <message>
++        <source>RadioButton2</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ປຸ່ມລັດດຽວ 2</translation></message>
++    <message>
++        <source>RadioButton3</source>
++        <extracomment>Palette Editor Preview Widget</extracomment>
++        <translation>ປຸ່ມວົງກົມເລືອກ 3</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PromotionModel</name>
++    <message>
++        <source>Name</source>
++        <translation>ຊື່</translation></message>
++    <message>
++        <source>Header file</source>
++        <translation>ໄຟລ໌ຫົວຂໍ້</translation></message>
++    <message>
++        <source>Global include</source>
++        <translation>ລວມທົ່ວໂລກ</translation></message>
++    <message>
++        <source>Usage</source>
++        <translation>ການນຳໃຊ້</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PromotionTaskMenu</name>
++    <message>
++        <source>Promoted widgets...</source>
++        <translation>ວິດເຈັດທີ່ສົ່ງເສີມ...</translation></message>
++    <message>
++        <source>Promote to ...</source>
++        <translation>ຍົກຂຶ້ນເປັນ ...</translation></message>
++    <message>
++        <source>Change signals/slots...</source>
++        <translation>ປ່ຽນສັນຍານ/ຊ່ອງ...</translation></message>
++    <message>
++        <source>Promote to</source>
++        <translation>ຍົກຂຶ້ນຕຳແໜ່ງ</translation></message>
++    <message>
++        <source>Demote to %1</source>
++        <translation>ຫຼຸດລົງເປັນ %1</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PropertyEditor</name>
++    <message>
++        <source>Add Dynamic Property...</source>
++        <translation>ເພີ່ມຄຸນສົມບັດແບບໄດນາມິກ...</translation></message>
++    <message>
++        <source>Remove Dynamic Property</source>
++        <translation>ລຶບຄຸນສົມບັດແບບໄດນາມິກ</translation></message>
++    <message>
++        <source>Sorting</source>
++        <translation>ຈັດລຽງ</translation></message>
++    <message>
++        <source>Color Groups</source>
++        <translation>ກຸ່ມສີ</translation></message>
++    <message>
++        <source>Tree View</source>
++        <translation>ມຸມມອງແບບຕົ້ນໄມ້</translation></message>
++    <message>
++        <source>Drop Down Button View</source>
++        <translation>ປຸ່ມລົງລາຍການເບິ່ງ</translation></message>
++    <message>
++        <source>String...</source>
++        <translation>ສະຕຣິງ...</translation></message>
++    <message>
++        <source>Bool...</source>
++        <translation>ບູນ...</translation></message>
++    <message>
++        <source>Other...</source>
++        <translation>ອື່ນໆ...</translation></message>
++    <message>
++        <source>Configure Property Editor</source>
++        <translation>ຕັ້ງຄ່າແກ້ໄຂຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>Filter</source>
++        <translation>ກັ່ນຕອງ</translation></message>
++    <message>
++        <source>Object: %1
++Class: %2</source>
++        <translation>ວັດຖຸ: %1
++ຫ້ອງຮຽນ: %2</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::PropertyLineEdit</name>
++    <message>
++        <source>Insert line break</source>
++        <translation>ໃສ່ຕົວຫັກເສັ້ນ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::QDesignerPromotionDialog</name>
++    <message>
++        <source>Promoted Widgets</source>
++        <translation>ວິດເຈັດທີ່ໄດ້ຮັບການສົ່ງເສີມ</translation></message>
++    <message>
++        <source>Promoted Classes</source>
++        <translation>ຫ້ອງຮຽນທີ່ສົ່ງເສີມ</translation></message>
++    <message>
++        <source>Promote</source>
++        <translation>ໂຄສະນາ</translation></message>
++    <message>
++        <source>Change signals/slots...</source>
++        <translation>ປ່ຽນສັນຍານ/ຊ່ອງ...</translation></message>
++    <message>
++        <source>%1 - Error</source>
++        <translation>%1 - ຜິດພາດ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::QDesignerResource</name>
++    <message>
++        <source>Loading qrc file</source>
++        <translation>ກຳລັງໂຫຼດໄຟລ໌ qrc</translation></message>
++    <message>
++        <source>The specified qrc file &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;could not be found. Do you want to update the file location?&lt;/p&gt;</source>
++        <translation>ຟາຍ qrc ທີ່ລະບຸໄວ້ &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;ບໍ່ສາມາດພົບເຫັນ. ທ່ານຕ້ອງການອັບເດດສະຖານທີ່ຂອງຟາຍບໍ່?&lt;/p&gt;</translation></message>
++    <message>
++        <source>New location for %1</source>
++        <translation>ສະຖານທີ່ໃໝ່ສຳລັບ %1</translation></message>
++    <message>
++        <source>Resource files (*.qrc)</source>
++        <translation>ໄຟລ໌ຊັບພະຍາກອນ (*.qrc)</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::QDesignerTaskMenu</name>
++    <message>
++        <source>Layout Alignment</source>
++        <translation>ການຈັດຮູບແບບການຈັດວາງ</translation></message>
++    <message>
++        <source>No Horizontal Alignment</source>
++        <translation>ບໍ່ມີການຈັດຕັ້ງແນວນອນ</translation></message>
++    <message>
++        <source>Left</source>
++        <translation>ຊ້າຍ</translation></message>
++    <message>
++        <source>Center Horizontally</source>
++        <translation>ຈັດກາງແນວນອນ</translation></message>
++    <message>
++        <source>Right</source>
++        <translation>ຂວາ</translation></message>
++    <message>
++        <source>No Vertical Alignment</source>
++        <translation>ບໍ່ມີການຈັດຕັ້ງແນວຕັ້ງ</translation></message>
++    <message>
++        <source>Top</source>
++        <translation>ດ້ານເທິງ</translation></message>
++    <message>
++        <source>Center Vertically</source>
++        <translation>ຈຸດກາງແນວຕັ້ງ</translation></message>
++    <message>
++        <source>Bottom</source>
++        <translation>ລຸ່ມ</translation></message>
++    <message>
++        <source>Change objectName...</source>
++        <translation>ປ່ຽນ objectName...</translation></message>
++    <message>
++        <source>Change toolTip...</source>
++        <translation>ປ່ຽນ toolTip...</translation></message>
++    <message>
++        <source>Change whatsThis...</source>
++        <translation>ປ່ຽນ whatsThis...</translation></message>
++    <message>
++        <source>Change styleSheet...</source>
++        <translation>ປ່ຽນແບບ styleSheet...</translation></message>
++    <message>
++        <source>Create Menu Bar</source>
++        <translation>ສ້າງແຖບເມນູ</translation></message>
++    <message>
++        <source>Add Tool Bar</source>
++        <translation>ເພີ່ມແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>Create Status Bar</source>
++        <translation>ສ້າງແຖບສະຖານະ</translation></message>
++    <message>
++        <source>Remove Status Bar</source>
++        <translation>ລຶບແຖບສະຖານະ</translation></message>
++    <message>
++        <source>Change signals/slots...</source>
++        <translation>ປ່ຽນສັນຍານ/ຊ່ອງ...</translation></message>
++    <message>
++        <source>Go to slot...</source>
++        <translation>ໄປຫາຊ່ອງ...</translation></message>
++    <message>
++        <source>Size Constraints</source>
++        <translation>ຂໍ້ຈຳກັດຂະໜາດ</translation></message>
++    <message>
++        <source>Set Minimum Width</source>
++        <translation>ຕັ້ງຄ່າຄວາມກວ້າງຕໍ່າສຸດ</translation></message>
++    <message>
++        <source>Set Minimum Height</source>
++        <translation>ຕັ້ງຄ່າຄວາມສູງຕໍ່າສຸດ</translation></message>
++    <message>
++        <source>Set Minimum Size</source>
++        <translation>ຕັ້ງຂະໜາດຕໍ່າສຸດ</translation></message>
++    <message>
++        <source>Set Maximum Width</source>
++        <translation>ຕັ້ງຄ່າຄວາມກວ້າງສູງສຸດ</translation></message>
++    <message>
++        <source>Set Maximum Height</source>
++        <translation>ຕັ້ງຄ່າຄວາມສູງສູງສຸດ</translation></message>
++    <message>
++        <source>Set Maximum Size</source>
++        <translation>ຕັ້ງຂະໜາດສູງສຸດ</translation></message>
++    <message>
++        <source>Edit ToolTip</source>
++        <translation>ແກ້ໄຂ ToolTip</translation></message>
++    <message>
++        <source>Edit WhatsThis</source>
++        <translation>ແກ້ໄຂ WhatsThis</translation></message>
++    <message numerus="yes">
++        <source>Set size constraint on %n widget(s)</source>
++        <translation>
++            <numerusform>ກຳນົດຂໍ້ຈຳກັດຂະໜາດໃສ່ %n ວິດເຈັດ</numerusform>
++        </translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::QDesignerWidgetBox</name>
++    <message>
++        <source>Unexpected element &lt;%1&gt;</source>
++        <translation>ອົງປະກອບທີ່ບໍ່ຄາດຄິດ &lt;%1&gt;</translation></message>
++    <message>
++        <source>A parse error occurred at line %1, column %2 of the XML code specified for the widget %3: %4
++%5</source>
++        <translation>ມີຂໍ້ຜິດພາດໃນການວິເຄາະເກີດຂຶ້ນທີ່ເສັ້ນ %1, ຖັນ %2 ຂອງລະຫັດ XML ທີ່ກຳນົດໄວ້ສຳລັບວິດເຈັດ %3: %4
++%5</translation></message>
++    <message>
++        <source>The XML code specified for the widget %1 does not contain any widget elements.
++%2</source>
++        <translation>ລະຫັດ XML ທີ່ລະບຸໄວ້ສຳລັບ widget %1 ບໍ່ມີອົງປະກອບ widget ໃດໆ.
++%2</translation></message>
++    <message>
++        <source>An error has been encountered at line %1 of %2: %3</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນທີ່ເສັ້ນ %1 ຂອງ %2: %3</translation></message>
++    <message>
++        <source>Unexpected element &lt;%1&gt; encountered when parsing for &lt;widget&gt; or &lt;ui&gt;</source>
++        <translation>ອົງປະກອບທີ່ບໍ່ຄາດຄິດ &lt;%1&gt; ພົບເຫັນເມື່ອກຳລັງວິເຄາະສຳລັບ &lt;widget&gt; ຫຼື &lt;ui&gt;</translation></message>
++    <message>
++        <source>Unexpected end of file encountered when parsing widgets.</source>
++        <translation>ພົບບັນຫາການຈັດການໄຟລ໌ທີ່ບໍ່ຄາດຄິດເມື່ອວິເຄາະວິດເຈັດ.</translation></message>
++    <message>
++        <source>A widget element could not be found.</source>
++        <translation>ອົງປະກອບ widget ບໍ່ສາມາດພົບເຫັນໄດ້.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::QtGradientStopsController</name>
++    <message>
++        <source>H</source>
++        <translation>ຮ</translation></message>
++    <message>
++        <source>S</source>
++        <translation>ສ</translation></message>
++    <message>
++        <source>V</source>
++        <translation>ພ</translation></message>
++    <message>
++        <source>Hue</source>
++        <translation>ຮູ້</translation></message>
++    <message>
++        <source>Sat</source>
++        <translation>ວັນເສົາ</translation></message>
++    <message>
++        <source>Val</source>
++        <translation>ຄ່າ</translation></message>
++    <message>
++        <source>Saturation</source>
++        <translation>ຄວາມອີ່ມຕົວ</translation></message>
++    <message>
++        <source>Value</source>
++        <translation>ມູນຄ່າ</translation></message>
++    <message>
++        <source>R</source>
++        <translation>ພາສາລາວ</translation></message>
++    <message>
++        <source>G</source>
++        <translation>ຈ</translation></message>
++    <message>
++        <source>B</source>
++        <translation>ບ</translation></message>
++    <message>
++        <source>Red</source>
++        <translation>ສີແດງ</translation></message>
++    <message>
++        <source>Green</source>
++        <translation>ຂຽວ</translation></message>
++    <message>
++        <source>Blue</source>
++        <translation>ຟ້າ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::RichTextEditorDialog</name>
++    <message>
++        <source>Edit text</source>
++        <translation>ແກ້ໄຂຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Rich Text</source>
++        <translation>ຂໍ້ຄວາມຮູບແບບອຸດົມສົມບູນ</translation></message>
++    <message>
++        <source>Source</source>
++        <translation>ແປເປັນພາສາລາວ: ແຫຼ່ງຂໍ້ມູນ</translation></message>
++    <message>
++        <source>&amp;OK</source>
++        <translation>&amp;OK</translation></message>
++    <message>
++        <source>&amp;Cancel</source>
++        <translation>&amp;ຍົກເລີກ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::RichTextEditorToolBar</name>
++    <message>
++        <source>Bold</source>
++        <translation>ໜັງສືໜາ</translation></message>
++    <message>
++        <source>CTRL+B</source>
++        <translation>CTRL+B</translation></message>
++    <message>
++        <source>Italic</source>
++        <translation>ຕົວເລກເຄົ້າ</translation></message>
++    <message>
++        <source>CTRL+I</source>
++        <translation>CTRL+I</translation></message>
++    <message>
++        <source>Underline</source>
++        <translation>ຂີດຂີດລຸ່ມ</translation></message>
++    <message>
++        <source>CTRL+U</source>
++        <translation>CTRL+U</translation></message>
++    <message>
++        <source>Left Align</source>
++        <translation>ຊື່ຊ້າຍ</translation></message>
++    <message>
++        <source>Center</source>
++        <translation>ສູນກາງ</translation></message>
++    <message>
++        <source>Right Align</source>
++        <translation>ຊື່ຂວາ</translation></message>
++    <message>
++        <source>Justify</source>
++        <translation>ຊື່ຫຼັກຖານ</translation></message>
++    <message>
++        <source>Right to Left</source>
++        <translation>ຂວາໄປຊ້າຍ</translation></message>
++    <message>
++        <source>Superscript</source>
++        <translation>ຕົວເລກສູງ</translation></message>
++    <message>
++        <source>Subscript</source>
++        <translation>ຕົວຫຍໍ້ລຸ່ມ</translation></message>
++    <message>
++        <source>Insert &amp;Link</source>
++        <translation>ໃສ່ &amp;Link</translation></message>
++    <message>
++        <source>Insert &amp;Image</source>
++        <translation>ໃສ່ &amp;Image</translation></message>
++    <message>
++        <source>Simplify Rich Text</source>
++        <translation>ປັບປຸງຂໍ້ຄວາມທີ່ມີຮູບແບບໃຫ້ງ່າຍຂຶ້ນ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::SignalSlotDialog</name>
++    <message>
++        <source>There is already a slot with the signature '%1'.</source>
++        <translation>ມີຊ່ອງທີ່ມີລາຍເຊັນ '%1' ຢູ່ແລ້ວ.</translation></message>
++    <message>
++        <source>There is already a signal with the signature '%1'.</source>
++        <translation>ມີສັນຍານທີ່ມີລາຍເຊັນ '%1' ຢູ່ແລ້ວ.</translation></message>
++    <message>
++        <source>%1 - Duplicate Signature</source>
++        <translation>%1 - ລົງນາມຊໍ້າ</translation></message>
++    <message>
++        <source>Signals/Slots of %1</source>
++        <translation>ສັນຍານ/ຊ່ອງຂອງ %1</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::SignalSlotEditorPlugin</name>
++    <message>
++        <source>Edit Signals/Slots</source>
++        <translation>ແກ້ໄຂສັນຍານ/ຊ່ອງ</translation></message>
++    <message>
++        <source>F4</source>
++        <translation>F4</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::SignalSlotEditorTool</name>
++    <message>
++        <source>Edit Signals/Slots</source>
++        <translation>ແກ້ໄຂສັນຍານ/ຊ່ອງ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::StatusBarTaskMenu</name>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::StringListEditorButton</name>
++    <message>
++        <source>Change String List</source>
++        <translation>ປ່ຽນລາຍການສະຕຣິງ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::StyleSheetEditorDialog</name>
++    <message>
++        <source>Valid Style Sheet</source>
++        <translation>ຮູບແບບສະໄຕລ໌ຊິດທີ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Add Resource...</source>
++        <translation>ເພີ່ມຊັບພະຍາກອນ...</translation></message>
++    <message>
++        <source>Add Gradient...</source>
++        <translation>ເພີ່ມກຼາດຽນ...</translation></message>
++    <message>
++        <source>Add Color...</source>
++        <translation>ເພີ່ມສີ...</translation></message>
++    <message>
++        <source>Add Font...</source>
++        <translation>ເພີ່ມຟອນ...</translation></message>
++    <message>
++        <source>Edit Style Sheet</source>
++        <translation>ແກ້ໄຂສະຕາຍລ໌ຊີດ</translation></message>
++    <message>
++        <source>Invalid Style Sheet</source>
++        <translation>ຮູບແບບສະໄຕລ໌ຊິດບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TabOrderEditor</name>
++    <message>
++        <source>Start from Here</source>
++        <translation>ເລີ່ມຈາກທີ່ນີ້</translation></message>
++    <message>
++        <source>Restart</source>
++        <translation>ຣີສະຕາດ</translation></message>
++    <message>
++        <source>Tab Order List...</source>
++        <translation>ລາຍການຄຳສັ່ງແຖບ...</translation></message>
++    <message>
++        <source>Tab Order List</source>
++        <translation>ລາຍການຄຳສັ່ງແທັບ</translation></message>
++    <message>
++        <source>Tab Order</source>
++        <translation>ລຳດັບແຖບ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TabOrderEditorPlugin</name>
++    <message>
++        <source>Edit Tab Order</source>
++        <translation>ແກ້ໄຂລຳດັບແຖບ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TabOrderEditorTool</name>
++    <message>
++        <source>Edit Tab Order</source>
++        <translation>ແກ້ໄຂລຳດັບແຖບ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TableWidgetEditor</name>
++    <message>
++        <source>Edit Table Widget</source>
++        <translation>ແກ້ໄຂວິດເຈັດຕາຕະລາງ</translation></message>
++    <message>
++        <source>&amp;Items</source>
++        <translation>&amp;ລາຍການ</translation></message>
++    <message>
++        <source>Table Items</source>
++        <translation>ລາຍການຕາຕະລາງ</translation></message>
++    <message>
++        <source>Properties &amp;&gt;&gt;</source>
++        <translation>ຄຸນສົມບັດ &amp;&gt;&gt;</translation></message>
++    <message>
++        <source>New Column</source>
++        <translation>ຖັນໃໝ່</translation></message>
++    <message>
++        <source>New Row</source>
++        <translation>ແຖວໃໝ່</translation></message>
++    <message>
++        <source>&amp;Columns</source>
++        <translation>&amp;ຖັນ</translation></message>
++    <message>
++        <source>&amp;Rows</source>
++        <translation>&amp;ແຖວ</translation></message>
++    <message>
++        <source>Properties &amp;&lt;&lt;</source>
++        <translation>ຄຸນສົມບັດ &amp;&lt;&lt;</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TableWidgetTaskMenu</name>
++    <message>
++        <source>Edit Items...</source>
++        <translation>ແກ້ໄຂລາຍການ...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TemplateOptionsWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Additional Template Paths</source>
++        <translation>ເສັ້ນທາງແມ່ແບບເພີ່ມເຕີມ</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>Pick a directory to save templates in</source>
++        <translation>ເລືອກໂຟນເດີເພື່ອບັນທຶກແມ່ແບບໃນ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TextEditTaskMenu</name>
++    <message>
++        <source>Edit HTML</source>
++        <translation>ແກ້ໄຂ HTML</translation></message>
++    <message>
++        <source>Change HTML...</source>
++        <translation>ປ່ຽນ HTML...</translation></message>
++    <message>
++        <source>Edit Text</source>
++        <translation>ແກ້ໄຂຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Change Plain Text...</source>
++        <translation>ປ່ຽນຂໍ້ຄວາມທຳມະດາ...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TextEditor</name>
++    <message>
++        <source>Choose Resource...</source>
++        <translation>ເລືອກຊັບພະຍາກອນ...</translation></message>
++    <message>
++        <source>Choose File...</source>
++        <translation>ເລືອກໄຟລ໌...</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++    <message>
++        <source>Choose a File</source>
++        <translation>ເລືອກໄຟລ໌</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ToolBarEventFilter</name>
++    <message>
++        <source>Insert Separator before '%1'</source>
++        <translation>ໃສ່ແຍກກ່ອນ '%1'</translation></message>
++    <message>
++        <source>Append Separator</source>
++        <translation>ຕື່ມແຍກຕົວຄັດ</translation></message>
++    <message>
++        <source>Remove action '%1'</source>
++        <translation>ລຶບການກະທຳ '%1'</translation></message>
++    <message>
++        <source>Remove Toolbar '%1'</source>
++        <translation>ລຶບແຖບເຄື່ອງມື '%1'</translation></message>
++    <message>
++        <source>Insert Separator</source>
++        <translation>ໃສ່ຕົວແຍກ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TreeWidgetEditor</name>
++    <message>
++        <source>Edit Tree Widget</source>
++        <translation>ແກ້ໄຂວິດເຈັດຕົ້ນໄມ້</translation></message>
++    <message>
++        <source>&amp;Items</source>
++        <translation>&amp;ລາຍການ</translation></message>
++    <message>
++        <source>Tree Items</source>
++        <translation>ລາຍການຕົ້ນໄມ້</translation></message>
++    <message>
++        <source>1</source>
++        <translation>1</translation></message>
++    <message>
++        <source>New Item</source>
++        <translation>ລາຍການໃໝ່</translation></message>
++    <message>
++        <source>&amp;New</source>
++        <translation>&amp;ໃໝ່</translation></message>
++    <message>
++        <source>New Subitem</source>
++        <translation>ລາຍການຍ່ອຍໃໝ່</translation></message>
++    <message>
++        <source>New &amp;Subitem</source>
++        <translation>ໃໝ່ &amp;ລາຍການຍ່ອຍ</translation></message>
++    <message>
++        <source>Delete Item</source>
++        <translation>ລຶບລາຍການ</translation></message>
++    <message>
++        <source>&amp;Delete</source>
++        <translation>&amp;ລຶບ</translation></message>
++    <message>
++        <source>Move Item Left (before Parent Item)</source>
++        <translation>ຍ້າຍລາຍການໄປທາງຊ້າຍ (ກ່ອນລາຍການຫຼັກ)</translation></message>
++    <message>
++        <source>L</source>
++        <translation>ລ</translation></message>
++    <message>
++        <source>Move Item Right (as a First Subitem of the Next Sibling Item)</source>
++        <translation>ຍ້າຍລາຍການໄປທາງຂວາ (ເປັນລາຍການຍ່ອຍທຳອິດຂອງລາຍການພີ່ນ້ອງຕໍ່ໄປ)</translation></message>
++    <message>
++        <source>R</source>
++        <translation>ພາສາລາວ: ອ</translation></message>
++    <message>
++        <source>Move Item Up</source>
++        <translation>ຍ້າຍລາຍການຂຶ້ນ</translation></message>
++    <message>
++        <source>U</source>
++        <translation>ຍ</translation></message>
++    <message>
++        <source>Move Item Down</source>
++        <translation>ຍ້າຍລາຍການລົງ</translation></message>
++    <message>
++        <source>D</source>
++        <translation>ດ</translation></message>
++    <message>
++        <source>Properties &amp;&gt;&gt;</source>
++        <translation>ຄຸນສົມບັດ &amp;&gt;&gt;</translation></message>
++    <message>
++        <source>New Column</source>
++        <translation>ຖັນໃໝ່</translation></message>
++    <message>
++        <source>&amp;Columns</source>
++        <translation>&amp;ຖັນ</translation></message>
++    <message>
++        <source>Per column properties</source>
++        <translation>ຄຸນສົມບັດຕໍ່ຖັນ</translation></message>
++    <message>
++        <source>Common properties</source>
++        <translation>ຄຸນສົມບັດທົ່ວໄປ</translation></message>
++    <message>
++        <source>Properties &amp;&lt;&lt;</source>
++        <translation>ຄຸນສົມບັດ &amp;&lt;&lt;</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::TreeWidgetTaskMenu</name>
++    <message>
++        <source>Edit Items...</source>
++        <translation>ແກ້ໄຂລາຍການ...</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::WidgetBox</name>
++    <message>
++        <source>Filter</source>
++        <translation>ກັ່ນຕອງ</translation></message>
++    <message>
++        <source>Warning: Widget creation failed in the widget box. This could be caused by invalid custom widget XML.</source>
++        <translation>ຄຳເຕືອນ: ການສ້າງ Widget ລົ້ມເຫລວໃນກ່ອງ widget. ນີ້ອາດເກີດຈາກ XML widget ທີ່ກຳນົດເອງບໍ່ຖືກຕ້ອງ.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::WidgetBoxTreeWidget</name>
++    <message>
++        <source>Scratchpad</source>
++        <translation>ສະແຄັດພາດ</translation></message>
++    <message>
++        <source>Custom Widgets</source>
++        <translation>ວິດເຈັດທີ່ປັບແຕ່ງເອງ</translation></message>
++    <message>
++        <source>Expand all</source>
++        <translation>ຂະຫຍາຍທັງໝົດ</translation></message>
++    <message>
++        <source>Collapse all</source>
++        <translation>ຫຍໍ້ທັງໝົດ</translation></message>
++    <message>
++        <source>List View</source>
++        <translation>ລາຍການມຸມມອງ</translation></message>
++    <message>
++        <source>Icon View</source>
++        <translation>ມຸມມອງໄອຄອນ</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Edit name</source>
++        <translation>ແກ້ໄຂຊື່</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::WidgetDataBase</name>
++    <message>
++        <source>A custom widget plugin whose class name (%1) matches that of an existing class has been found.</source>
++        <translation>ປລັກອິນວິດເຈັດທີ່ກຳນົດເອງທີ່ມີຊື່ຄລາດ (%1) ຕົງກັບຊື່ຄລາດທີ່ມີຢູ່ແລ້ວ ໄດ້ຖືກພົບເຫັນ.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::WidgetEditorTool</name>
++    <message>
++        <source>Edit Widgets</source>
++        <translation>ແກ້ໄຂວິດເຈັດ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::WidgetFactory</name>
++    <message>
++        <source>The custom widget factory registered for widgets of class %1 returned 0.</source>
++        <translation>ບໍລິສັດຜະລິດວິດເຈັດທີ່ກຳນົດເອງທີ່ລົງທະບຽນສຳລັບວິດເຈັດຂອງຫ້ອງ %1 ສົ່ງຄືນ 0.</translation></message>
++    <message>
++        <source>A class name mismatch occurred when creating a widget using the custom widget factory registered for widgets of class %1. It returned a widget of class %2.</source>
++        <translation>ມີການບໍ່ກົງກັນຂອງຊື່ຫ້ອງງານເກີດຂຶ້ນເມື່ອສ້າງວິດເຈັດໂດຍໃຊ້ໂຮງງານວິດເຈັດທີ່ກຳນົດເອງທີ່ລົງທະບຽນສຳລັບວິດເຈັດຂອງຫ້ອງງານ %1. ມັນໄດ້ສົ່ງຄືນວິດເຈັດຂອງຫ້ອງງານ %2.</translation></message>
++    <message>
++        <source>The current page of the container '%1' (%2) could not be determined while creating a layout.This indicates an inconsistency in the ui-file, probably a layout being constructed on a container widget.</source>
++        <translation>ໜ້າປັດຈຸບັນຂອງກະຕ່າ '%1' (%2) ບໍ່ສາມາດກຳນົດໄດ້ໃນຂະນະທີ່ກຳລັງສ້າງລາຍການ. ນີ້ຊີ້ບອກເຖິງຄວາມບໍ່ສອດຄ່ອງໃນໄຟລ໌ ui, ອາດເປັນລາຍການທີ່ກຳລັງຖືກສ້າງຂຶ້ນເທິງເວັດເຈັດກະຕ່າ.</translation></message>
++    <message>
++        <source>Attempt to add a layout to a widget '%1' (%2) which already has an unmanaged layout of type %3.
++This indicates an inconsistency in the ui-file.</source>
++        <translation>ພະຍາຍາມເພີ່ມລະບົບຈັດແຈງໃຫ້ກັບວິດເຈັດ '%1' (%2) ທີ່ມີລະບົບຈັດແຈງທີ່ບໍ່ຖືກຈັດການຢູ່ແລ້ວ ປະເພດ %3.
++ນີ້ຊີ້ບອກເຖິງຄວາມບໍ່ສອດຄ່ອງໃນໄຟລ໌ ui.</translation></message>
++    <message>
++        <source>Cannot create style '%1'.</source>
++        <translation>ບໍ່ສາມາດສ້າງຮູບແບບ '%1' ໄດ້.</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::WizardContainerWidgetTaskMenu</name>
++    <message>
++        <source>Next</source>
++        <translation>ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Back</source>
++        <translation>ກັບຄືນ</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ZoomMenu</name>
++    <message>
++        <source>%1 %</source>
++        <extracomment>Zoom factor</extracomment>
++        <translation>%1 %</translation></message>
++</context>
++<context>
++    <name>qdesigner_internal::ZoomablePreviewDeviceSkin</name>
++    <message>
++        <source>&amp;Zoom</source>
++        <translation>&amp;ຂະຫຍາຍ</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/linguist_lo.ts b/translations/linguist_lo.ts
+new file mode 100644
+index 0000000..9805b33
+--- /dev/null
++++ b/translations/linguist_lo.ts
+@@ -0,0 +1,1297 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>AboutDialog</name>
++    <message>
++        <source>Qt Linguist</source>
++        <translation>Qt Linguist</translation></message>
++</context>
++<context>
++    <name>BatchTranslationDialog</name>
++    <message>
++        <source>Qt Linguist - Batch Translation</source>
++        <translation>Qt Linguist - ການແປພາສາແບບຊຸດ</translation></message>
++    <message>
++        <source>Options</source>
++        <translation>ຕົວເລືອກ</translation></message>
++    <message>
++        <source>Set translated entries to finished</source>
++        <translation>ຕັ້ງຄ່າບັນທຶກທີ່ແປແລ້ວໃຫ້ສຳເລັດ</translation></message>
++    <message>
++        <source>Retranslate entries with existing translation</source>
++        <translation>ແປຂໍ້ຄວາມທີ່ມີການແປແລ້ວອີກຄັ້ງ</translation></message>
++    <message>
++        <source>Note that the modified entries will be reset to unfinished if 'Set translated entries to finished' above is unchecked</source>
++        <translation>ສັງເກດວ່າຂໍ້ມູນທີ່ໄດ້ດັດແກ້ຈະຖືກຕັ້ງຄືນເປັນບໍ່ສຳເລັດຖ້າ 'ຕັ້ງຂໍ້ມູນທີ່ແປແລ້ວໃຫ້ສຳເລັດ' ຂ້າງເທິງບໍ່ໄດ້ເລືອກ</translation></message>
++    <message>
++        <source>Translate also finished entries</source>
++        <translation>ແປລາຍການທີ່ສຳເລັດແລ້ວດ້ວຍ</translation></message>
++    <message>
++        <source>Phrase book preference</source>
++        <translation>ຄຳສັ່ງສະເພາະປື້ມຄຳສັບ</translation></message>
++    <message>
++        <source>Move up</source>
++        <translation>ຍ້າຍຂຶ້ນ</translation></message>
++    <message>
++        <source>Move down</source>
++        <translation>ຍ້າຍລົງ</translation></message>
++    <message>
++        <source>The batch translator will search through the selected phrase books in the order given above</source>
++        <translation>ຜູ້ແປຊຸດຈະຄົ້ນຫາຜ່ານປຶ້ມປະໂຫຍກທີ່ເລືອກໄວ້ຕາມລຳດັບທີ່ກຳນົດໄວ້ຂ້າງເທິງ</translation></message>
++    <message>
++        <source>&amp;Run</source>
++        <translation>&amp;ດຳເນີນງານ</translation></message>
++    <message>
++        <source>Cancel</source>
++        <translation>ຍົກເລີກ</translation></message>
++    <message>
++        <source>Batch Translation of '%1' - Qt Linguist</source>
++        <translation>ການແປແບບຊຸດຂອງ '%1' - Qt Linguist</translation></message>
++    <message>
++        <source>Searching, please wait...</source>
++        <translation>ກຳລັງຊອກຫາ, ກະລຸນາລໍຖ້າ...</translation></message>
++    <message>
++        <source>&amp;Cancel</source>
++        <translation>&amp;ຍົກເລີກ</translation></message>
++    <message>
++        <source>Linguist batch translator</source>
++        <translation>ຜູ້ແປພາສາແປເປັນກຸ່ມ</translation></message>
++    <message numerus="yes">
++        <source>Batch translated %n entries</source>
++        <translation>
++            <numerusform>ແປແບບຊຸດ %n ລາຍການ</numerusform>
++        </translation></message>
++</context>
++<context>
++    <name>DataModel</name>
++    <message>
++        <source>The translation file '%1' will not be loaded because it is empty.</source>
++        <translation>ໄຟລ໌ການແປ '%1' ຈະບໍ່ຖືກໂຫຼດເພາະວ່າມັນວ່າງເປົ່າ.</translation></message>
++    <message>
++        <source>&lt;qt&gt;Duplicate messages found in '%1':</source>
++        <translation>&lt;qt&gt;ພົບຂໍ້ຄວາມຊໍ້າກັນໃນ '%1':</translation></message>
++    <message>
++        <source>&lt;p&gt;[more duplicates omitted]</source>
++        <translation>&lt;p&gt;[more duplicates omitted]</translation></message>
++    <message>
++        <source>&lt;p&gt;* ID: %1</source>
++        <translation>&lt;p&gt;* ລະຫັດ: %1</translation></message>
++    <message>
++        <source>&lt;p&gt;* Context: %1&lt;br&gt;* Source: %2</source>
++        <translation>&lt;p&gt;* ບໍລິບົດ: %1&lt;br&gt;* ແຫຼ່ງທີ່ມາ: %2</translation></message>
++    <message>
++        <source>&lt;br&gt;* Comment: %3</source>
++        <translation>&lt;br&gt;* ຄຳເຫັນ: %3</translation></message>
++    <message>
++        <source>Linguist does not know the plural rules for '%1'.
++Will assume a single universal form.</source>
++        <translation>Linguist ບໍ່ຮູ້ກົດເກນພະຫຸພົດສຳລັບ '%1'.
++ຈະສົມມຸດວ່າເປັນຮູບແບບສາກົນດຽວ.</translation></message>
++    <message>
++        <source>Cannot create '%2': %1</source>
++        <translation>ບໍ່ສາມາດສ້າງ '%2': %1</translation></message>
++    <message>
++        <source>%1 (%2)</source>
++        <extracomment>&lt;language&gt; (&lt;country&gt;)</extracomment>
++        <translation>%1 (%2)</translation></message>
++    <message>
++        <source>Universal Form</source>
++        <translation>ແບບຟອມສາກົນ</translation></message>
++</context>
++<context>
++    <name>ErrorsView</name>
++    <message>
++        <source>Accelerator possibly superfluous in translation.</source>
++        <translation>ຕົວເລັ່ງອາດຈະບໍ່ຈຳເປັນໃນການແປ.</translation></message>
++    <message>
++        <source>Accelerator possibly missing in translation.</source>
++        <translation>ອາດຈະຂາດຕົວເລັ່ງໃນການແປ.</translation></message>
++    <message>
++        <source>Translation does not have same leading and trailing whitespace as the source text.</source>
++        <translation>ການແປບໍ່ມີຊ່ອງຫວ່າງນໍາໜ້າ ແລະ ຕາມຫຼັງຄືກັນກັບຂໍ້ຄວາມຕົ້ນສະບັບ.</translation></message>
++    <message>
++        <source>Translation does not end with the same punctuation as the source text.</source>
++        <translation>ການແປບໍ່ສິ້ນສຸດດ້ວຍສັນຍາລັກດຽວກັນກັບຂໍ້ຄວາມຕົ້ນສະບັບ.</translation></message>
++    <message>
++        <source>A phrase book suggestion for '%1' was ignored.</source>
++        <translation>ຄຳແນະນຳປຶ້ມປະໂຫຍກສຳລັບ '%1' ຖືກບໍ່ສົນໃຈ.</translation></message>
++    <message>
++        <source>Translation does not refer to the same place markers as in the source text.</source>
++        <translation>ການແປບໍ່ໄດ້ອ້າງອີງເຖິງຕົວຊີ້ບອກສະຖານທີ່ດຽວກັນກັບໃນຂໍ້ຄວາມຕົ້ນສະບັບ.</translation></message>
++    <message>
++        <source>Translation does not contain the necessary %n/%Ln place marker.</source>
++        <translation>ການແປບໍ່ມີຕົວໝາຍຕຳແໜ່ງ %n/%Ln ທີ່ຈຳເປັນ.</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>FMT</name>
++    <message>
++        <source>GNU Gettext localization files</source>
++        <translation>ເອກະສານການທ້ອນແປພາສາທ້ອງຖິ່ນ GNU Gettext</translation></message>
++    <message>
++        <source>GNU Gettext localization template files</source>
++        <translation>ເອກະສານແມ່ແບບການທ້ອງຖິ່ນຂອງ GNU Gettext</translation></message>
++    <message>
++        <source>Compiled Qt translations</source>
++        <translation>ການແປພາສາ Qt ທີ່ຖືກລວບລວມ</translation></message>
++    <message>
++        <source>Qt Linguist 'Phrase Book'</source>
++        <translation>Qt Linguist 'ປຶ້ມປະໂຫຍກ'</translation></message>
++    <message>
++        <source>Qt translation sources</source>
++        <translation>ແຫຼ່ງຂໍ້ມູນການແປພາສາ Qt</translation></message>
++    <message>
++        <source>XLIFF localization files</source>
++        <translation>ໄຟລ໌ການທ້ອນແປ XLIFF</translation></message>
++</context>
++<context>
++    <name>FindDialog</name>
++    <message>
++        <source>Find</source>
++        <translation>ຊອກຫາ</translation></message>
++    <message>
++        <source>This window allows you to search for some text in the translation source file.</source>
++        <translation>ປ່ອງຢ້ຽມນີ້ອະນຸຍາດໃຫ້ທ່ານຄົ້ນຫາຂໍ້ຄວາມບາງສ່ວນໃນໄຟລ໌ແຫຼ່ງຂໍ້ມູນການແປ.</translation></message>
++    <message>
++        <source>&amp;Find what:</source>
++        <translation>&amp;ຊອກຫາຫຍັງ:</translation></message>
++    <message>
++        <source>Type in the text to search for.</source>
++        <translation>ພິມຂໍ້ຄວາມເພື່ອຄົ້ນຫາ.</translation></message>
++    <message>
++        <source>Options</source>
++        <translation>ຕົວເລືອກ</translation></message>
++    <message>
++        <source>Lets you use a Perl-compatible regular expression</source>
++        <translation>ອະນຸຍາດໃຫ້ທ່ານໃຊ້ການສະແດງອອກປົກກະຕິທີ່ສອດຄ່ອງກັບ Perl</translation></message>
++    <message>
++        <source>Regular &amp;expression</source>
++        <translation>Regular &amp;expression</translation></message>
++    <message>
++        <source>Texts such as 'TeX' and 'tex' are considered as different when checked.</source>
++        <translation>ຂໍ້ຄວາມຕ່າງໆ ເຊັ່ນ 'TeX' ແລະ 'tex' ຖືກພິຈາລະນາເປັນສິ່ງທີ່ແຕກຕ່າງກັນເມື່ອກວດສອບ.</translation></message>
++    <message>
++        <source>&amp;Match case</source>
++        <translation>&amp;ຈັບຄູ່ຕົວອັກສອນ</translation></message>
++    <message>
++        <source>Source texts are searched when checked.</source>
++        <translation>ຂໍ້ຄວາມຕົ້ນສະບັບຈະຖືກຄົ້ນຫາເມື່ອຖືກກວດສອບ.</translation></message>
++    <message>
++        <source>&amp;Source texts</source>
++        <translation>&amp;ຂໍ້ຄວາມຕົ້ນສະບັບ</translation></message>
++    <message>
++        <source>Obsoleted messages are skipped when checked.</source>
++        <translation>ຂໍ້ຄວາມທີ່ລ້າສະໄຫມຖືກຂ້າມໄປເມື່ອກວດສອບ.</translation></message>
++    <message>
++        <source>Skip &amp;obsolete</source>
++        <translation>ຂ້າມ &amp;obsolete</translation></message>
++    <message>
++        <source>Comments and contexts are searched when checked.</source>
++        <translation>ຄຳເຫັນ ແລະ ບໍລິບົດຖືກຄົ້ນຫາເມື່ອກວດສອບແລ້ວ.</translation></message>
++    <message>
++        <source>&amp;Comments</source>
++        <translation>&amp;ຄຳເຫັນ</translation></message>
++    <message>
++        <source>Ignore &amp;accelerators</source>
++        <translation>ບໍ່ສົນໃຈ &amp;accelerators</translation></message>
++    <message>
++        <source>Translations are searched when checked.</source>
++        <translation>ການແປພາສາຈະຖືກຄົ້ນຫາເມື່ອຖືກກວດສອບ.</translation></message>
++    <message>
++        <source>&amp;Translations</source>
++        <translation>&amp;ການແປ</translation></message>
++    <message>
++        <source>Click here to find the next occurrence of the text you typed in.</source>
++        <translation>ກົດທີ່ນີ້ເພື່ອຊອກຫາການເກີດຂຶ້ນຕໍ່ໄປຂອງຂໍ້ຄວາມທີ່ທ່ານພິມເຂົ້າ.</translation></message>
++    <message>
++        <source>Find Next</source>
++        <translation>ຄົ້ນຫາຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Click here to close this window.</source>
++        <translation>ກົດທີ່ນີ້ເພື່ອປິດປ່ອງຢ້ຽມນີ້.</translation></message>
++    <message>
++        <source>Cancel</source>
++        <translation>ຍົກເລີກ</translation></message>
++    <message>
++        <source />
++        <comment>Choose Edit|Find from the menu bar or press Ctrl+F to pop up the Find dialog</comment>
++        <translation type="unfinished" /></message>
++</context>
++<context>
++    <name>FormMultiWidget</name>
++    <message>
++        <source>Alt+Delete</source>
++        <extracomment>translate, but don't change</extracomment>
++        <translation>Alt+Delete</translation></message>
++    <message>
++        <source>Shift+Alt+Insert</source>
++        <extracomment>translate, but don't change</extracomment>
++        <translation>Shift+Alt+Insert</translation></message>
++    <message>
++        <source>Alt+Insert</source>
++        <extracomment>translate, but don't change</extracomment>
++        <translation>Alt+Insert</translation></message>
++    <message>
++        <source>Confirmation - Qt Linguist</source>
++        <translation>ຢືນຢັນ - Qt Linguist</translation></message>
++    <message>
++        <source>Delete non-empty length variant?</source>
++        <translation>ລຶບຕົວແປຄວາມຍາວທີ່ບໍ່ວ່າງເປົ່າ?</translation></message>
++</context>
++<context>
++    <name>LRelease</name>
++    <message numerus="yes">
++        <source>Dropped %n message(s) which had no ID.</source>
++        <translation>
++            <numerusform>ຖິກລົງ %n ຂໍ້ຄວາມທີ່ບໍ່ມີ ID</numerusform>
++        </translation></message>
++    <message numerus="yes">
++        <source>Excess context/disambiguation dropped from %n message(s).</source>
++        <translation>
++            <numerusform>ບໍລິບັດບໍ່ສົມບູນຈາກຂໍ້ຄວາມ %n ຖືກຍົກເລີກ.</numerusform>
++        </translation></message>
++    <message numerus="yes">
++        <source>    Generated %n translation(s) (%1 finished and %2 unfinished)</source>
++        <translation>
++            <numerusform>ສ້າງການແປ %n ຊິ້ນ (%1 ສຳເລັດແລ້ວ ແລະ %2 ຍັງບໍ່ສຳເລັດ)</numerusform>
++        </translation></message>
++    <message numerus="yes">
++        <source>    Ignored %n untranslated source text(s)</source>
++        <translation>
++            <numerusform>ບໍ່ສົນໃຈ %n ຂໍ້ຄວາມຕົ້ນສະບັບທີ່ບໍ່ໄດ້ແປ</numerusform>
++        </translation></message>
++</context>
++<context>
++    <name>MainWindow</name>
++    <message>
++        <source>MainWindow</source>
++        <translation>ຫນ້າຕົ້ນ</translation></message>
++    <message>
++        <source>&amp;Phrases</source>
++        <translation>&amp;ປະໂຫຍກ</translation></message>
++    <message>
++        <source>&amp;Close Phrase Book</source>
++        <translation>&amp;ປິດປຶ້ມປະໂຫຍກ</translation></message>
++    <message>
++        <source>&amp;Edit Phrase Book</source>
++        <translation>&amp;ແກ້ໄຂປື້ມປະໂຫຍກ</translation></message>
++    <message>
++        <source>&amp;Print Phrase Book</source>
++        <translation>&amp;lt;ພິມປຶ້ມປະໂຫຍກ&amp;gt;</translation></message>
++    <message>
++        <source>V&amp;alidation</source>
++        <translation>ການກວດສອບ</translation></message>
++    <message>
++        <source>&amp;View</source>
++        <translation>&amp;ເບິ່ງ</translation></message>
++    <message>
++        <source>Vie&amp;ws</source>
++        <translation>ມຸມມອງ</translation></message>
++    <message>
++        <source>&amp;Toolbars</source>
++        <translation>&amp;ແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>&amp;Zoom</source>
++        <translation>&amp;ຂະຫຍາຍ</translation></message>
++    <message>
++        <source>Guesses</source>
++        <translation>ການຄາດເດົາ</translation></message>
++    <message>
++        <source>&amp;Help</source>
++        <translation>&amp;ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>&amp;Translation</source>
++        <translation>&amp;ການແປ</translation></message>
++    <message>
++        <source>&amp;File</source>
++        <translation>&amp;ໄຟລ໌</translation></message>
++    <message>
++        <source>Recently Opened &amp;Files</source>
++        <translation>ເປີດເມື່ອບໍ່ດົນມານີ້ &amp;Files</translation></message>
++    <message>
++        <source>&amp;Edit</source>
++        <translation>&amp;ແກ້ໄຂ</translation></message>
++    <message>
++        <source>&amp;Open...</source>
++        <translation>&amp;ເປີດ...</translation></message>
++    <message>
++        <source>Open a Qt translation source file (TS file) for editing</source>
++        <translation>ເປີດໄຟລ໌ແຫຼ່ງການແປພາສາ Qt (ໄຟລ໌ TS) ເພື່ອແກ້ໄຂ</translation></message>
++    <message>
++        <source>Ctrl+O</source>
++        <translation>Ctrl+O</translation></message>
++    <message>
++        <source>E&amp;xit</source>
++        <translation>E&amp;xit</translation></message>
++    <message>
++        <source>Close this window and exit.</source>
++        <translation>ປິດປ່ອງຢ້ຽມນີ້ ແລະ ອອກຈາກ.</translation></message>
++    <message>
++        <source>Ctrl+Q</source>
++        <translation>Ctrl+Q</translation></message>
++    <message>
++        <source>Save</source>
++        <translation>ບັນທຶກ</translation></message>
++    <message>
++        <source>Save changes made to this Qt translation source file</source>
++        <translation>ບັນທຶກການປ່ຽນແປງທີ່ເຮັດໃນໄຟລ໌ແຫຼ່ງການແປ Qt ນີ້</translation></message>
++    <message>
++        <source>Save &amp;As...</source>
++        <translation>ບັນທຶກ &amp;ເປັນ...</translation></message>
++    <message>
++        <source>Save As...</source>
++        <translation>ບັນທຶກເປັນ...</translation></message>
++    <message>
++        <source>Save changes made to this Qt translation source file into a new file.</source>
++        <translation>ບັນທຶກການປ່ຽນແປງທີ່ເຮັດໃຫ້ແກ່ໄຟລ໌ແຫຼ່ງຂໍ້ຄວາມ Qt ນີ້ເຂົ້າໄປໃນໄຟລ໌ໃໝ່.</translation></message>
++    <message>
++        <source>Release</source>
++        <translation>ປ່ອຍ</translation></message>
++    <message>
++        <source>Create a Qt message file suitable for released applications from the current message file.</source>
++        <translation>ສ້າງໄຟລ໌ຂໍ້ຄວາມ Qt ທີ່ເໝາະສົມສຳລັບແອັບພລິເຄຊັນທີ່ຖືກປ່ອຍອອກມາຈາກໄຟລ໌ຂໍ້ຄວາມປະຈຸບັນ.</translation></message>
++    <message>
++        <source>&amp;Print...</source>
++        <translation>&amp;ພິມ...</translation></message>
++    <message>
++        <source>Print a list of all the translation units in the current translation source file.</source>
++        <translation>ພິມລາຍການຂອງຫົວໜ່ວຍການແປທັງໝົດໃນໄຟລ໌ແຫຼ່ງການແປປະຈຸບັນ.</translation></message>
++    <message>
++        <source>Ctrl+P</source>
++        <translation>Ctrl+P</translation></message>
++    <message>
++        <source>&amp;Undo</source>
++        <translation>&amp;ກັບຄືນ</translation></message>
++    <message>
++        <source>Undo the last editing operation performed on the current translation.</source>
++        <translation>ຍົກເລີກການດຳເນີນການແກ້ໄຂຫຼ້າສຸດທີ່ດຳເນີນກັບການແປປັດຈຸບັນ.</translation></message>
++    <message>
++        <source>Ctrl+Z</source>
++        <translation>Ctrl+Z</translation></message>
++    <message>
++        <source>&amp;Redo</source>
++        <translation>&amp;ດໍາເນີນການຄືນໃໝ່</translation></message>
++    <message>
++        <source>Redo an undone editing operation performed on the translation.</source>
++        <translation>ກຳລັງດຳເນີນການແກ້ໄຂການແປທີ່ຖືກຍົກເລີກໃຫ້ຄືນໃໝ່.</translation></message>
++    <message>
++        <source>Ctrl+Y</source>
++        <translation>Ctrl+Y</translation></message>
++    <message>
++        <source>Cu&amp;t</source>
++        <translation>ຕັດ</translation></message>
++    <message>
++        <source>Copy the selected translation text to the clipboard and deletes it.</source>
++        <translation>ຄັດລອກຂໍ້ຄວາມທີ່ແປໄວ້ໄປທີ່ຄລິບບອດ ແລະ ລຶບມັນອອກ.</translation></message>
++    <message>
++        <source>Ctrl+X</source>
++        <translation>Ctrl+X</translation></message>
++    <message>
++        <source>&amp;Copy</source>
++        <translation>&amp;ສຳເນົາ</translation></message>
++    <message>
++        <source>Copy the selected translation text to the clipboard.</source>
++        <translation>ຄັດລອກຂໍ້ຄວາມທີ່ແປໄວ້ໄປທີ່ຄລິບບອດ.</translation></message>
++    <message>
++        <source>Ctrl+C</source>
++        <translation>Ctrl+C</translation></message>
++    <message>
++        <source>&amp;Paste</source>
++        <translation>&amp;ວາງ</translation></message>
++    <message>
++        <source>Paste the clipboard text into the translation.</source>
++        <translation>ວາງຂໍ້ຄວາມຈາກຄລິບບອດເຂົ້າໃນການແປ</translation></message>
++    <message>
++        <source>Ctrl+V</source>
++        <translation>Ctrl+V</translation></message>
++    <message>
++        <source>Select &amp;All</source>
++        <translation>ເລືອກ &amp;ທັງໝົດ</translation></message>
++    <message>
++        <source>Select the whole translation text.</source>
++        <translation>ເລືອກຂໍ້ຄວາມການແປທັງໝົດ.</translation></message>
++    <message>
++        <source>Ctrl+A</source>
++        <translation>Ctrl+A</translation></message>
++    <message>
++        <source>&amp;Find...</source>
++        <translation>&amp;ຊອກຫາ...</translation></message>
++    <message>
++        <source>Search for some text in the translation source file.</source>
++        <translation>ຄົ້ນຫາຂໍ້ຄວາມບາງສ່ວນໃນໄຟລ໌ແຫຼ່ງຂໍ້ມູນການແປ.</translation></message>
++    <message>
++        <source>Ctrl+F</source>
++        <translation>Ctrl+F</translation></message>
++    <message>
++        <source>Find &amp;Next</source>
++        <translation>ຊອກຫາ &amp; ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Continue the search where it was left.</source>
++        <translation>ສືບຕໍ່ການຄົ້ນຫາຕາມທີ່ມັນໄດ້ຖືກປະໄວ້.</translation></message>
++    <message>
++        <source>F3</source>
++        <translation>F3</translation></message>
++    <message>
++        <source>&amp;Prev Unfinished</source>
++        <translation>&amp;lt;Prev ທີ່ຍັງບໍ່ສຳເລັດ</translation></message>
++    <message>
++        <source>Previous unfinished item</source>
++        <translation>ລາຍການທີ່ຍັງບໍ່ສຳເລັດກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>Move to the previous unfinished item.</source>
++        <translation>ຍ້າຍໄປຫາລາຍການທີ່ຍັງບໍ່ສຳເລັດກ່ອນໜ້າ.</translation></message>
++    <message>
++        <source>Ctrl+K</source>
++        <translation>Ctrl+K</translation></message>
++    <message>
++        <source>&amp;Next Unfinished</source>
++        <translation>&amp;ຕໍ່ໄປທີ່ຍັງບໍ່ແລ້ວ</translation></message>
++    <message>
++        <source>Next unfinished item</source>
++        <translation>ລາຍການທີ່ຍັງບໍ່ສຳເລັດຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Move to the next unfinished item.</source>
++        <translation>ຍ້າຍໄປຫາລາຍການທີ່ຍັງບໍ່ສຳເລັດຖັດໄປ.</translation></message>
++    <message>
++        <source>Ctrl+J</source>
++        <translation>Ctrl+J</translation></message>
++    <message>
++        <source>P&amp;rev</source>
++        <translation>P&amp;ກັບຄືນ</translation></message>
++    <message>
++        <source>Move to previous item</source>
++        <translation>ຍ້າຍໄປຫາລາຍການກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>Move to the previous item.</source>
++        <translation>ຍ້າຍໄປຫາລາຍການກ່ອນໜ້າ.</translation></message>
++    <message>
++        <source>Ctrl+Shift+K</source>
++        <translation>Ctrl+Shift+K</translation></message>
++    <message>
++        <source>Ne&amp;xt</source>
++        <translation>ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Next item</source>
++        <translation>ລາຍການຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Move to the next item.</source>
++        <translation>ຍ້າຍໄປຫາລາຍການຕໍ່ໄປ.</translation></message>
++    <message>
++        <source>Ctrl+Shift+J</source>
++        <translation>Ctrl+Shift+J</translation></message>
++    <message>
++        <source>&amp;Done and Next</source>
++        <translation>&amp;ສຳເລັດແລ້ວ ແລະ ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Mark item as done and move to the next unfinished item</source>
++        <translation>ໝາຍລາຍການວ່າເຮັດແລ້ວ ແລະ ຍ້າຍໄປຫາລາຍການທີ່ຍັງບໍ່ເຮັດແລ້ວຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Mark this item as done and move to the next unfinished item.</source>
++        <translation>ໝາຍລາຍການນີ້ເປັນສຳເລັດແລ້ວ ແລະ ຍ້າຍໄປຫາລາຍການທີ່ຍັງບໍ່ສຳເລັດຖັດໄປ.</translation></message>
++    <message>
++        <source>Copy from source text</source>
++        <translation>ຄັດລອກຈາກຂໍ້ຄວາມແຫຼ່ງຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Copies the source text into the translation field</source>
++        <translation>ຄັດລອກຂໍ້ຄວາມຕົ້ນສະບັບເຂົ້າໃນຊ່ອງການແປ</translation></message>
++    <message>
++        <source>Copies the source text into the translation field.</source>
++        <translation>ຄັດລອກຂໍ້ຄວາມຕົ້ນສະບັບເຂົ້າໃນຊ່ອງການແປ.</translation></message>
++    <message>
++        <source>Ctrl+B</source>
++        <translation>Ctrl+B</translation></message>
++    <message>
++        <source>&amp;Accelerators</source>
++        <translation>&amp;ຕົວເລັ່ງໄວ</translation></message>
++    <message>
++        <source>Toggles the validity check of accelerators</source>
++        <translation>ປ່ຽນການກວດສອບຄວາມຖືກຕ້ອງຂອງຕົວເລັ່ງ</translation></message>
++    <message>
++        <source>Toggles the validity check of accelerators, i.e. whether the number of ampersands in the source and translation text is the same. If the check fails, a message is shown in the warnings window.</source>
++        <translation>ປ່ຽນການກວດສອບຄວາມຖືກຕ້ອງຂອງຕົວເລັ່ງ, ເຊິ່ງແມ່ນການກວດສອບວ່າຈຳນວນຂອງເຄື່ອງໝາຍ &amp; ໃນຂໍ້ຄວາມຕົ້ນສະບັບແລະຂໍ້ຄວາມທີ່ແປແມ່ນຄືກັນຫຼືບໍ່. ຖ້າການກວດສອບລົ້ມເຫຼວ, ຂໍ້ຄວາມຈະຖືກສະແດງໃນຫນ້າຕ່າງຄຳເຕືອນ.</translation></message>
++    <message>
++        <source>Surrounding &amp;Whitespace</source>
++        <translation>ອ້ອມຮອບ &amp;Whitespace</translation></message>
++    <message>
++        <source>Toggles the validity check of surrounding whitespace.</source>
++        <translation>ປ່ຽນການກວດສອບຄວາມຖືກຕ້ອງຂອງຊ່ອງຫວ່າງອ້ອມຮອບ.</translation></message>
++    <message>
++        <source>Toggles the validity check of surrounding whitespace. If the check fails, a message is shown in the warnings window.</source>
++        <translation>ປ່ຽນການກວດສອບຄວາມຖືກຕ້ອງຂອງຊ່ອງຫວ່າງອ້ອມຮອບ. ຖ້າການກວດສອບລົ້ມເຫລວ, ຂໍ້ຄວາມຈະຖືກສະແດງໃນຫນ້າຕ່າງຄໍາເຕືອນ.</translation></message>
++    <message>
++        <source>&amp;Ending Punctuation</source>
++        <translation>&amp;ເຄື່ອງໝາຍສິ້ນສຸດ</translation></message>
++    <message>
++        <source>Toggles the validity check of ending punctuation</source>
++        <translation>ປ່ຽນການກວດສອບຄວາມຖືກຕ້ອງຂອງສັນຍາລັກຈຸດສິ້ນສຸດ</translation></message>
++    <message>
++        <source>Toggles the validity check of ending punctuation. If the check fails, a message is shown in the warnings window.</source>
++        <translation>ປ່ຽນການກວດສອບຄວາມຖືກຕ້ອງຂອງຕົວຫຍໍ້ສິ້ນສຸດ. ຖ້າການກວດສອບລົ້ມເຫລວ, ຂໍ້ຄວາມຈະຖືກສະແດງໃນຫນ້າຕ່າງຄຳເຕືອນ.</translation></message>
++    <message>
++        <source>&amp;Phrase matches</source>
++        <translation>ຈັບຄູ່ປະໂຫຍກ</translation></message>
++    <message>
++        <source>Toggles checking that phrase suggestions are used</source>
++        <translation>ປ່ຽນການກວດສອບຄຳແນະນຳທີ່ຖືກນຳໃຊ້</translation></message>
++    <message>
++        <source>Toggles checking that phrase suggestions are used. If the check fails, a message is shown in the warnings window.</source>
++        <translation>ປ່ຽນການກວດສອບຄຳແນະນຳທີ່ຖືກນຳໃຊ້. ຖ້າການກວດສອບລົ້ມເຫລວ, ຂໍ້ຄວາມຈະຖືກສະແດງໃນຫນ້າຕ່າງຄຳເຕືອນ.</translation></message>
++    <message>
++        <source>Place &amp;Marker Matches</source>
++        <translation>ວາງ &amp;Marker Matches</translation></message>
++    <message>
++        <source>Toggles the validity check of place markers</source>
++        <translation>ປ່ຽນການກວດສອບຄວາມຖືກຕ້ອງຂອງເຄື່ອງໝາຍສະຖານທີ່</translation></message>
++    <message>
++        <source>Toggles the validity check of place markers, i.e. whether %1, %2, ... are used consistently in the source text and translation text. If the check fails, a message is shown in the warnings window.</source>
++        <translation>ປ່ຽນການກວດສອບຄວາມຖືກຕ້ອງຂອງຕົວໝາຍສະຖານທີ່, ເຊັ່ນວ່າ %1, %2, ... ຖືກນຳໃຊ້ຢ່າງສອດຄ່ອງໃນຂໍ້ຄວາມຕົ້ນສະບັບແລະຂໍ້ຄວາມທີ່ແປຫຼືບໍ່. ຖ້າການກວດສອບລົ້ມເຫຼວ, ຂໍ້ຄວາມຈະຖືກສະແດງໃນຫນ້າຕ່າງຄຳເຕືອນ.</translation></message>
++    <message>
++        <source>&amp;New Phrase Book...</source>
++        <translation>&amp;ປື້ມປະໂຫຍກໃໝ່...</translation></message>
++    <message>
++        <source>Create a new phrase book.</source>
++        <translation>ສ້າງປື້ມປະໂຫຍກໃໝ່.</translation></message>
++    <message>
++        <source>Ctrl+N</source>
++        <translation>Ctrl+N</translation></message>
++    <message>
++        <source>&amp;Open Phrase Book...</source>
++        <translation>&amp;lt;ເປີດປຶ້ມປະໂຫຍກ...</translation></message>
++    <message>
++        <source>Open a phrase book to assist translation.</source>
++        <translation>ເປີດປື້ມປະໂຫຍກເພື່ອຊ່ວຍໃນການແປ.</translation></message>
++    <message>
++        <source>Ctrl+H</source>
++        <translation>Ctrl+H</translation></message>
++    <message>
++        <source>&amp;Reset Sorting</source>
++        <translation>&amp;ຕັ້ງຄ່າການຈັດລຽງໃຫມ່</translation></message>
++    <message>
++        <source>Sort the items back in the same order as in the message file.</source>
++        <translation>ຈັດລຳດັບລາຍການກັບຄືນໃນລຳດັບດຽວກັນກັບໃນໄຟລ໌ຂໍ້ຄວາມ.</translation></message>
++    <message>
++        <source>&amp;Display guesses</source>
++        <translation>&amp;ສະແດງການຄາດເດົາ</translation></message>
++    <message>
++        <source>Set whether or not to display translation guesses.</source>
++        <translation>ຕັ້ງຄ່າວ່າຈະສະແດງການຄາດເດົາການແປຫຼືບໍ່.</translation></message>
++    <message>
++        <source>&amp;Statistics</source>
++        <translation>&amp;ສະຖິຕິ</translation></message>
++    <message>
++        <source>Display translation statistics.</source>
++        <translation>ສະແດງສະຖິຕິການແປ.</translation></message>
++    <message>
++        <source>&amp;Manual</source>
++        <translation>&amp;ຄູ່ມື</translation></message>
++    <message>
++        <source>F1</source>
++        <translation>F1</translation></message>
++    <message>
++        <source>About Qt Linguist</source>
++        <translation>ກ່ຽວກັບ Qt Linguist</translation></message>
++    <message>
++        <source>About Qt</source>
++        <translation>ກ່ຽວກັບ Qt</translation></message>
++    <message>
++        <source>Display information about the Qt toolkit by Digia.</source>
++        <translation>ສະແດງຂໍ້ມູນກ່ຽວກັບຊຸດເຄື່ອງມື Qt ໂດຍ Digia.</translation></message>
++    <message>
++        <source>&amp;What's This?</source>
++        <translation>&amp;lt;ນີ້ແມ່ນຫຍັງ?</translation></message>
++    <message>
++        <source>What's This?</source>
++        <translation>ນີ້ແມ່ນຫຍັງ?</translation></message>
++    <message>
++        <source>Enter What's This? mode.</source>
++        <translation>ເຂົ້າສູ່ໂໝດ "ນີ້ແມ່ນຫຍັງ?"</translation></message>
++    <message>
++        <source>Shift+F1</source>
++        <translation>Shift+F1</translation></message>
++    <message>
++        <source>&amp;Search And Translate...</source>
++        <translation>&amp;ຄົ້ນຫາ ແລະ ແປ...</translation></message>
++    <message>
++        <source>Replace the translation on all entries that matches the search source text.</source>
++        <translation>ປ່ຽນແປງການແປໃນທຸກໆລາຍການທີ່ກົງກັບຂໍ້ຄວາມຕົ້ນສະບັບທີ່ຄົ້ນຫາ.</translation></message>
++    <message>
++        <source>&amp;Batch Translation...</source>
++        <translation>&amp;ການແປພາສາເປັນຊຸດ...</translation></message>
++    <message>
++        <source>Batch translate all entries using the information in the phrase books.</source>
++        <translation>ແປທັງໝົດຕາມຂໍ້ມູນໃນປຶ້ມປະໂຫຍກ.</translation></message>
++    <message>
++        <source>Release As...</source>
++        <translation>ປ່ອຍເປັນ...</translation></message>
++    <message>
++        <source>Create a Qt message file suitable for released applications from the current message file. The filename will automatically be determined from the name of the TS file.</source>
++        <translation>ສ້າງໄຟລ໌ຂໍ້ຄວາມ Qt ທີ່ເໝາະສົມສໍາລັບແອັບພລິເຄຊັນທີ່ຖືກປ່ອຍອອກມາຈາກໄຟລ໌ຂໍ້ຄວາມປະຈຸບັນ. ຊື່ໄຟລ໌ຈະຖືກກໍານົດໂດຍອັດຕະໂນມັດຈາກຊື່ຂອງໄຟລ໌ TS.</translation></message>
++    <message>
++        <source>File</source>
++        <translation>ໄຟລ໌</translation></message>
++    <message>
++        <source>Edit</source>
++        <translation>ແກ້ໄຂ</translation></message>
++    <message>
++        <source>Translation</source>
++        <translation>ການແປ</translation></message>
++    <message>
++        <source>Validation</source>
++        <translation>ການກວດສອບ</translation></message>
++    <message>
++        <source>Help</source>
++        <translation>ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>Open/Refresh Form &amp;Preview</source>
++        <translation>ເປີດ/ຟື້ນຟີຟອມ &amp;ລວມເບິ່ງລ່ວງໜ້າ</translation></message>
++    <message>
++        <source>Form Preview Tool</source>
++        <translation>ເຄື່ອງມືການເບິ່ງລ່ວງຮູບແບບ</translation></message>
++    <message>
++        <source>F5</source>
++        <translation>F5</translation></message>
++    <message>
++        <source>Translation File &amp;Settings...</source>
++        <translation>ແປເອກະສານ &amp;ການຕັ້ງຄ່າ...</translation></message>
++    <message>
++        <source>&amp;Add to Phrase Book</source>
++        <translation>&amp;ເພີ່ມເຂົ້າປຶ້ມປະໂຫຍກ</translation></message>
++    <message>
++        <source>Ctrl+T</source>
++        <translation>Ctrl+T</translation></message>
++    <message>
++        <source>Open Read-O&amp;nly...</source>
++        <translation>ເປີດອ່ານໄດ້ຢ່າງດຽວ...</translation></message>
++    <message>
++        <source>&amp;Save All</source>
++        <translation>&amp;ບັນທຶກທັງໝົດ</translation></message>
++    <message>
++        <source>Ctrl+S</source>
++        <translation>Ctrl+S</translation></message>
++    <message>
++        <source>&amp;Release All</source>
++        <translation>&amp;ປ່ອຍທັງໝົດ</translation></message>
++    <message>
++        <source>Close</source>
++        <translation>ປິດ</translation></message>
++    <message>
++        <source>&amp;Close All</source>
++        <translation>&amp;ປິດທັງໝົດ</translation></message>
++    <message>
++        <source>Ctrl+W</source>
++        <translation>Ctrl+W</translation></message>
++    <message>
++        <source>Length Variants</source>
++        <translation>ຮູບແບບຄວາມຍາວ</translation></message>
++    <message>
++        <source>Visualize whitespace</source>
++        <translation>ເບິ່ງເຫັນຊ່ອງຫວ່າງ</translation></message>
++    <message>
++        <source>Toggles visualize whitespace in editors</source>
++        <translation>ປ່ຽນການສະແດງຊ່ອງຫວ່າງໃນບັນດາຕົວແກ້ໄຂ</translation></message>
++    <message>
++        <source>Increase</source>
++        <translation>ເພີ່ມຂຶ້ນ</translation></message>
++    <message>
++        <source>Ctrl++</source>
++        <translation>Ctrl++</translation></message>
++    <message>
++        <source>Decrease</source>
++        <translation>ຫຼຸດລົງ</translation></message>
++    <message>
++        <source>Ctrl+-</source>
++        <translation>Ctrl+-</translation></message>
++    <message>
++        <source>Reset to default</source>
++        <translation>ຣີເຊັດເປັນຄ່າເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Ctrl+0</source>
++        <translation>Ctrl+0</translation></message>
++    <message>
++        <source>Show more</source>
++        <translation>ສະແດງເພີ່ມເຕີມ</translation></message>
++    <message>
++        <source>Alt++</source>
++        <translation>Alt++</translation></message>
++    <message>
++        <source>Show fewer</source>
++        <translation>ສະແດງໜ້ອຍລົງ</translation></message>
++    <message>
++        <source>Alt+-</source>
++        <translation>Alt+-</translation></message>
++    <message>
++        <source>Alt+0</source>
++        <translation>Alt+0</translation></message>
++    <message>
++        <source>D&amp;one</source>
++        <translation>D&amp;ເຮັດແລ້ວ</translation></message>
++    <message>
++        <source>Mark item as done</source>
++        <translation>ໝາຍລາຍການວ່າເຮັດແລ້ວ</translation></message>
++    <message>
++        <source>Mark this item as done.</source>
++        <translation>ໝາຍລາຍການນີ້ເປັນສຳເລັດແລ້ວ.</translation></message>
++    <message>
++        <source />
++        <comment>This is the application's main window.</comment>
++        <translation type="unfinished" /></message>
++    <message>
++        <source>Source text</source>
++        <translation>ແປເປັນພາສາລາວ: ຂໍ້ຄວາມຕົ້ນສະບັບ</translation></message>
++    <message>
++        <source>Index</source>
++        <translation>ດັດຊະນີ</translation></message>
++    <message>
++        <source>Context</source>
++        <translation>ບໍລິບົດ</translation></message>
++    <message>
++        <source>Items</source>
++        <translation>ລາຍການ</translation></message>
++    <message>
++        <source>This panel lists the source contexts.</source>
++        <translation>ກະດານນີ້ລາຍຊື່ບໍລິບົດແຫຼ່ງຂໍ້ມູນ.</translation></message>
++    <message>
++        <source>Strings</source>
++        <translation>ສະຕຣິງ</translation></message>
++    <message>
++        <source>Phrases and guesses</source>
++        <translation>ປະໂຫຍກ ແລະ ການຄາດເດົາ</translation></message>
++    <message>
++        <source>Sources and Forms</source>
++        <translation>ແຫຼ່ງທີ່ມາ ແລະ ຮູບແບບ</translation></message>
++    <message>
++        <source>Warnings</source>
++        <translation>ຄຳເຕືອນ</translation></message>
++    <message>
++        <source> MOD </source>
++        <comment>status bar: file(s) modified</comment>
++        <translation>MOD</translation></message>
++    <message>
++        <source>Loading...</source>
++        <translation>ກຳລັງໂຫຼດ...</translation></message>
++    <message>
++        <source>Loading File - Qt Linguist</source>
++        <translation>ກຳລັງໂຫຼດໄຟລ໌ - Qt Linguist</translation></message>
++    <message>
++        <source>The file '%1' does not seem to be related to the currently open file(s) '%2'.
++
++Close the open file(s) first?</source>
++        <translation>ໄຟລ໌ '%1' ບໍ່ເຫັນວ່າຈະກ່ຽວຂ້ອງກັບໄຟລ໌ທີ່ເປີດຢູ່ປະຈຸບັນ '%2'.
++
++ຕ້ອງການປິດໄຟລ໌ທີ່ເປີດຢູ່ກ່ອນບໍ?</translation></message>
++    <message>
++        <source>The file '%1' does not seem to be related to the file '%2' which is being loaded as well.
++
++Skip loading the first named file?</source>
++        <translation>ໄຟລ໌ '%1' ບໍ່ເຫັນວ່າຈະກ່ຽວຂ້ອງກັບໄຟລ໌ '%2' ທີ່ກຳລັງຖືກໂຫຼດເຂົ້າມາເຊັ່ນກັນ.
++
++ຂ້າມການໂຫຼດໄຟລ໌ທີ່ກ່າວມາທຳອິດ?</translation></message>
++    <message numerus="yes">
++        <source>%n translation unit(s) loaded.</source>
++        <translation>
++            <numerusform>%n ຫົວໜ່ວຍການແປໄດ້ຖືກໂຫຼດແລ້ວ.</numerusform>
++        </translation></message>
++    <message>
++        <source>Related files (%1);;</source>
++        <translation>ຟາຍທີ່ກ່ຽວຂ້ອງ (%1);;</translation></message>
++    <message>
++        <source>Open Translation Files</source>
++        <translation>ເປີດໄຟລ໌ການແປ</translation></message>
++    <message>
++        <source>File saved.</source>
++        <translation>ບັນທຶກໄຟລ໌ແລ້ວ.</translation></message>
++    <message>
++        <source>Qt message files for released applications (*.qm)
++All files (*)</source>
++        <translation>ໄຟລ໌ຂໍ້ຄວາມ Qt ສໍາລັບແອັບພລິເຄຊັນທີ່ປ່ອຍອອກມາ (*.qm)
++ທຸກໄຟລ໌ (*)</translation></message>
++    <message>
++        <source>File created.</source>
++        <translation>ຟາຍຖືກສ້າງແລ້ວ.</translation></message>
++    <message>
++        <source>Printing...</source>
++        <translation>ພິມ...</translation></message>
++    <message>
++        <source>Context: %1</source>
++        <translation>ບໍລິບົດ: %1</translation></message>
++    <message>
++        <source>finished</source>
++        <translation>ສຳເລັດແລ້ວ</translation></message>
++    <message>
++        <source>unresolved</source>
++        <translation>ບໍ່ໄດ້ແກ້ໄຂ</translation></message>
++    <message>
++        <source>obsolete</source>
++        <translation>ເກົ່າແກ່</translation></message>
++    <message>
++        <source>Printing... (page %1)</source>
++        <translation>ກຳລັງພິມ... (ໜ້າ %1)</translation></message>
++    <message>
++        <source>Printing completed</source>
++        <translation>ພິມສຳເລັດແລ້ວ</translation></message>
++    <message>
++        <source>Printing aborted</source>
++        <translation>ການພິມຖືກຍົກເລີກ</translation></message>
++    <message>
++        <source>Search wrapped.</source>
++        <translation>ຄົ້ນຫາຫຸ້ມພັນ.</translation></message>
++    <message>
++        <source>Qt Linguist</source>
++        <translation>Qt Linguist</translation></message>
++    <message>
++        <source>Cannot find the string '%1'.</source>
++        <translation>ບໍ່ສາມາດຊອກຫາສະຕຣິງ '%1' ໄດ້.</translation></message>
++    <message>
++        <source>Search And Translate in '%1' - Qt Linguist</source>
++        <translation>ຄົ້ນຫາ ແລະ ແປ້ງໃນ '%1' - Qt Linguist</translation></message>
++    <message>
++        <source>Translate - Qt Linguist</source>
++        <translation>ແປ - Qt Linguist</translation></message>
++    <message numerus="yes">
++        <source>Translated %n entry(s)</source>
++        <translation>
++            <numerusform>ປ່ຽນເປັນພາສາລາວ: ແປ %n ລາຍການ</numerusform>
++        </translation></message>
++    <message>
++        <source>No more occurrences of '%1'. Start over?</source>
++        <translation>ບໍ່ມີການປະກົດຕົວຂອງ '%1' ອີກຕໍ່ໄປ. ເລີ່ມໃໝ່ບໍ?</translation></message>
++    <message>
++        <source>Create New Phrase Book</source>
++        <translation>ສ້າງປື້ມປະໂຫຍກໃໝ່</translation></message>
++    <message>
++        <source>Qt phrase books (*.qph)
++All files (*)</source>
++        <translation>ປື້ມປະໂຫຍກ Qt (*.qph)
++ທຸກໆໄຟລ໌ (*)</translation></message>
++    <message>
++        <source>Phrase book created.</source>
++        <translation>ປຶ້ມປະໂຫຍກຖືກສ້າງຂຶ້ນແລ້ວ.</translation></message>
++    <message>
++        <source>Open Phrase Book</source>
++        <translation>ເປີດປຶ້ມປະໂຫຍກ</translation></message>
++    <message>
++        <source>Qt phrase books (*.qph);;All files (*)</source>
++        <translation>ປື້ມປະໂຫຍກ Qt (*.qph);;ໄຟລ໌ທັງໝົດ (*)</translation></message>
++    <message numerus="yes">
++        <source>%n phrase(s) loaded.</source>
++        <translation>
++            <numerusform>%n ປະໂຫຍກ ໄດ້ຖືກໂຫຼດແລ້ວ.</numerusform>
++        </translation></message>
++    <message>
++        <source>Add to phrase book</source>
++        <translation>ເພີ່ມໃສ່ປຶ້ມປະໂຫຍກ</translation></message>
++    <message>
++        <source>No appropriate phrasebook found.</source>
++        <translation>ບໍ່ພົບປຶ້ມປະໂຫຍກທີ່ເໝາະສົມ.</translation></message>
++    <message>
++        <source>Adding entry to phrasebook %1</source>
++        <translation>ເພີ່ມລາຍການໃສ່ປຶ້ມປະໂຫຍກ %1</translation></message>
++    <message>
++        <source>Select phrase book to add to</source>
++        <translation>ເລືອກປື້ມປະໂຫຍກເພື່ອເພີ່ມເຂົ້າ</translation></message>
++    <message>
++        <source>Unable to launch Qt Assistant (%1)</source>
++        <translation>ບໍ່ສາມາດເປີດ Qt Assistant (%1) ໄດ້</translation></message>
++    <message>
++        <source>Version %1</source>
++        <translation>ລູ້ນ %1</translation></message>
++    <message>
++        <source>&lt;center&gt;&lt;img src=":/images/icons/linguist-128-32.png"/&gt;&lt;/img&gt;&lt;p&gt;%1&lt;/p&gt;&lt;/center&gt;&lt;p&gt;Qt Linguist is a tool for adding translations to Qt applications.&lt;/p&gt;&lt;p&gt;Copyright (C) %2 The Qt Company Ltd.</source>
++        <translation>&lt;center&gt;&lt;img src=":/images/icons/linguist-128-32.png"/&gt;&lt;/img&gt;&lt;p&gt;%1&lt;/p&gt;&lt;/center&gt;&lt;p&gt;Qt Linguist is a tool for adding translations to Qt applications.&lt;/p&gt;&lt;p&gt;Copyright (C) %2 The Qt Company Ltd.</translation></message>
++    <message>
++        <source>Do you want to save the modified files?</source>
++        <translation>ທ່ານຕ້ອງການບັນທຶກໄຟລ໌ທີ່ຖືກແກ້ໄຂບໍ?</translation></message>
++    <message>
++        <source>Do you want to save '%1'?</source>
++        <translation>ທ່ານຕ້ອງການບັນທຶກ '%1' ບໍ?</translation></message>
++    <message>
++        <source>Qt Linguist[*]</source>
++        <translation>Qt Linguist[*]</translation></message>
++    <message>
++        <source>%1[*] - Qt Linguist</source>
++        <translation>%1[*] - Qt ລິງກວິສ</translation></message>
++    <message>
++        <source>No untranslated translation units left.</source>
++        <translation>ບໍ່ມີຫົວໜ່ວຍການແປທີ່ຍັງບໍ່ໄດ້ແປເຫຼືອຢູ່.</translation></message>
++    <message>
++        <source>&amp;Window</source>
++        <translation>&amp;ຫນ້າຕ່າງ</translation></message>
++    <message>
++        <source>Minimize</source>
++        <translation>ຫຼຸດຂະຫນາດນ້ອຍສຸດ</translation></message>
++    <message>
++        <source>Ctrl+M</source>
++        <translation>Ctrl+M</translation></message>
++    <message>
++        <source>Display the manual for %1.</source>
++        <translation>ສະແດງຄູ່ມືສໍາລັບ %1</translation></message>
++    <message>
++        <source>Display information about %1.</source>
++        <translation>ສະແດງຂໍ້ມູນກ່ຽວກັບ %1.</translation></message>
++    <message>
++        <source>&amp;Save '%1'</source>
++        <translation>&amp;ບັນທຶກ '%1'</translation></message>
++    <message>
++        <source>Save '%1' &amp;As...</source>
++        <translation>ບັນທຶກ '%1' ເປັນ...</translation></message>
++    <message>
++        <source>Release '%1'</source>
++        <translation>ປ່ອຍ '%1'</translation></message>
++    <message>
++        <source>Release '%1' As...</source>
++        <translation>ປ່ອຍ '%1' ເປັນ...</translation></message>
++    <message>
++        <source>&amp;Close '%1'</source>
++        <translation>&amp;ປິດ '%1'</translation></message>
++    <message>
++        <source>&amp;Save</source>
++        <translation>&amp;ບັນທຶກ</translation></message>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;ປິດ</translation></message>
++    <message>
++        <source>Save All</source>
++        <translation>ບັນທຶກທັງໝົດ</translation></message>
++    <message>
++        <source>Close All</source>
++        <translation>ປິດທັງໝົດ</translation></message>
++    <message>
++        <source>&amp;Release</source>
++        <translation>&amp;ປ່ອຍ</translation></message>
++    <message>
++        <source>Translation File &amp;Settings for '%1'...</source>
++        <translation>ແປໄຟລ໌ &amp; ການຕັ້ງຄ່າສໍາລັບ '%1'...</translation></message>
++    <message>
++        <source>&amp;Batch Translation of '%1'...</source>
++        <translation>&amp;ການແປແບບຊຸດຂອງ '%1'...</translation></message>
++    <message>
++        <source>Search And &amp;Translate in '%1'...</source>
++        <translation>ຄົ້ນຫາ ແລະ &amp;ແປ້ນພາສາໃນ '%1'...</translation></message>
++    <message>
++        <source>Search And &amp;Translate...</source>
++        <translation>ຄົ້ນຫາ ແລະ &amp;ແປ...</translation></message>
++    <message>
++        <source>Cannot read from phrase book '%1'.</source>
++        <translation>ບໍ່ສາມາດອ່ານຈາກປື້ມປະໂຫຍກ '%1' ໄດ້.</translation></message>
++    <message>
++        <source>Close this phrase book.</source>
++        <translation>ປິດປຶ້ມປະໂຫຍກນີ້.</translation></message>
++    <message>
++        <source>Enables you to add, modify, or delete entries in this phrase book.</source>
++        <translation>ຊ່ວຍໃຫ້ທ່ານສາມາດເພີ່ມ, ແກ້ໄຂ, ຫຼືລຶບລ້າງຂໍ້ຄວາມໃນປື້ມປະໂຫຍກນີ້.</translation></message>
++    <message>
++        <source>Print the entries in this phrase book.</source>
++        <translation>ພິມລາຍການໃນປື້ມປະໂຫຍກນີ້.</translation></message>
++    <message>
++        <source>Cannot create phrase book '%1'.</source>
++        <translation>ບໍ່ສາມາດສ້າງປຶ້ມປະໂຫຍກ '%1' ໄດ້.</translation></message>
++    <message>
++        <source>Do you want to save phrase book '%1'?</source>
++        <translation>ທ່ານຕ້ອງການບັນທຶກປຶ້ມປະໂຫຍກ '%1' ບໍ?</translation></message>
++    <message numerus="yes">
++        <source>%n unfinished message(s) left.</source>
++        <translation>
++            <numerusform>%n ຂໍ້ຄວາມທີ່ຍັງບໍ່ສຳເລັດຍັງເຫຼືອ.</numerusform>
++        </translation></message>
++    <message>
++        <source>All</source>
++        <translation>ທັງໝົດ</translation></message>
++</context>
++<context>
++    <name>MessageEditor</name>
++    <message>
++        <source />
++        <comment>This is the right panel of the main window.</comment>
++        <translation type="unfinished" /></message>
++    <message>
++        <source>This whole panel allows you to view and edit the translation of some source text.</source>
++        <translation>ກະດານທັງໝົດນີ້ອະນຸຍາດໃຫ້ທ່ານເບິ່ງແລະແກ້ໄຂການແປຂໍ້ຄວາມຕົ້ນສະບັບບາງສ່ວນ.</translation></message>
++    <message>
++        <source>Source text</source>
++        <translation>ຂໍ້ຄວາມຕົ້ນສະບັບ</translation></message>
++    <message>
++        <source>This area shows the source text.</source>
++        <translation>ພື້ນທີ່ນີ້ສະແດງຂໍ້ຄວາມຕົ້ນສະບັບ.</translation></message>
++    <message>
++        <source>Source text (Plural)</source>
++        <translation>ແປເປັນພາສາລາວ: ຂໍ້ຄວາມແຫຼ່ງຂໍ້ມູນ (ພະຫຸພົດ)</translation></message>
++    <message>
++        <source>This area shows the plural form of the source text.</source>
++        <translation>ພື້ນທີ່ນີ້ສະແດງຮູບແບບພະຫຸພົດຂອງຂໍ້ຄວາມແຫຼ່ງຂໍ້ມູນ.</translation></message>
++    <message>
++        <source>Developer comments</source>
++        <translation>ຄຳເຫັນຂອງຜູ້ພັດທະນາ</translation></message>
++    <message>
++        <source>This area shows a comment that may guide you, and the context in which the text occurs.</source>
++        <translation>ພື້ນທີ່ນີ້ສະແດງຄຳເຫັນທີ່ອາດຈະຊ່ວຍນຳທາງທ່ານ, ແລະບໍລິບົດທີ່ຂໍ້ຄວາມນີ້ເກີດຂຶ້ນ.</translation></message>
++    <message>
++        <source>Here you can enter comments for your own use. They have no effect on the translated applications.</source>
++        <translation>ທີ່ນີ້ທ່ານສາມາດໃສ່ຄຳອະທິບາຍສຳລັບການນຳໃຊ້ຂອງທ່ານເອງ. ພວກມັນບໍ່ມີຜົນກະທົບຕໍ່ແອັບພລິເຄຊັນທີ່ແປແລ້ວ.</translation></message>
++    <message>
++        <source>Translation to %1 (%2)</source>
++        <translation>ແປເປັນ %1 (%2)</translation></message>
++    <message>
++        <source>This is where you can enter or modify the translation of the above source text.</source>
++        <translation>ນີ້ແມ່ນບ່ອນທີ່ທ່ານສາມາດໃສ່ ຫຼື ແກ້ໄຂການແປຂໍ້ຄວາມຕົ້ນສະບັບຂ້າງເທິງ.</translation></message>
++    <message>
++        <source>Translation to %1</source>
++        <translation>ແປເປັນ %1</translation></message>
++    <message>
++        <source>Translator comments for %1</source>
++        <translation>ຄຳອະທິບາຍຂອງຜູ້ແປສຳລັບ %1</translation></message>
++    <message>
++        <source>'%1'
++Line: %2</source>
++        <translation>'%1'
++ເສັ້ນ: %2</translation></message>
++</context>
++<context>
++    <name>MessageModel</name>
++    <message>
++        <source>Completion status for %1</source>
++        <translation>ສະຖານະການສຳເລັດສຳລັບ %1</translation></message>
++    <message>
++        <source>&lt;file header&gt;</source>
++        <translation>&lt;file header&gt;</translation></message>
++    <message>
++        <source>&lt;context comment&gt;</source>
++        <translation>&lt;context comment&gt;</translation></message>
++    <message>
++        <source>&lt;unnamed context&gt;</source>
++        <translation>&lt;unnamed context&gt;</translation></message>
++    <message numerus="yes">
++        <source>%n unfinished message(s) left.</source>
++        <translation>
++            <numerusform>%n ຂໍ້ຄວາມທີ່ຍັງບໍ່ສຳເລັດຍັງຄ້າງຢູ່.</numerusform>
++        </translation></message>
++</context>
++<context>
++    <name>PhraseBook</name>
++    <message>
++        <source>Parse error at line %1, column %2 (%3).</source>
++        <translation>ຂໍ້ຜິດພາດໃນການວິເຄາະທີ່ເສັ້ນ %1, ຖັນ %2 (%3).</translation></message>
++</context>
++<context>
++    <name>PhraseBookBox</name>
++    <message>
++        <source>Edit Phrase Book</source>
++        <translation>ແກ້ໄຂປຶ້ມປະໂຫຍກ</translation></message>
++    <message>
++        <source>This window allows you to add, modify, or delete entries in a phrase book.</source>
++        <translation>ປ່ອງຢ້ຽມນີ້ຊ່ວຍໃຫ້ທ່ານສາມາດເພີ່ມ, ແກ້ໄຂ, ຫຼືລຶບລ້າງຂໍ້ຄວາມໃນປຶ້ມປະໂຫຍກ.</translation></message>
++    <message>
++        <source>&amp;Translation:</source>
++        <translation>&amp;lt;ການແປ:</translation></message>
++    <message>
++        <source>This is the phrase in the target language corresponding to the source phrase.</source>
++        <translation>ນີ້ແມ່ນປະໂຫຍກໃນພາສາປາຍທາງທີ່ສອດຄ່ອງກັບປະໂຫຍກແຫຼ່ງຂໍ້ມູນ.</translation></message>
++    <message>
++        <source>S&amp;ource phrase:</source>
++        <translation>S&amp;ource phrase:</translation></message>
++    <message>
++        <source>This is a definition for the source phrase.</source>
++        <translation>ນີ້ແມ່ນຄຳຈຳກັດສຳລັບປະໂຫຍກແຫຼ່ງຂໍ້ມູນ.</translation></message>
++    <message>
++        <source>This is the phrase in the source language.</source>
++        <translation>ນີ້ແມ່ນປະໂຫຍກໃນພາສາຕົ້ນສະບັບ.</translation></message>
++    <message>
++        <source>&amp;Definition:</source>
++        <translation>&amp;lt;Definition:</translation></message>
++    <message>
++        <source>Click here to add the phrase to the phrase book.</source>
++        <translation>ຄລິກທີ່ນີ້ເພື່ອເພີ່ມປະໂຫຍກໃສ່ປື້ມປະໂຫຍກ.</translation></message>
++    <message>
++        <source>&amp;New Entry</source>
++        <translation>&amp;ເຂົ້າໃໝ່</translation></message>
++    <message>
++        <source>Click here to remove the entry from the phrase book.</source>
++        <translation>ຄລິກທີ່ນີ້ເພື່ອລຶບລາຍການອອກຈາກປື້ມປະໂຫຍກ.</translation></message>
++    <message>
++        <source>&amp;Remove Entry</source>
++        <translation>&amp;ລຶບລາຍການ</translation></message>
++    <message>
++        <source>Settin&amp;gs...</source>
++        <translation>ຕັ້ງຄ່າ...</translation></message>
++    <message>
++        <source>Click here to save the changes made.</source>
++        <translation>ກົດທີ່ນີ້ເພື່ອບັນທຶກການປ່ຽນແປງທີ່ເຮັດໄວ້.</translation></message>
++    <message>
++        <source>&amp;Save</source>
++        <translation>&amp;ບັນທຶກ</translation></message>
++    <message>
++        <source>Click here to close this window.</source>
++        <translation>ກົດທີ່ນີ້ເພື່ອປິດປ່ອງຢ້ຽມນີ້.</translation></message>
++    <message>
++        <source>Close</source>
++        <translation>ປິດ</translation></message>
++    <message>
++        <source />
++        <comment>Go to Phrase &gt; Edit Phrase Book... The dialog that pops up is a PhraseBookBox.</comment>
++        <translation type="unfinished" /></message>
++    <message>
++        <source>(New Entry)</source>
++        <translation>(ລາຍການໃໝ່)</translation></message>
++    <message>
++        <source>%1[*] - Qt Linguist</source>
++        <translation>%1[*] - Qt ລິງກວິສ</translation></message>
++    <message>
++        <source>Qt Linguist</source>
++        <translation>Qt Linguist</translation></message>
++    <message>
++        <source>Cannot save phrase book '%1'.</source>
++        <translation>ບໍ່ສາມາດບັນທຶກປຶ້ມປະໂຫຍກ '%1' ໄດ້.</translation></message>
++</context>
++<context>
++    <name>PhraseModel</name>
++    <message>
++        <source>Source phrase</source>
++        <translation>ປະໂຫຍກແຫຼ່ງຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Translation</source>
++        <translation>ການແປ</translation></message>
++    <message>
++        <source>Definition</source>
++        <translation>ຄຳຈຳກັດ</translation></message>
++</context>
++<context>
++    <name>PhraseView</name>
++    <message>
++        <source>Insert</source>
++        <translation>ໃສ່</translation></message>
++    <message>
++        <source>Edit</source>
++        <translation>ແກ້ໄຂ</translation></message>
++    <message>
++        <source>Go to</source>
++        <translation>ໄປຫາ</translation></message>
++    <message>
++        <source>Guess from '%1' (%2)</source>
++        <translation>ຄາດເດົາຈາກ '%1' (%2)</translation></message>
++    <message>
++        <source>Guess from '%1'</source>
++        <translation>ຄາດເດົາຈາກ '%1'</translation></message>
++</context>
++<context>
++    <name>QObject</name>
++    <message>
++        <source>Translation files (%1);;</source>
++        <translation>ໄຟລ໌ການແປ (%1);;</translation></message>
++    <message>
++        <source>All files (*)</source>
++        <translation>ທຸກໆໄຟລ໌ (*)</translation></message>
++    <message>
++        <source>Qt Linguist</source>
++        <translation>Qt Linguist</translation></message>
++</context>
++<context>
++    <name>SourceCodeView</name>
++    <message>
++        <source>&lt;i&gt;Source code not available&lt;/i&gt;</source>
++        <translation>&lt;i&gt;ລະຫັດແຫຼ່ງບໍ່ມີ&lt;/i&gt;</translation></message>
++    <message>
++        <source>&lt;i&gt;File %1 not available&lt;/i&gt;</source>
++        <translation>&lt;i&gt;ໄຟລ໌ %1 ບໍ່ມີຢູ່&lt;/i&gt;</translation></message>
++    <message>
++        <source>&lt;i&gt;File %1 not readable&lt;/i&gt;</source>
++        <translation>&lt;i&gt;ໄຟລ໌ %1 ບໍ່ສາມາດອ່ານໄດ້&lt;/i&gt;</translation></message>
++</context>
++<context>
++    <name>Statistics</name>
++    <message>
++        <source>Statistics</source>
++        <translation>ສະຖິຕິ</translation></message>
++    <message>
++        <source>Close</source>
++        <translation>ປິດ</translation></message>
++    <message>
++        <source>Translation</source>
++        <translation>ການແປ</translation></message>
++    <message>
++        <source>Source</source>
++        <translation>ແປເປັນພາສາລາວ: ແຫຼ່ງຂໍ້ມູນ</translation></message>
++    <message>
++        <source>0</source>
++        <translation>0</translation></message>
++    <message>
++        <source>Words:</source>
++        <translation>ຄຳສັບ:</translation></message>
++    <message>
++        <source>Characters:</source>
++        <translation>ຕົວອັກສອນ:</translation></message>
++    <message>
++        <source>Characters (with spaces):</source>
++        <translation>ຕົວອັກສອນ (ພ້ອມຊ່ອງຫວ່າງ):</translation></message>
++</context>
++<context>
++    <name>TranslateDialog</name>
++    <message>
++        <source>This window allows you to search for some text in the translation source file.</source>
++        <translation>ປ່ອງຢ້ຽມນີ້ອະນຸຍາດໃຫ້ທ່ານຄົ້ນຫາຂໍ້ຄວາມບາງສ່ວນໃນໄຟລ໌ແຫຼ່ງການແປ.</translation></message>
++    <message>
++        <source>Type in the text to search for.</source>
++        <translation>ພິມຂໍ້ຄວາມເພື່ອຄົ້ນຫາ.</translation></message>
++    <message>
++        <source>Find &amp;source text:</source>
++        <translation>ຊອກຫາ &amp;source text:</translation></message>
++    <message>
++        <source>&amp;Translate to:</source>
++        <translation>&amp;lt;ແປເປັນພາສາ:</translation></message>
++    <message>
++        <source>Search options</source>
++        <translation>ຕົວເລືອກການຊອກຫາ</translation></message>
++    <message>
++        <source>Texts such as 'TeX' and 'tex' are considered as different when checked.</source>
++        <translation>ຂໍ້ຄວາມເຊັ່ນ 'TeX' ແລະ 'tex' ຖືກພິຈາລະນາເປັນສິ່ງທີ່ແຕກຕ່າງກັນເມື່ອກວດສອບ.</translation></message>
++    <message>
++        <source>Match &amp;case</source>
++        <translation>ກົງກັນ &amp;case</translation></message>
++    <message>
++        <source>Mark new translation as &amp;finished</source>
++        <translation>ໝາຍການແປໃຫມ່ວ່າ &amp;ສໍາເລັດແລ້ວ</translation></message>
++    <message>
++        <source>Click here to find the next occurrence of the text you typed in.</source>
++        <translation>ກົດທີ່ນີ້ເພື່ອຊອກຫາການປະກົດຕົວຕໍ່ໄປຂອງຂໍ້ຄວາມທີ່ທ່ານພິມເຂົ້າ.</translation></message>
++    <message>
++        <source>Find Next</source>
++        <translation>ຊອກຫາຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Translate</source>
++        <translation>ແປ</translation></message>
++    <message>
++        <source>Translate All</source>
++        <translation>ແປທັງໝົດ</translation></message>
++    <message>
++        <source>Click here to close this window.</source>
++        <translation>ກົດທີ່ນີ້ເພື່ອປິດປ່ອງຢ້ຽມນີ້.</translation></message>
++    <message>
++        <source>Cancel</source>
++        <translation>ຍົກເລີກ</translation></message>
++</context>
++<context>
++    <name>TranslationSettingsDialog</name>
++    <message>
++        <source>Source language</source>
++        <translation>ແປເປັນພາສາລາວ: ພາສາຕົ້ນສະບັບ</translation></message>
++    <message>
++        <source>Language</source>
++        <translation>ພາສາ</translation></message>
++    <message>
++        <source>Country/Region</source>
++        <translation>ປະເທດ/ພາກພື້ນ</translation></message>
++    <message>
++        <source>Target language</source>
++        <translation>ພາສາປາຍທາງ</translation></message>
++    <message>
++        <source>%1 (%2)</source>
++        <extracomment>&lt;english&gt; (&lt;endonym&gt;) (language and country names)</extracomment>
++        <translation>%1 (%2)</translation></message>
++    <message>
++        <source>Settings for '%1' - Qt Linguist</source>
++        <translation>ການຕັ້ງຄ່າສໍາລັບ '%1' - Qt Linguist</translation></message>
++    <message>
++        <source>Any Country</source>
++        <translation>ປະເທດໃດກໍ່ໄດ້</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qt_help_lo.ts b/translations/qt_help_lo.ts
+new file mode 100644
+index 0000000..4e8ab9d
+--- /dev/null
++++ b/translations/qt_help_lo.ts
+@@ -0,0 +1,201 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>FilterNameDialogClass</name>
++    <message>
++        <source>Add Filter</source>
++        <translation>ເພີ່ມຕົວກອງ</translation></message>
++    <message>
++        <source>Filter Name:</source>
++        <translation>ຊື່ຕົວກອງ:</translation></message>
++</context>
++<context>
++    <name>QHelp</name>
++    <message>
++        <source>Untitled</source>
++        <translation>ບໍ່ມີຫົວຂໍ້</translation></message>
++</context>
++<context>
++    <name>QHelpCollectionHandler</name>
++    <message>
++        <source>The collection file "%1" is not set up yet.</source>
++        <translation>ຟາຍການລວບລວມ "%1" ຍັງບໍ່ໄດ້ຖືກຕັ້ງຄ່າເທື່ອ.</translation></message>
++    <message>
++        <source>Cannot load sqlite database driver.</source>
++        <translation>ບໍ່ສາມາດໂຫຼດຕົວຂັບຐັງຖານຂໍ້ມູນ sqlite ໄດ້.</translation></message>
++    <message>
++        <source>Cannot open collection file: %1</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ຄົບຄວນ: %1</translation></message>
++    <message>
++        <source>Cannot create tables in file %1.</source>
++        <translation>ບໍ່ສາມາດສ້າງຕາຕະລາງໃນໄຟລ໌ %1 ໄດ້.</translation></message>
++    <message>
++        <source>Cannot create index tables in file %1.</source>
++        <translation>ບໍ່ສາມາດສ້າງຕາຕະລາງດັດຊະນີໃນໄຟລ໌ %1 ໄດ້.</translation></message>
++    <message>
++        <source>Cannot register index tables in file %1.</source>
++        <translation>ບໍ່ສາມາດລົງທະບຽນຕາຕະລາງດັດສະນີໃນໄຟລ໌ %1 ໄດ້.</translation></message>
++    <message>
++        <source>Cannot unregister index tables in file %1.</source>
++        <translation>ບໍ່ສາມາດຍົກເລີກການລົງທະບຽນຕາຕະລາງດັດສະນີໃນໄຟລ໌ %1 ໄດ້.</translation></message>
++    <message>
++        <source>The collection file "%1" already exists.</source>
++        <translation>ໄຟລ໌ຄໍເລັກຊັນ "%1" ມີຢູ່ແລ້ວ.</translation></message>
++    <message>
++        <source>Cannot create directory: %1</source>
++        <translation>ບໍ່ສາມາດສ້າງໂຟນເດີ: %1</translation></message>
++    <message>
++        <source>Cannot copy collection file: %1</source>
++        <translation>ບໍ່ສາມາດສຳເນົາໄຟລ໌ຄອນເລັກຊັນ: %1</translation></message>
++    <message>
++        <source>Unknown filter "%1".</source>
++        <translation>ຕັດການບໍ່ຮູ້ "%1".</translation></message>
++    <message>
++        <source>Cannot register filter %1.</source>
++        <translation>ບໍ່ສາມາດລົງທະບຽນຕົວກອງ %1 ໄດ້.</translation></message>
++    <message>
++        <source>Cannot open documentation file %1.</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ເອກະສານ %1 ໄດ້.</translation></message>
++    <message>
++        <source>Invalid documentation file "%1".</source>
++        <translation>ເອກະສານບໍ່ຖືກຕ້ອງ "%1".</translation></message>
++    <message>
++        <source>The namespace %1 was not registered.</source>
++        <translation>ຊື່ເຂດ %1 ບໍ່ໄດ້ຖືກລົງທະບຽນ.</translation></message>
++    <message>
++        <source>Namespace %1 already exists.</source>
++        <translation>ຊ່ອງຂອງຊື່ %1 ມີຢູ່ແລ້ວ.</translation></message>
++    <message>
++        <source>Cannot register namespace "%1".</source>
++        <translation>ບໍ່ສາມາດລົງທະບຽນ namespace "%1" ໄດ້.</translation></message>
++    <message>
++        <source>Cannot register virtual folder '%1'.</source>
++        <translation>ບໍ່ສາມາດລົງທະບຽນໂຟນເດີ່ສະເພາະ '%1' ໄດ້.</translation></message>
++    <message>
++        <source>Version %1</source>
++        <translation>ລຸ້ນ %1</translation></message>
++</context>
++<context>
++    <name>QHelpDBReader</name>
++    <message>
++        <source>Cannot open database "%1" "%2": %3</source>
++        <extracomment>The placeholders are: %1 - The name of the database which cannot be opened %2 - The unique id for the connection %3 - The actual error string</extracomment>
++        <translation>ບໍ່ສາມາດເປີດຖານຂໍ້ມູນ "%1" "%2": %3</translation></message>
++</context>
++<context>
++    <name>QHelpFilterSettingsWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Filter</source>
++        <translation>ກັ່ນຕອງ</translation></message>
++    <message>
++        <source>Components</source>
++        <translation>ສ່ວນປະກອບ</translation></message>
++    <message>
++        <source>Versions</source>
++        <translation>ລຸ້ນ</translation></message>
++    <message>
++        <source>Add...</source>
++        <translation>ເພີ່ມ...</translation></message>
++    <message>
++        <source>Rename...</source>
++        <translation>ປ່ຽນຊື່...</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Add Filter</source>
++        <translation>ເພີ່ມຕົວກັ່ນຕອງ</translation></message>
++    <message>
++        <source>New Filter</source>
++        <translation>ຕົວກອງໃຫມ່</translation></message>
++    <message>
++        <source>Rename Filter</source>
++        <translation>ປ່ຽນຊື່ຕົວກອງ</translation></message>
++    <message>
++        <source>Remove Filter</source>
++        <translation>ລຶບຕົວກັ່ນຕອງ</translation></message>
++    <message>
++        <source>Are you sure you want to remove the "%1" filter?</source>
++        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການລຶບຕົວກອງ "%1"?</translation></message>
++    <message>
++        <source>Filter Exists</source>
++        <translation>ກັ່ນຕອງມີຢູ່</translation></message>
++    <message>
++        <source>The filter "%1" already exists.</source>
++        <translation>ຕົວກອງ "%1" ມີຢູ່ແລ້ວ.</translation></message>
++    <message>
++        <source>No Component</source>
++        <translation>ບໍ່ມີອົງປະກອບ</translation></message>
++    <message>
++        <source>Invalid Component</source>
++        <translation>ສ່ວນປະກອບບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>No Version</source>
++        <translation>ບໍ່ມີລຸ້ນ</translation></message>
++    <message>
++        <source>Invalid Version</source>
++        <translation>ລູກຄ້າທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QHelpSearchQueryWidget</name>
++    <message>
++        <source>Search for:</source>
++        <translation>ຄົ້ນຫາ:</translation></message>
++    <message>
++        <source>Previous search</source>
++        <translation>ການຄົ້ນຫາກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>Next search</source>
++        <translation>ຄົ້ນຫາຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Search</source>
++        <translation>ຄົ້ນຫາ</translation></message>
++</context>
++<context>
++    <name>QHelpSearchResultWidget</name>
++    <message numerus="yes">
++        <source>%1 - %2 of %n Hits</source>
++        <translation>
++            <numerusform>%1 - %2 ຂອງ %n ການຄົ້ນພົບ</numerusform>
++        </translation></message>
++    <message>
++        <source>0 - 0 of 0 Hits</source>
++        <translation>0 - 0 ຈາກ 0 ການຄົ້ນຫາ</translation></message>
++</context>
++<context>
++    <name>QOptionsWidget</name>
++    <message>
++        <source>No Option</source>
++        <translation>ບໍ່ມີທາງເລືອກ</translation></message>
++    <message>
++        <source>Invalid Option</source>
++        <translation>ທາງເລືອກບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QResultWidget</name>
++    <message>
++        <source>Search Results</source>
++        <translation>ຜົນການຄົ້ນຫາ</translation></message>
++    <message>
++        <source>Note:</source>
++        <translation>ໝາຍເຫດ:</translation></message>
++    <message>
++        <source>The search results may not be complete since the documentation is still being indexed.</source>
++        <translation>ຜົນການຄົ້ນຫາອາດຈະບໍ່ສົມບູນເພາະວ່າເອກະສານຍັງກຳລັງຖືກດັດສະນີ</translation></message>
++    <message>
++        <source>Your search did not match any documents.</source>
++        <translation>ການຄົ້ນຫາຂອງທ່ານບໍ່ກົງກັບເອກະສານໃດໆ.</translation></message>
++    <message>
++        <source>(The reason for this might be that the documentation is still being indexed.)</source>
++        <translation>(ເຫດຜົນສໍາລັບສິ່ງນີ້ອາດຈະເປັນເພາະວ່າເອກະສານຍັງຖືກດັດສະນີຢູ່.)</translation></message>
++</context>
++<context>
++    <name>fulltextsearch::qt::QHelpSearchIndexWriter</name>
++    <message>
++        <source>Cannot open database "%1" using connection "%2": %3</source>
++        <translation>ບໍ່ສາມາດເປີດຖານຂໍ້ມູນ "%1" ໂດຍໃຊ້ການເຊື່ອມຕໍ່ "%2": %3</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qt_lo.ts b/translations/qt_lo.ts
+new file mode 100644
+index 0000000..b698438
+--- /dev/null
++++ b/translations/qt_lo.ts
+@@ -0,0 +1,7 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<dependencies>
++<dependency catalog="qtbase_zh_CN" />
++<dependency catalog="qtmultimedia_zh_CN" />
++</dependencies>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qtbase_lo.ts b/translations/qtbase_lo.ts
+new file mode 100644
+index 0000000..ed7f160
+--- /dev/null
++++ b/translations/qtbase_lo.ts
+@@ -0,0 +1,6075 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>CloseButton</name>
++    <message>
++        <source>Close Tab</source>
++        <translation>ປິດແຖບ</translation></message>
++</context>
++<context>
++    <name>MAC_APPLICATION_MENU</name>
++    <message>
++        <source>About %1</source>
++        <translation>ກ່ຽວກັບ %1</translation></message>
++    <message>
++        <source>Preferences...</source>
++        <translation>ການຕັ້ງຄ່າ...</translation></message>
++    <message>
++        <source>Services</source>
++        <translation>ບໍລິການ</translation></message>
++    <message>
++        <source>Hide %1</source>
++        <translation>ເຊື່ອງ %1</translation></message>
++    <message>
++        <source>Hide Others</source>
++        <translation>ເຊື່ອງອື່ນໆ</translation></message>
++    <message>
++        <source>Show All</source>
++        <translation>ສະແດງທັງໝົດ</translation></message>
++    <message>
++        <source>Quit %1</source>
++        <translation>ອອກຈາກ %1</translation></message>
++</context>
++<context>
++    <name>Print Device Input Slot</name>
++    <message>
++        <source>Automatic</source>
++        <translation>ອັດຕະໂນມັດ</translation></message>
++</context>
++<context>
++    <name>Print Device Output Bin</name>
++    <message>
++        <source>Automatic</source>
++        <translation>ອັດຕະໂນມັດ</translation></message>
++</context>
++<context>
++    <name>QAbstractSocket</name>
++    <message>
++        <source>Socket operation timed out</source>
++        <translation>ການດຳເນີນງານຂອງຊັອກເກັດໝົດເວລາ</translation></message>
++    <message>
++        <source>Operation on socket is not supported</source>
++        <translation>ການດຳເນີນການກ່ຽວກັບ socket ບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation></message>
++    <message>
++        <source>Host not found</source>
++        <translation>ເຈົ້າໂຮສບໍ່ພົບ</translation></message>
++    <message>
++        <source>Connection refused</source>
++        <translation>ການເຊື່ອມຕໍ່ຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>Connection timed out</source>
++        <translation>ການເຊື່ອມຕໍ່ໝົດເວລາ</translation></message>
++    <message>
++        <source>Trying to connect while connection is in progress</source>
++        <translation>ພະຍາຍາມເຊື່ອມຕໍ່ຂະນະທີ່ການເຊື່ອມຕໍ່ກຳລັງດຳເນີນຢູ່</translation></message>
++    <message>
++        <source>Socket is not connected</source>
++        <translation>ຊ໊ອກເກັດບໍ່ໄດ້ເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Network unreachable</source>
++        <translation>ເຄືອຂ່າຍບໍ່ສາມາດເຂົ້າເຖິງໄດ້</translation></message>
++</context>
++<context>
++    <name>QAbstractSpinBox</name>
++    <message>
++        <source>&amp;Select All</source>
++        <translation>&amp;lt;ເລືອກທັງໝົດ&amp;gt;</translation></message>
++    <message>
++        <source>&amp;Step up</source>
++        <translatorcomment>这是数值框的加减按钮</translatorcomment>
++        <translation>&amp;ຂັ້ນຕອນຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Step &amp;down</source>
++        <translatorcomment>这是数值框的加减按钮</translatorcomment>
++        <translation>ຂັ້ນຕອນ &amp;down</translation></message>
++</context>
++<context>
++    <name>QAccessibleActionInterface</name>
++    <message>
++        <source>Press</source>
++        <translation>ກົດ</translation></message>
++    <message>
++        <source>Increase</source>
++        <translation>ເພີ່ມຂຶ້ນ</translation></message>
++    <message>
++        <source>Decrease</source>
++        <translation>ຫຼຸດລົງ</translation></message>
++    <message>
++        <source>ShowMenu</source>
++        <translation>ສະແດງເມນູ</translation></message>
++    <message>
++        <source>SetFocus</source>
++        <translation>ຕັ້ງຈຸດສຸມ</translation></message>
++    <message>
++        <source>Toggle</source>
++        <translation>ປ່ຽນ</translation></message>
++    <message>
++        <source>Scroll Left</source>
++        <translation>ລ່ອນໄປຊ້າຍ</translation></message>
++    <message>
++        <source>Scroll Right</source>
++        <translation>ເລື່ອນໄປທາງຂວາ</translation></message>
++    <message>
++        <source>Scroll Up</source>
++        <translation>ເລື່ອນຂຶ້ນ</translation></message>
++    <message>
++        <source>Scroll Down</source>
++        <translation>ເລື່ອນລົງ</translation></message>
++    <message>
++        <source>Previous Page</source>
++        <translation>ຫນ້າກ່ອນຫນ້າ</translation></message>
++    <message>
++        <source>Next Page</source>
++        <translation>ຫນ້າຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Triggers the action</source>
++        <translation>ກະຕຸ້ນການປະຕິບັດ</translation></message>
++    <message>
++        <source>Increase the value</source>
++        <translation>ເພີ່ມມູນຄ່າ</translation></message>
++    <message>
++        <source>Decrease the value</source>
++        <translation>ຫຼຸດລົງຄ່າ</translation></message>
++    <message>
++        <source>Shows the menu</source>
++        <translation>ສະແດງເມນູ</translation></message>
++    <message>
++        <source>Sets the focus</source>
++        <translation>ຕັ້ງຄ່າໂຟກັດ</translation></message>
++    <message>
++        <source>Toggles the state</source>
++        <translation>ປ່ຽນສະຖານະ</translation></message>
++    <message>
++        <source>Scrolls to the left</source>
++        <translation>ກັບໄປທາງຊ້າຍ</translation></message>
++    <message>
++        <source>Scrolls to the right</source>
++        <translation>ກັບໄປທາງຂວາ</translation></message>
++    <message>
++        <source>Scrolls up</source>
++        <translation>ກັບໄປດ້ານເທິງ</translation></message>
++    <message>
++        <source>Scrolls down</source>
++        <translation>ເລື່ອນລົງ</translation></message>
++    <message>
++        <source>Goes back a page</source>
++        <translation>ກັບຄືນໜ້າກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>Goes to the next page</source>
++        <translation>ໄປຫາໜ້າຕໍ່ໄປ</translation></message>
++</context>
++<context>
++    <name>QAndroidPlatformTheme</name>
++    <message>
++        <source>Yes</source>
++        <translation>ແມ່ນແລ້ວ</translation></message>
++    <message>
++        <source>Yes to All</source>
++        <translation>ແມ່ນສຳລັບທຸກຢ່າງ</translation></message>
++    <message>
++        <source>No</source>
++        <translation>ບໍ່</translation></message>
++    <message>
++        <source>No to All</source>
++        <translation>ບໍ່ຕໍ່ທຸກຢ່າງ</translation></message>
++</context>
++<context>
++    <name>QApplication</name>
++    <message>
++        <source>Executable '%1' requires Qt %2, found Qt %3.</source>
++        <translation>ຟາຍທີ່ສາມາດປະຕິບັດໄດ້ '%1' ຕ້ອງການ Qt %2, ພົບ Qt %3.</translation></message>
++    <message>
++        <source>Incompatible Qt Library Error</source>
++        <translation>ຂໍ້ຜິດພາດຫ້ອງສະໝຸດ Qt ທີ່ບໍ່ສາມາດໃຊ້ຮ່ວມກັນໄດ້</translation></message>
++</context>
++<context>
++    <name>QCocoaMenuItem</name>
++    <message>
++        <source>About Qt</source>
++        <translation>ກ່ຽວກັບ Qt</translation></message>
++    <message>
++        <source>About</source>
++        <translation>ກ່ຽວກັບ</translation></message>
++    <message>
++        <source>Config</source>
++        <translation>ຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>Preference</source>
++        <translation>ການຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>Options</source>
++        <translation>ຕົວເລືອກ</translation></message>
++    <message>
++        <source>Setting</source>
++        <translation>ການຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>Setup</source>
++        <translation>ຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>Quit</source>
++        <translation>ອອກ</translation></message>
++    <message>
++        <source>Exit</source>
++        <translation>ອອກ</translation></message>
++    <message>
++        <source>Cut</source>
++        <translation>ຕັດ</translation></message>
++    <message>
++        <source>Copy</source>
++        <translation>ສຳເນົາ</translation></message>
++    <message>
++        <source>Paste</source>
++        <translation>ວາງ</translation></message>
++    <message>
++        <source>Select All</source>
++        <translation>ເລືອກທັງໝົດ</translation></message>
++</context>
++<context>
++    <name>QCocoaTheme</name>
++    <message>
++        <source>Don't Save</source>
++        <translation>ບໍ່ບັນທຶກ</translation></message>
++</context>
++<context>
++    <name>QColorDialog</name>
++    <message>
++        <source>Hu&amp;e:</source>
++        <translatorcomment>HSV 模型中的 Hue 一般按照 PS 习惯翻译为“色相”。虽然 Hue 也有翻译成色调的，但那更倾向于传统绘画，不应该用在 HSV 这种显然是数字色彩的语境中。“色相”是数码美术界对 Hue 的通用翻译，此翻译已经过色彩管理的多本大学教材核对。</translatorcomment>
++        <translation>ຮູ້:</translation></message>
++    <message>
++        <source>&amp;Sat:</source>
++        <translation>&amp;ເສົາ:</translation></message>
++    <message>
++        <source>&amp;Val:</source>
++        <translatorcomment>HSV 模型中的 Value 一般按照 PS 习惯翻译为明度</translatorcomment>
++        <translation>&amp;Val:</translation></message>
++    <message>
++        <source>&amp;Red:</source>
++        <translatorcomment>通道名称</translatorcomment>
++        <translation>&amp;ສີແດງ:</translation></message>
++    <message>
++        <source>&amp;Green:</source>
++        <translatorcomment>通道名称</translatorcomment>
++        <translation>&amp;ສີຂຽວ:</translation></message>
++    <message>
++        <source>Bl&amp;ue:</source>
++        <translatorcomment>通道名称</translatorcomment>
++        <translation>ຟ້າ:</translation></message>
++    <message>
++        <source>A&amp;lpha channel:</source>
++        <translation>ຊ່ອງອັນຟາ:</translation></message>
++    <message>
++        <source>&amp;HTML:</source>
++        <translation>&amp;lt;HTML:</translation></message>
++    <message>
++        <source>Cursor at %1, %2
++Press ESC to cancel</source>
++        <translation>ເຄີເຊີຢູ່ທີ່ %1, %2
++ກົດ ESC ເພື່ອຍົກເລີກ</translation></message>
++    <message>
++        <source>Select Color</source>
++        <translation>ເລືອກສີ</translation></message>
++    <message>
++        <source>&amp;Basic colors</source>
++        <translation>&amp;ສີພື້ນຖານ</translation></message>
++    <message>
++        <source>&amp;Custom colors</source>
++        <translation>&amp;ສີທີ່ກຳນົດເອງ</translation></message>
++    <message>
++        <source>&amp;Add to Custom Colors</source>
++        <translation>&amp;ເພີ່ມເຂົ້າສີທີ່ກຳນົດເອງ</translation></message>
++    <message>
++        <source>&amp;Pick Screen Color</source>
++        <translation>&amp;ເລືອກສີຈາກຫນ້າຈໍ</translation></message>
++</context>
++<context>
++    <name>QComboBox</name>
++    <message>
++        <source>Open the combo box selection popup</source>
++        <translation>ເປີດປ໊ອບອັບການເລືອກຄອມໂບບອກຊ໌</translation></message>
++    <message>
++        <source>False</source>
++        <translation>ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>True</source>
++        <translation>ຈິງ</translation></message>
++</context>
++<context>
++    <name>QCommandLineParser</name>
++    <message>
++        <source>Displays version information.</source>
++        <translation>ສະແດງຂໍ້ມູນສະບັບ.</translation></message>
++    <message>
++        <source>Displays this help.</source>
++        <translation>ສະແດງຄວາມຊ່ວຍເຫຼືອນີ້.</translation></message>
++    <message>
++        <source>Displays help on commandline options.</source>
++        <translation>ສະແດງຄຳຊ່ວຍເຫຼືອກ່ຽວກັບຕົວເລືອກບັນຊີຄຳສັ່ງ.</translation></message>
++    <message>
++        <source>Displays help including Qt specific options.</source>
++        <translation>ສະແດງຄວາມຊ່ວຍເຫຼືອລວມທັງຕົວເລືອກສະເພາະ Qt.</translation></message>
++    <message>
++        <source>Unknown option '%1'.</source>
++        <translation>ທາງເລືອກ '%1' ທີ່ບໍ່ຮູ້ຈັກ.</translation></message>
++    <message>
++        <source>Unknown options: %1.</source>
++        <translation>ຕົວເລືອກທີ່ບໍ່ຮູ້ຈັກ: %1.</translation></message>
++    <message>
++        <source>Missing value after '%1'.</source>
++        <translation>ຂາດຄ່າຫຼັງຈາກ '%1'.</translation></message>
++    <message>
++        <source>Unexpected value after '%1'.</source>
++        <translation>ຄ່າທີ່ບໍ່ຄາດຄິດຫຼັງຈາກ '%1'.</translation></message>
++    <message>
++        <source>[options]</source>
++        <translation>[ຕົວເລືອກ]</translation></message>
++    <message>
++        <source>Usage: %1</source>
++        <translation>ການນຳໃຊ້: %1</translation></message>
++    <message>
++        <source>Options:</source>
++        <translation>ຕົວເລືອກ:</translation></message>
++    <message>
++        <source>Arguments:</source>
++        <translation>ອາກິວເມັນ:</translation></message>
++</context>
++<context>
++    <name>QCoreApplication</name>
++    <message>
++        <source>%1: key is empty</source>
++        <comment>QSystemSemaphore</comment>
++        <translation>%1: ກະແຈຫວ່າງເປົ່າ</translation></message>
++    <message>
++        <source>%1: unable to make key</source>
++        <comment>QSystemSemaphore</comment>
++        <translation>%1: ບໍ່ສາມາດສ້າງກະແຈໄດ້</translation></message>
++    <message>
++        <source>%1: ftok failed</source>
++        <comment>QSystemSemaphore</comment>
++        <translation>%1: ftok ລົ້ມເຫລວ</translation></message>
++</context>
++<context>
++    <name>QCupsJobWidget</name>
++    <message>
++        <source>Job</source>
++        <translation>ວຽກ</translation></message>
++    <message>
++        <source>Job Control</source>
++        <translation>ການຄວບຄຸມວຽກ</translation></message>
++    <message>
++        <source>Scheduled printing:</source>
++        <translation>ການພິມຕາມຕາຕະລາງ:</translation></message>
++    <message>
++        <source>Billing information:</source>
++        <translation>ຂໍ້ມູນການຊຳລະເງິນ:</translation></message>
++    <message>
++        <source>Job priority:</source>
++        <translation>ຄວາມສຳຄັນຂອງວຽກ:</translation></message>
++    <message>
++        <source>Banner Pages</source>
++        <translation>ໜ້າປະກອບສ່ວນ</translation></message>
++    <message>
++        <source>End:</source>
++        <comment>Banner page at end</comment>
++        <translation>ສິ້ນສຸດ</translation></message>
++    <message>
++        <source>Start:</source>
++        <comment>Banner page at start</comment>
++        <translation>ເລີ່ມຕົ້ນ:</translation></message>
++    <message>
++        <source>Print Immediately</source>
++        <translation>ພິມທັນທີ</translation></message>
++    <message>
++        <source>Hold Indefinitely</source>
++        <translation>ຖືໄວ້ຕະຫຼອດໄປ</translation></message>
++    <message>
++        <source>Day (06:00 to 17:59)</source>
++        <translation>ມື້ (06:00 ເຖິງ 17:59)</translation></message>
++    <message>
++        <source>Night (18:00 to 05:59)</source>
++        <translation>ກາງຄືນ (18:00 ເຖິງ 05:59)</translation></message>
++    <message>
++        <source>Second Shift (16:00 to 23:59)</source>
++        <translation>ການປ່ຽນທີສອງ (16:00 ເຖິງ 23:59)</translation></message>
++    <message>
++        <source>Third Shift (00:00 to 07:59)</source>
++        <translation>ການປ່ຽນທີສາມ (00:00 ເຖິງ 07:59)</translation></message>
++    <message>
++        <source>Weekend (Saturday to Sunday)</source>
++        <translation>ວັນສຸກຫາວັນອາທິດ</translation></message>
++    <message>
++        <source>Specific Time</source>
++        <translation>ເວລາສະເພາະ</translation></message>
++    <message>
++        <source>None</source>
++        <comment>CUPS Banner page</comment>
++        <translation>ບໍ່ມີ</translation></message>
++    <message>
++        <source>Standard</source>
++        <comment>CUPS Banner page</comment>
++        <translation>ມາດຕະຖານ</translation></message>
++    <message>
++        <source>Unclassified</source>
++        <comment>CUPS Banner page</comment>
++        <translation>ບໍ່ໄດ້ຈັດປະເພດ</translation></message>
++    <message>
++        <source>Confidential</source>
++        <comment>CUPS Banner page</comment>
++        <translation>ລັບ</translation></message>
++    <message>
++        <source>Classified</source>
++        <comment>CUPS Banner page</comment>
++        <translation>ຈັດປະເພດ</translation></message>
++    <message>
++        <source>Secret</source>
++        <comment>CUPS Banner page</comment>
++        <translation>ລັບ</translation></message>
++    <message>
++        <source>Top Secret</source>
++        <comment>CUPS Banner page</comment>
++        <translation>ລັບສູງສຸດ</translation></message>
++</context>
++<context>
++    <name>QCupsPrinterSupport</name>
++    <message>
++        <source>Authentication Needed</source>
++        <translation>ການຢືນຢັນຕົວຕ້ອງການ</translation></message>
++    <message>
++        <source>Authentication needed to use %1.</source>
++        <translation>ການຢືນຢັນຕ້ອງການເພື່ອໃຊ້ %1.</translation></message>
++    <message>
++        <source>Authentication needed to use %1 on %2.</source>
++        <translation>ການຢືນຢັນຕ້ອງການເພື່ອໃຊ້ %1 ໃນ %2.</translation></message>
++    <message>
++        <source>Username:</source>
++        <translation>ຊື່ຜູ້ໃຊ້:</translation></message>
++    <message>
++        <source>Password:</source>
++        <translation>ລະຫັດຜ່ານ:</translation></message>
++</context>
++<context>
++    <name>QDB2Driver</name>
++    <message>
++        <source>Unable to connect</source>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ໄດ້</translation></message>
++    <message>
++        <source>Unable to commit transaction</source>
++        <translation>ບໍ່ສາມາດດຳເນີນການທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to rollback transaction</source>
++        <translation>ບໍ່ສາມາດກັບຄືນການເຮັດທຸລະກຳ</translation></message>
++    <message>
++        <source>Unable to set autocommit</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າການສົ່ງຂໍ້ມູນອັດຕະໂນມັດ</translation></message>
++</context>
++<context>
++    <name>QDB2Result</name>
++    <message>
++        <source>Unable to execute statement</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖະແຫຼງ</translation></message>
++    <message>
++        <source>Unable to prepare statement</source>
++        <translation>ບໍ່ສາມາດກະກຽມຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Unable to bind variable</source>
++        <translation>ບໍ່ສາມາດຜູກຕົວແປໄດ້</translation></message>
++    <message>
++        <source>Unable to fetch record %1</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນ %1 ໄດ້</translation></message>
++    <message>
++        <source>Unable to fetch next</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນຕໍ່ໄປໄດ້</translation></message>
++    <message>
++        <source>Unable to fetch first</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນທຳອິດໄດ້</translation></message>
++</context>
++<context>
++    <name>QDBusTrayIcon</name>
++    <message>
++        <source>OK</source>
++        <translation>ຕົກລົງ</translation></message>
++</context>
++<context>
++    <name>QDateTimeParser</name>
++    <message>
++        <source>AM</source>
++        <translation>ອາເມລິກາ</translation></message>
++    <message>
++        <source>am</source>
++        <translation>ອ</translation></message>
++    <message>
++        <source>PM</source>
++        <translation>ປະທານບໍລິຫານ</translation></message>
++    <message>
++        <source>pm</source>
++        <translation>ບໍ່ມີຂໍ້ຄວາມ</translation></message>
++</context>
++<context>
++    <name>QDialog</name>
++    <message>
++        <source>What's This?</source>
++        <translation>ນີ້ແມ່ນຫຍັງ?</translation></message>
++</context>
++<context>
++    <name>QDialogButtonBox</name>
++    <message>
++        <source>OK</source>
++        <translation>ຕົກລົງ</translation></message>
++</context>
++<context>
++    <name>QDirModel</name>
++    <message>
++        <source>Name</source>
++        <translation>ຊື່</translation></message>
++    <message>
++        <source>Size</source>
++        <translation>ຂະໜາດ</translation></message>
++    <message>
++        <source>Kind</source>
++        <comment>Match OS X Finder</comment>
++        <translation>ເມື່ອຍ</translation></message>
++    <message>
++        <source>Type</source>
++        <comment>All other platforms</comment>
++        <translation>ພິມ</translation></message>
++    <message>
++        <source>Date Modified</source>
++        <translation>ວັນທີແກ້ໄຂ</translation></message>
++</context>
++<context>
++    <name>QDnsLookup</name>
++    <message>
++        <source>Operation cancelled</source>
++        <translation>ການດຳເນີນງານຖືກຍົກເລີກ</translation></message>
++</context>
++<context>
++    <name>QDnsLookupRunnable</name>
++    <message>
++        <source>IPv6 addresses for nameservers are currently not supported</source>
++        <translation>ທີ່ຢູ່ IPv6 ສຳລັບ nameservers ປະຈຸບັນບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>Invalid domain name</source>
++        <translation>ຊື່ໂດເມນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Not yet supported on Android</source>
++        <translation>ຍັງບໍ່ທັນສະຫນັບສະຫນູນໃນ Android</translation></message>
++    <message>
++        <source>Resolver functions not found</source>
++        <translation>ຟັງຊັນການແກ້ໄຂບັນຫາບໍ່ພົບ</translation></message>
++    <message>
++        <source>Resolver initialization failed</source>
++        <translation>ການເລີ່ມຕົ້ນຕົວແກ້ໄຂລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Server could not process query</source>
++        <translation>ເຊີບເວີບໍ່ສາມາດປະມວນຜົນຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Server failure</source>
++        <translation>ຄວາມລົ້ມເຫຼວຂອງເຊີບເວີ</translation></message>
++    <message>
++        <source>Non existent domain</source>
++        <translation>ໂດເມນທີ່ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>Server refused to answer</source>
++        <translation>ເຊີບເວີປະຕິເສດທີ່ຈະຕອບ</translation></message>
++    <message>
++        <source>Invalid reply received</source>
++        <translation>ການຕອບກັບທີ່ບໍ່ຖືກຕ້ອງໄດ້ຮັບ</translation></message>
++    <message>
++        <source>Could not expand domain name</source>
++        <translation>ບໍ່ສາມາດຂະຫຍາຍຊື່ໂດເມນໄດ້</translation></message>
++    <message>
++        <source>Invalid IPv4 address record</source>
++        <translation>ບັນທຶກທີ່ຢູ່ IPv4 ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid IPv6 address record</source>
++        <translation>ບັນທຶກທີ່ຢູ່ IPv6 ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid canonical name record</source>
++        <translation>ບັນທຶກຊື່ທີ່ຖືກຕ້ອງບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid name server record</source>
++        <translation>ບັນທຶກເຊີບເວີຊື່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid pointer record</source>
++        <translation>ບັນທຶກຕົວຊີ້ບອກບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid mail exchange record</source>
++        <translation>ບັນທຶກການແລກປ່ຽນອີເມວບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid service record</source>
++        <translation>ບັນທຶກການບໍລິການບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid text record</source>
++        <translation>ບັນທຶກຂໍ້ຄວາມບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Resolver library can't be loaded: No runtime library loading support</source>
++        <translation>ຫໍສະໝຸດຕົວແກ້ໄຂບໍ່ສາມາດໂຫຼດໄດ້: ບໍ່ມີການສະໜັບສະໜູນການໂຫຼດຫໍສະໝຸດລັນໄທມ</translation></message>
++    <message>
++        <source>No hostname given</source>
++        <translation>ບໍ່ມີຊື່ໂຮສຖືກລະບຸ</translation></message>
++    <message>
++        <source>Invalid hostname</source>
++        <translation>ຊື່ໂຮສບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Host %1 could not be found.</source>
++        <translation>ເຄືອຂ່າຍ %1 ບໍ່ສາມາດພົບເຫັນໄດ້.</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QDockWidget</name>
++    <message>
++        <source>Float</source>
++        <extracomment>Accessible name for button undocking a dock widget (floating state)</extracomment>
++        <translation>ລອຍ</translation></message>
++    <message>
++        <source>Undocks and re-attaches the dock widget</source>
++        <translation>ປົດການຕິດຕັ້ງແລະຕິດຕັ້ງຄືນວິດເຈັດທີ່ຕິດຕັ້ງ</translation></message>
++    <message>
++        <source>Close</source>
++        <extracomment>Accessible name for button closing a dock widget</extracomment>
++        <translation>ປິດ</translation></message>
++    <message>
++        <source>Closes the dock widget</source>
++        <translation>ປິດວິດເຈັດທີ່ຕິດຢູ່</translation></message>
++</context>
++<context>
++    <name>QDomParser</name>
++    <message>
++        <source>Error occurred while processing XML declaration</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນການປະກາດ XML</translation></message>
++    <message>
++        <source>Multiple DTD sections are not allowed</source>
++        <translation>ບໍ່ອະນຸຍາດໃຫ້ມີພາກສ່ວນ DTD ຫຼາຍອັນ</translation></message>
++    <message>
++        <source>Error occurred while processing document type declaration</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນປະການປະກາດປະເພດເອກະສານ</translation></message>
++    <message>
++        <source>Error occurred while processing comment</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນຄຳເຫັນ</translation></message>
++    <message>
++        <source>Error occurred while processing a processing instruction</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນຄໍາແນະນໍາການປະມວນຜົນ</translation></message>
++    <message>
++        <source>Error occurred while processing a start element</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນອົງປະກອບເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Unexpected end element '%1'</source>
++        <translation>ອົງປະກອບສິ້ນສຸດທີ່ບໍ່ຄາດຄິດ '%1'</translation></message>
++    <message>
++        <source>Error occurred while processing an end element</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນອົງປະກອບສິ້ນສຸດ</translation></message>
++    <message>
++        <source>Error occurred while processing the element content</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນເນື້ອໃນຂອງອົງປະກອບ</translation></message>
++    <message>
++        <source>Error occurred while processing comments</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະປະມວນຜົນຄຳເຫັນ</translation></message>
++    <message>
++        <source>Error occurred while processing an entity reference</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນການອ້າງອີງເອນທີຕີ</translation></message>
++    <message>
++        <source>Unexpected token</source>
++        <translation>ໂຕເຊັນທີ່ບໍ່ຄາດຄິດ</translation></message>
++    <message>
++        <source>Tag mismatch</source>
++        <translation>ບັນຊີທີ່ບໍ່ກົງກັນ</translation></message>
++    <message>
++        <source>Error occurred while processing entity declaration</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນການປະກາດເອນທິຕີ</translation></message>
++    <message>
++        <source>Error occurred while processing notation declaration</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ປະມວນຜົນການປະກາດສັນຍາລັກ</translation></message>
++</context>
++<context>
++    <name>QDtls</name>
++    <message>
++        <source>Invalid (empty) secret</source>
++        <translation>ບໍ່ຖືກຕ້ອງ (ວ່າງ) ຄວາມລັບ</translation></message>
++    <message>
++        <source>Multicast and broadcast addresses are not supported</source>
++        <translation>ທີ່ຢູ່ສົ່ງຫຼາຍຈຸດ ແລະ ທີ່ຢູ່ອອກອາກາດບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation></message>
++    <message>
++        <source>Cannot set peer after handshake started</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າ peer ຫຼັງຈາກການຈັບມືເລີ່ມຕົ້ນແລ້ວ</translation></message>
++    <message>
++        <source>Invalid address</source>
++        <translation>ທີ່ຢູ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Cannot set verification name after handshake started</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຊື່ການຢັ້ງຢືນຫຼັງຈາກການຈັບມືເລີ່ມຕົ້ນແລ້ວ</translation></message>
++    <message>
++        <source>Cannot set configuration after handshake started</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າການຕັ້ງຄ່າຫຼັງຈາກການຈັບມືເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Cannot start/continue handshake, invalid handshake state</source>
++        <translation>ບໍ່ສາມາດເລີ່ມ/ສືບຕໍ່ການຈັບມືໄດ້, ສະຖານະການຈັບມືບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid (nullptr) socket</source>
++        <translation>ບໍ່ຖືກຕ້ອງ (nullptr) ຊັອກເກັດ</translation></message>
++    <message>
++        <source>To start a handshake you must set peer's address and port first</source>
++        <translation>ເພື່ອເລີ່ມຕົ້ນການຈັບມື, ທ່ານຕ້ອງຕັ້ງທີ່ຢູ່ແລະພອດຂອງຜູ້ເຊື່ອມຕໍ່ກ່ອນ</translation></message>
++    <message>
++        <source>To start a handshake, DTLS server requires non-empty datagram (client hello)</source>
++        <translation>ເພື່ອເລີ່ມຕົ້ນການຈັບມື, ເຊີບເວີ DTLS ຕ້ອງການຂໍ້ມູນທີ່ບໍ່ວ່າງເປົ່າ (ການທັກທາຍຂອງລູກຄ້າ)</translation></message>
++    <message>
++        <source>Cannot start handshake, already done/in progress</source>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນການຈັບມືໄດ້, ໄດ້ເຮັດແລ້ວ/ກຳລັງດຳເນີນຢູ່</translation></message>
++    <message>
++        <source>A valid QUdpSocket and non-empty datagram are needed to continue the handshake</source>
++        <translation>ຕ້ອງມີ QUdpSocket ທີ່ຖືກຕ້ອງ ແລະ ຂໍ້ມູນທີ່ບໍ່ວ່າງເປົ່າເພື່ອດຳເນີນການຈັບມືຕໍ່</translation></message>
++    <message>
++        <source>Cannot continue handshake, not in InProgress state</source>
++        <translation>ບໍ່ສາມາດດຳເນີນການຈັບມືຕໍ່ໄດ້, ບໍ່ຢູ່ໃນສະຖານະ InProgress</translation></message>
++    <message>
++        <source>Cannot resume, not in VerificationError state</source>
++        <translation>ບໍ່ສາມາດດຳເນີນຕໍ່ໄດ້, ບໍ່ຢູ່ໃນສະຖານະຜິດພາດການຢັ້ງຢືນ</translation></message>
++    <message>
++        <source>No handshake in progress, nothing to abort</source>
++        <translation>ບໍ່ມີການຈັບມືກຳລັງດຳເນີນຢູ່, ບໍ່ມີຫຍັງທີ່ຈະຍົກເລີກ</translation></message>
++    <message>
++        <source>Cannot send shutdown alert, not encrypted</source>
++        <translation>ບໍ່ສາມາດສົ່ງການແຈ້ງເຕືອນປິດລະບົບໄດ້, ບໍ່ໄດ້ເຂົ້າລະຫັດ</translation></message>
++    <message>
++        <source>Cannot write a datagram, not in encrypted state</source>
++        <translation>ບໍ່ສາມາດຂຽນດາຕາກຣາມໄດ້, ບໍ່ຢູ່ໃນສະພາບການເຂົ້າລະຫັດ</translation></message>
++    <message>
++        <source>Cannot read a datagram, not in encrypted state</source>
++        <translation>ບໍ່ສາມາດອ່ານຂໍ້ມູນດາຕາກຣາມໄດ້, ບໍ່ຢູ່ໃນສະຖານະທີ່ເຂົ້າລະຫັດ</translation></message>
++    <message>
++        <source>%1 failed</source>
++        <extracomment>%1: Some function</extracomment>
++        <translation>%1 ລົ້ມເຫຼວ</translation></message>
++    <message>
++        <source>Invalid SslMode, SslServerMode or SslClientMode expected</source>
++        <translation>SslMode, SslServerMode ຫຼື SslClientMode ທີ່ບໍ່ຖືກຕ້ອງ ທີ່ຄາດຫວັງ</translation></message>
++    <message>
++        <source>Invalid protocol version, DTLS protocol expected</source>
++        <translation>ລຸ້ນໂປຣໂຕຄອນບໍ່ຖືກຕ້ອງ, ຄາດຫວັງວ່າໂປຣໂຕຄອນ DTLS</translation></message>
++    <message>
++        <source>BIO_ADD_new failed, cannot start handshake</source>
++        <translation>BIO_ADD_new ລົ້ມເຫລວ, ບໍ່ສາມາດເລີ່ມການຈັບມືໄດ້</translation></message>
++    <message>
++        <source>Cannot start the handshake, verified client hello expected</source>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນການຈັບມືໄດ້, ຄາດຫວັງວ່າລູກຄ້າທີ່ຖືກຢັ້ງຢືນຈະສະແດງຄວາມສະບາຍໃຈ</translation></message>
++    <message>
++        <source>Peer verification failed</source>
++        <translation>ການກວດສອບຈາກຜູ້ອື່ນລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>The DTLS connection has been closed</source>
++        <translation>ການເຊື່ອມຕໍ່ DTLS ໄດ້ຖືກປິດແລ້ວ</translation></message>
++    <message>
++        <source>Error while writing: %1</source>
++        <translation>ຜິດພາດໃນຂະນະຂຽນ: %1</translation></message>
++    <message>
++        <source>The DTLS connection has been shutdown</source>
++        <translation>ການເຊື່ອມຕໍ່ DTLS ໄດ້ຖືກປິດລົງແລ້ວ</translation></message>
++    <message>
++        <source>Error while reading: %1</source>
++        <translation>ຜິດພາດໃນການອ່ານ: %1</translation></message>
++</context>
++<context>
++    <name>QDtlsClientVerifier</name>
++    <message>
++        <source>A valid UDP socket, non-empty datagram, valid address/port were expected</source>
++        <translation>ຄາດຫວັງວ່າຈະໄດ້ຮັບ socket UDP ທີ່ຖືກຕ້ອງ, datagram ທີ່ບໍ່ວ່າງເປົ່າ, ທີ່ຢູ່/ພອດ ທີ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>BIO_ADDR_new failed, ignoring client hello</source>
++        <translation>BIO_ADDR_new ລົ້ມເຫລວ, ບໍ່ສົນໃຈການທັກທາຍສະບາຍດີຂອງລູກຄ້າ</translation></message>
++</context>
++<context>
++    <name>QErrorMessage</name>
++    <message>
++        <source>Debug Message:</source>
++        <translation>ຂໍ້ຄວາມດີບັກ:</translation></message>
++    <message>
++        <source>Warning:</source>
++        <translation>ຄຳເຕືອນ:</translation></message>
++    <message>
++        <source>Critical Error:</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ຮ້າຍແຮງ:</translation></message>
++    <message>
++        <source>Fatal Error:</source>
++        <translation>ຂໍ້ຜິດພາດຮ້າຍແຮງ:</translation></message>
++    <message>
++        <source>Information:</source>
++        <translation>ຂໍ້ມູນ:</translation></message>
++    <message>
++        <source>&amp;Show this message again</source>
++        <translation>&amp;lt;ສະແດງຂໍ້ຄວາມນີ້ອີກ&amp;gt;</translation></message>
++    <message>
++        <source>&amp;OK</source>
++        <translation>&amp;ຕົກລົງ</translation></message>
++</context>
++<context>
++    <name>QFile</name>
++    <message>
++        <source>Destination file is the same file.</source>
++        <translation>ໄຟລ໌ປາຍທາງແມ່ນໄຟລ໌ດຽວກັນ.</translation></message>
++    <message>
++        <source>Source file does not exist.</source>
++        <translation>ແຫຼ່ງຂໍ້ມູນບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>Destination file exists</source>
++        <translation>ໄຟລ໌ປາຍທາງມີຢູ່ແລ້ວ</translation></message>
++    <message>
++        <source>Error while renaming: %1</source>
++        <translation>ຜິດພາດໃນການປ່ຽນຊື່: %1</translation></message>
++    <message>
++        <source>Unable to restore from %1: %2</source>
++        <translation>ບໍ່ສາມາດຟື້ນຟູຈາກ %1: %2</translation></message>
++    <message>
++        <source>Will not rename sequential file using block copy</source>
++        <translation>ຈະບໍ່ປ່ຽນຊື່ໄຟລ໌ຕາມລຳດັບໂດຍໃຊ້ການສຳເນົາບລັອກ</translation></message>
++    <message>
++        <source>Cannot remove source file</source>
++        <translation>ບໍ່ສາມາດລຶບໄຟລ໌ແຫຼ່ງຂໍ້ມູນໄດ້</translation></message>
++    <message>
++        <source>Cannot open destination file: %1</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ປາຍທາງ: %1</translation></message>
++    <message>
++        <source>Cannot open %1 for input</source>
++        <translation>ບໍ່ສາມາດເປີດ %1 ສຳລັບການປ້ອນຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Cannot open for output: %1</source>
++        <translation>ບໍ່ສາມາດເປີດສຳລັບຜົນຜະລິດ: %1</translation></message>
++    <message>
++        <source>Cannot open for output</source>
++        <translation>ບໍ່ສາມາດເປີດສຳລັບຜົນຜະລິດ</translation></message>
++    <message>
++        <source>Failure to write block</source>
++        <translation>ບໍ່ສາມາດຂຽນບລັອກໄດ້</translation></message>
++    <message>
++        <source>Cannot create %1 for output</source>
++        <translation>ບໍ່ສາມາດສ້າງ %1 ສຳລັບຜົນຜະລິດ</translation></message>
++</context>
++<context>
++    <name>QFileDevice</name>
++    <message>
++        <source>No file engine available or engine does not support UnMapExtension</source>
++        <translation>ບໍ່ມີເຄື່ອງຈັກໄຟລ໌ທີ່ມີຢູ່ ຫຼື ເຄື່ອງຈັກບໍ່ສະໜັບສະໜູນ UnMapExtension</translation></message>
++    <message>
++        <source>No file engine available</source>
++        <translation>ບໍ່ມີເຄື່ອງຈັກໄຟລ໌ທີ່ມີຢູ່</translation></message>
++</context>
++<context>
++    <name>QFileDialog</name>
++    <message>
++        <source>All Files (*)</source>
++        <translation>ທຸກໆໄຟລ໌ (*)</translation></message>
++    <message>
++        <source>Look in:</source>
++        <translation>ຊອກຫາໃນ:</translation></message>
++    <message>
++        <source>Back</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Go back</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Alt+Left</source>
++        <translation>Alt+ຊ້າຍ</translation></message>
++    <message>
++        <source>Forward</source>
++        <translation>ສົ່ງຕໍ່</translation></message>
++    <message>
++        <source>Go forward</source>
++        <translation>ກ້າວໜ້າ</translation></message>
++    <message>
++        <source>Alt+Right</source>
++        <translation>Alt+ຂວາ</translation></message>
++    <message>
++        <source>Parent Directory</source>
++        <translation>ແມ່ບົດແລະພໍ່ບົດ</translation></message>
++    <message>
++        <source>Go to the parent directory</source>
++        <translation>ໄປທີ່ໂຟນເດີ້ແມ່</translation></message>
++    <message>
++        <source>Alt+Up</source>
++        <translation>Alt+Up</translation></message>
++    <message>
++        <source>Create New Folder</source>
++        <translation>ສ້າງໂຟນເດີໃໝ່</translation></message>
++    <message>
++        <source>Create a New Folder</source>
++        <translation>ສ້າງໂຟນເດີໃໝ່</translation></message>
++    <message>
++        <source>List View</source>
++        <translation>ລາຍການມຸມມອງ</translation></message>
++    <message>
++        <source>Change to list view mode</source>
++        <translation>ປ່ຽນເປັນໂໝດການເບິ່ງແບບລາຍການ</translation></message>
++    <message>
++        <source>Detail View</source>
++        <translation>ມຸມມອງລາຍລະອຽດ</translation></message>
++    <message>
++        <source>Change to detail view mode</source>
++        <translation>ປ່ຽນເປັນໂໝດເບິ່ງລາຍລະອຽດ</translation></message>
++    <message>
++        <source>Sidebar</source>
++        <translation>ແຖບດ້ານຂ້າງ</translation></message>
++    <message>
++        <source>List of places and bookmarks</source>
++        <translation>ລາຍການສະຖານທີ່ ແລະ ບຸກມາກ</translation></message>
++    <message>
++        <source>Files</source>
++        <translation>ຟາຍ</translation></message>
++    <message>
++        <source>Files of type:</source>
++        <translation>ຟາຍປະເພດ:</translation></message>
++    <message>
++        <source>Find Directory</source>
++        <translation>ຊອກຫາໂຟນເດີ</translation></message>
++    <message>
++        <source>Open</source>
++        <translation>ເປີດ</translation></message>
++    <message>
++        <source>Save As</source>
++        <translation>ບັນທຶກເປັນ</translation></message>
++    <message>
++        <source>Directory:</source>
++        <translation>ໂດຍບໍລິສັດ:</translation></message>
++    <message>
++        <source>File &amp;name:</source>
++        <translation>ໄຟລ໌ &amp;name:</translation></message>
++    <message>
++        <source>&amp;Open</source>
++        <translation>&amp;ເປີດ</translation></message>
++    <message>
++        <source>&amp;Choose</source>
++        <translation>&amp;ເລືອກ</translation></message>
++    <message>
++        <source>&amp;Save</source>
++        <translation>&amp;ບັນທຶກ</translation></message>
++    <message>
++        <source>Show </source>
++        <translation>ສະແດງ</translation></message>
++    <message>
++        <source>&amp;Rename</source>
++        <translation>&amp;ປ່ຽນຊື່</translation></message>
++    <message>
++        <source>&amp;Delete</source>
++        <translation>&amp;ລຶບ</translation></message>
++    <message>
++        <source>Show &amp;hidden files</source>
++        <translation>ສະແດງໄຟລ໌ທີ່ເຊື່ອງໄວ້</translation></message>
++    <message>
++        <source>&amp;New Folder</source>
++        <translation>&amp;ໂຟນເດີໃໝ່</translation></message>
++    <message>
++        <source>All files (*)</source>
++        <translation>ທຸກໆໄຟລ໌ (*)</translation></message>
++    <message>
++        <source>Directories</source>
++        <translation>ໂຟນເດີ</translation></message>
++    <message>
++        <source>%1
++Directory not found.
++Please verify the correct directory name was given.</source>
++        <translation>%1
++ບໍ່ພົບໂຟນເດີ.
++ກະລຸນາຢືນຢັນຊື່ໂຟນເດີທີ່ຖືກຕ້ອງໄດ້ຖືກລະບຸ.</translation></message>
++    <message>
++        <source>%1 already exists.
++Do you want to replace it?</source>
++        <translation>%1 ໄດ້ມີຢູ່ແລ້ວ.
++ທ່ານຕ້ອງການທີ່ຈະແທນທີ່ມັນບໍ?</translation></message>
++    <message>
++        <source>%1
++File not found.
++Please verify the correct file name was given.</source>
++        <translation>%1
++ບໍ່ພົບໄຟລ໌.
++ກະລຸນາຢືນຢັນຊື່ໄຟລ໌ທີ່ຖືກຕ້ອງໄດ້ຖືກໃຫ້.</translation></message>
++    <message>
++        <source>New Folder</source>
++        <translation>ໂຟນເດີໃໝ່</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>'%1' is write protected.
++Do you want to delete it anyway?</source>
++        <translation>'%1' ຖືກປົກປ້ອງການຂຽນ.
++ທ່ານຕ້ອງການລຶບມັນແທ້ບໍ?</translation></message>
++    <message>
++        <source>Are you sure you want to delete '%1'?</source>
++        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການລຶບ '%1'?</translation></message>
++    <message>
++        <source>Could not delete directory.</source>
++        <translation>ບໍ່ສາມາດລຶບໂຟນເດີໄດ້.</translation></message>
++    <message>
++        <source>Recent Places</source>
++        <translation>ສະຖານທີ່ຫຼ້າສຸດ</translation></message>
++    <message>
++        <source>Remove</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>My Computer</source>
++        <translation>ຄອມພິວເຕີຂອງຂ້ອຍ</translation></message>
++    <message>
++        <source>Drive</source>
++        <translation>ຂັບລົດ</translation></message>
++    <message>
++        <source>%1 File</source>
++        <extracomment>%1 is a file name suffix, for example txt</extracomment>
++        <translation>%1 ໄຟລ໌</translation></message>
++    <message>
++        <source>File</source>
++        <translation>ໄຟລ໌</translation></message>
++    <message>
++        <source>File Folder</source>
++        <comment>Match Windows Explorer</comment>
++        <translation>ໂຟນເດີ້ຟາຍ</translation></message>
++    <message>
++        <source>Folder</source>
++        <comment>All other platforms</comment>
++        <translation>ໂຟນເດີ</translation></message>
++    <message>
++        <source>Alias</source>
++        <comment>OS X Finder</comment>
++        <translation>ນາມສົມມຸດ</translation></message>
++    <message>
++        <source>Shortcut</source>
++        <comment>All other platforms</comment>
++        <translation>ທາງລັດ</translation></message>
++    <message>
++        <source>Unknown</source>
++        <translation>ບໍ່ຮູ້</translation></message>
++</context>
++<context>
++    <name>QFileSystemModel</name>
++    <message>
++        <source>&lt;b&gt;The name "%1" cannot be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuation marks.</source>
++        <translation>&lt;b&gt;ຊື່ "%1" ບໍ່ສາມາດນຳໃຊ້ໄດ້.&lt;/b&gt;&lt;p&gt;ລອງໃຊ້ຊື່ອື່ນ, ທີ່ມີຕົວອັກສອນໜ້ອຍກວ່າ ຫຼື ບໍ່ມີເຄື່ອງໝາຍວັກຕອນ.</translation></message>
++    <message>
++        <source>Invalid filename</source>
++        <translation>ຊື່ໄຟລ໌ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Name</source>
++        <translation>ຊື່</translation></message>
++    <message>
++        <source>Size</source>
++        <translation>ຂະໜາດ</translation></message>
++    <message>
++        <source>Kind</source>
++        <comment>Match OS X Finder</comment>
++        <translation>ເມື່ອຍ</translation></message>
++    <message>
++        <source>Type</source>
++        <comment>All other platforms</comment>
++        <translation>ພິມ</translation></message>
++    <message>
++        <source>Date Modified</source>
++        <translation>ວັນທີແກ້ໄຂ</translation></message>
++    <message>
++        <source>My Computer</source>
++        <translation>ຄອມພິວເຕີຂອງຂ້ອຍ</translation></message>
++    <message>
++        <source>Computer</source>
++        <translation>ຄອມພິວເຕີ</translation></message>
++</context>
++<context>
++    <name>QFontDatabase</name>
++    <message>
++        <source>Normal</source>
++        <comment>The Normal or Regular font weight</comment>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ປົກກະຕິ</translation></message>
++    <message>
++        <source>Bold</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ໜາ</translation></message>
++    <message>
++        <source>Demi Bold</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ເດມີ ໂບລດ</translation></message>
++    <message>
++        <source>Medium</source>
++        <comment>The Medium font weight</comment>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ປານກາງ</translation></message>
++    <message>
++        <source>Black</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ດໍາ</translation></message>
++    <message>
++        <source>Light</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ແສງສະຫວ່າງ</translation></message>
++    <message>
++        <source>Thin</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ບາງ</translation></message>
++    <message>
++        <source>Extra Light</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ບາງເລັກນ້ອຍ</translation></message>
++    <message>
++        <source>Extra Bold</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>Extra Bold</translation></message>
++    <message>
++        <source>Extra</source>
++        <extracomment>The word for "Extra" as in "Extra Bold, Extra Thin" used as a pattern for string searches</extracomment>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ເພີ່ມເຕີມ</translation></message>
++    <message>
++        <source>Demi</source>
++        <extracomment>The word for "Demi" as in "Demi Bold" used as a pattern for string searches</extracomment>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ເດມີ</translation></message>
++    <message>
++        <source>Italic</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ຕົວເລັກ</translation></message>
++    <message>
++        <source>Oblique</source>
++        <translatorcomment>按照字体教材翻译修订，保留英文是因为西文字体自带的风格只有英文命名，如果只有中文，核对时将异常困难。</translatorcomment>
++        <translation>ອອບລິກ</translation></message>
++    <message>
++        <source>Any</source>
++        <translation>ໃດໆ</translation></message>
++    <message>
++        <source>Latin</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ລາຕິນ</translation></message>
++    <message>
++        <source>Greek</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ກະຣິກ</translation></message>
++    <message>
++        <source>Cyrillic</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ອັກສອນຊີຣິວລິກ</translation></message>
++    <message>
++        <source>Armenian</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ອາມິເນຍ</translation></message>
++    <message>
++        <source>Hebrew</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ພາສາເຮບຣິວ</translation></message>
++    <message>
++        <source>Arabic</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ອາຣັບ</translation></message>
++    <message>
++        <source>Syriac</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ຊີເຣຍ</translation></message>
++    <message>
++        <source>Thaana</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ທານາ</translation></message>
++    <message>
++        <source>Devanagari</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ດີວານາກາຣີ</translation></message>
++    <message>
++        <source>Bengali</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ບັງກະລາ</translation></message>
++    <message>
++        <source>Gurmukhi</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ກຸມຸກີ</translation></message>
++    <message>
++        <source>Gujarati</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ກູຈາຣາຕີ</translation></message>
++    <message>
++        <source>Oriya</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ໂອຣິຍາ</translation></message>
++    <message>
++        <source>Tamil</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ພາສາທະມິນ</translation></message>
++    <message>
++        <source>Telugu</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ເປັນພາສາທີ່ເວົ້າໃນພາກໃຕ້ຂອງອິນເດຍ</translation></message>
++    <message>
++        <source>Kannada</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ກັນນາດາ</translation></message>
++    <message>
++        <source>Malayalam</source>
++        <translation>ມາລາຢາລັມ</translation></message>
++    <message>
++        <source>Sinhala</source>
++        <translation>ສິນຫາລາ</translation></message>
++    <message>
++        <source>Thai</source>
++        <translation>ພາສາໄທ</translation></message>
++    <message>
++        <source>Lao</source>
++        <translation>ພາສາລາວ</translation></message>
++    <message>
++        <source>Tibetan</source>
++        <translation>ທິເບດ</translation></message>
++    <message>
++        <source>Myanmar</source>
++        <translation>ມຽນມາ</translation></message>
++    <message>
++        <source>Georgian</source>
++        <translation>ຈໍເຈຍ</translation></message>
++    <message>
++        <source>Khmer</source>
++        <translation>ຂະແມ</translation></message>
++    <message>
++        <source>Simplified Chinese</source>
++        <translation>ຈີນທີ່ງ່າຍດາຍ</translation></message>
++    <message>
++        <source>Traditional Chinese</source>
++        <translation>ຈີນດັ້ງເດີມ</translation></message>
++    <message>
++        <source>Japanese</source>
++        <translation>ພາສາຍີ່ປຸ່ນ</translation></message>
++    <message>
++        <source>Korean</source>
++        <translation>ພາສາເກົາຫຼີ</translation></message>
++    <message>
++        <source>Vietnamese</source>
++        <translation>ຫວຽດນາມ</translation></message>
++    <message>
++        <source>Symbol</source>
++        <translation>ສັນຍາລັກ</translation></message>
++    <message>
++        <source>Ogham</source>
++        <translation>ໂອກາມ</translation></message>
++    <message>
++        <source>Runic</source>
++        <translation>ລູນິກ</translation></message>
++    <message>
++        <source>N'Ko</source>
++        <translation>N'Ko</translation></message>
++</context>
++<context>
++    <name>QFontDialog</name>
++    <message>
++        <source>Select Font</source>
++        <translation>ເລືອກຟອນ</translation></message>
++    <message>
++        <source>&amp;Font</source>
++        <translation>&amp;ຟອນ</translation></message>
++    <message>
++        <source>Font st&amp;yle</source>
++        <translation>ຮູບແບບຕົວອັກສອນ</translation></message>
++    <message>
++        <source>&amp;Size</source>
++        <translation>&amp;ຂະໜາດ</translation></message>
++    <message>
++        <source>Effects</source>
++        <translation>ຜົນກະທົບ</translation></message>
++    <message>
++        <source>Stri&amp;keout</source>
++        <translation>ຂີດຂ້າມ</translation></message>
++    <message>
++        <source>&amp;Underline</source>
++        <translation>&amp;ຂີດຂັ້ນລຸ່ມ</translation></message>
++    <message>
++        <source>Sample</source>
++        <translation>ຕົວຢ່າງ</translation></message>
++    <message>
++        <source>Wr&amp;iting System</source>
++        <translatorcomment>按照 unicode 码表标准名称统一译名</translatorcomment>
++        <translation>ລະບົບການຂຽນ</translation></message>
++</context>
++<context>
++    <name>QFtp</name>
++    <message>
++        <source>Not connected</source>
++        <translation>ບໍ່ໄດ້ເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Host %1 not found</source>
++        <translation>ໂຮສ %1 ບໍ່ພົບ</translation></message>
++    <message>
++        <source>Connection refused to host %1</source>
++        <translation>ການເຊື່ອມຕໍ່ຖືກປະຕິເສດເຂົ້າຫາເຈົ້າພາບ %1</translation></message>
++    <message>
++        <source>Connection timed out to host %1</source>
++        <translation>ການເຊື່ອມຕໍ່ໝົດເວລາໄປຍັງເຈົ້າພາບ %1</translation></message>
++    <message>
++        <source>Connected to host %1</source>
++        <translation>ເຊື່ອມຕໍ່ກັບເຈົ້າໜ້າທີ່ %1</translation></message>
++    <message>
++        <source>Data Connection refused</source>
++        <translation>ການເຊື່ອມຕໍ່ຂໍ້ມູນຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Connecting to host failed:
++%1</source>
++        <translation>ເຊື່ອມຕໍ່ກັບໂຮສຕ໌ບໍ່ສຳເລັດ:
++%1</translation></message>
++    <message>
++        <source>Login failed:
++%1</source>
++        <translation>ເຂົ້າສູ່ລະບົບບໍ່ສຳເລັດ:
++%1</translation></message>
++    <message>
++        <source>Listing directory failed:
++%1</source>
++        <translation>ບັນຊີໂຄງການລາຍຊື່ລົ້ມເຫລວ:
++%1</translation></message>
++    <message>
++        <source>Changing directory failed:
++%1</source>
++        <translation>ປ່ຽນໂຟນເດີບໍ່ສຳເລັດ:
++%1</translation></message>
++    <message>
++        <source>Downloading file failed:
++%1</source>
++        <translation>ດາວໂຫຼດໄຟລ໌ລົ້ມເຫລວ:
++%1</translation></message>
++    <message>
++        <source>Uploading file failed:
++%1</source>
++        <translation>ອັບໂຫຼດໄຟລ໌ລົ້ມເຫຼວ:
++%1</translation></message>
++    <message>
++        <source>Removing file failed:
++%1</source>
++        <translation>ລົບໄຟລ໌ບໍ່ສຳເລັດ:
++%1</translation></message>
++    <message>
++        <source>Creating directory failed:
++%1</source>
++        <translation>ສ້າງໂຟນເດີບໍ່ສຳເລັດ:
++%1</translation></message>
++    <message>
++        <source>Removing directory failed:
++%1</source>
++        <translation>ການລຶບໂຟນເດີລົ້ມເຫລວ:
++%1</translation></message>
++    <message>
++        <source>Connection closed</source>
++        <translation>ການເຊື່ອມຕໍ່ຖືກປິດ</translation></message>
++</context>
++<context>
++    <name>QGnomeTheme</name>
++    <message>
++        <source>&amp;OK</source>
++        <translation>&amp;ຕົກລົງ</translation></message>
++    <message>
++        <source>&amp;Save</source>
++        <translation>&amp;ບັນທຶກ</translation></message>
++    <message>
++        <source>&amp;Cancel</source>
++        <translation>&amp;ຍົກເລີກ</translation></message>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;ປິດ</translation></message>
++    <message>
++        <source>Close without Saving</source>
++        <translation>ປິດໂດຍບໍ່ບັນທຶກ</translation></message>
++</context>
++<context>
++    <name>QGuiApplication</name>
++    <message>
++        <source>QT_LAYOUT_DIRECTION</source>
++        <comment>Translate this string to the string 'LTR' in left-to-right languages or to 'RTL' in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
++        <translation>QT_LAYOUT_DIRECTION</translation></message>
++    <message>
++        <source>QPA plugin. See QGuiApplication documentation for available options for each plugin.</source>
++        <translation>ປລັກອິນ QPA. ເບິ່ງເອກະສານ QGuiApplication ສຳລັບຕົວເລືອກທີ່ມີຢູ່ສຳລັບແຕ່ລະປລັກອິນ.</translation></message>
++    <message>
++        <source>Path to the platform plugins.</source>
++        <translation>ເສັ້ນທາງໄປຫາແພັດຟອມປັກອິນ.</translation></message>
++    <message>
++        <source>Platform theme.</source>
++        <translation>ຫົວຂໍ້ຂອງແພລດຟອມ.</translation></message>
++    <message>
++        <source>Additional plugins to load, can be specified multiple times.</source>
++        <translation>ປລັກອິນເພີ່ມເຕີມທີ່ຈະໂຫຼດ, ສາມາດກຳນົດໄດ້ຫຼາຍຄັ້ງ.</translation></message>
++    <message>
++        <source>Window geometry for the main window, using the X11-syntax, like 100x100+50+50.</source>
++        <translation>ຂະໜາດຂອງປ່ອງຢ້ຽມຫຼັກ, ໃຊ້ສັນຍາລັກ X11, ເຊັ່ນ 100x100+50+50.</translation></message>
++    <message>
++        <source>Default window icon.</source>
++        <translation>ໄອຄອນປ່ອງຢ້ຽມເລີ່ມຕົ້ນ.</translation></message>
++    <message>
++        <source>Title of the first window.</source>
++        <translation>ຫົວຂໍ້ຂອງປ່ອງຢ້ຽມທຳອິດ.</translation></message>
++    <message>
++        <source>Sets the application's layout direction to Qt::RightToLeft (debugging helper).</source>
++        <translation>ຕັ້ງທິດທາງການຈັດແບບຂອງແອັບພລິເຄຊັນເປັນ Qt::RightToLeft (ເຄື່ອງມືຊ່ວຍໃນການດີບັກ).</translation></message>
++    <message>
++        <source>Restores the application from an earlier session.</source>
++        <translation>ຟື້ນຟູແອັບພລິເຄຊັນຈາກເຊດຊັນກ່ອນໜ້າ.</translation></message>
++    <message>
++        <source>Display name, overrides $DISPLAY.</source>
++        <translation>ຊື່ທີ່ສະແດງ, ທົດແທນ $DISPLAY.</translation></message>
++    <message>
++        <source>Instance name according to ICCCM 4.1.2.5.</source>
++        <translation>ຊື່ຕົວຢ່າງຕາມ ICCCM 4.1.2.5.</translation></message>
++    <message>
++        <source>Disable mouse grabbing (useful in debuggers).</source>
++        <translation>ປິດການຈັບເມົາ (ເປັນປະໂຫຍດໃນການດີບັກ).</translation></message>
++    <message>
++        <source>Force mouse grabbing (even when running in a debugger).</source>
++        <translation>ບັງຄັບໃຫ້ຈັບເມົາ (ເຖິງແມ່ນວ່າກຳລັງແລ່ນໃນ debugger).</translation></message>
++    <message>
++        <source>ID of the X11 Visual to use.</source>
++        <translation>ID ຂອງ X11 Visual ທີ່ຈະໃຊ້.</translation></message>
++    <message>
++        <source>Alias for --windowgeometry.</source>
++        <translation>ຊື່ຫຍໍ້ສໍາລັບ --windowgeometry.</translation></message>
++    <message>
++        <source>Alias for --windowicon.</source>
++        <translation>ຊື່ຫຍໍ້ສຳລັບ --windowicon.</translation></message>
++    <message>
++        <source>Alias for --windowtitle.</source>
++        <translation>ຊື່ຫຍໍ້ສໍາລັບ --windowtitle.</translation></message>
++</context>
++<context>
++    <name>QHostInfo</name>
++    <message>
++        <source>No host name given</source>
++        <translation>ບໍ່ມີຊື່ໂຮສຖືກລະບຸ</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QHostInfoAgent</name>
++    <message>
++        <source>No host name given</source>
++        <translation>ບໍ່ມີຊື່ໂຮສຖືກລະບຸ</translation></message>
++    <message>
++        <source>Invalid hostname</source>
++        <translation>ຊື່ໂຮສບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Unknown address type</source>
++        <translation>ປະເພດທີ່ຢູ່ທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Host not found</source>
++        <translation>ໂຮສບໍ່ພົບ</translation></message>
++    <message>
++        <source>Unknown error (%1)</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ (%1)</translation></message>
++</context>
++<context>
++    <name>QHttp</name>
++    <message>
++        <source>Connection closed</source>
++        <translation>ການເຊື່ອມຕໍ່ຖືກປິດ</translation></message>
++    <message>
++        <source>Host %1 not found</source>
++        <translation>ໂຮສ %1 ບໍ່ພົບ</translation></message>
++    <message>
++        <source>Connection refused</source>
++        <translation>ການເຊື່ອມຕໍ່ຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>Proxy requires authentication</source>
++        <translation>ພຣອກຊີຕ້ອງການການຢືນຢັນຕົວຕົນ</translation></message>
++    <message>
++        <source>Host requires authentication</source>
++        <translation>ເຈົ້າໂຮສຕ໌ຕ້ອງການການຢືນຢັນຕົວຕົນ</translation></message>
++    <message>
++        <source>Data corrupted</source>
++        <translation>ຂໍ້ມູນຖືກທໍາລາຍ</translation></message>
++    <message>
++        <source>Unknown protocol specified</source>
++        <translation>ບໍ່ຮູ້ກັບໂປຣໂຕຄໍທີ່ລະບຸໄວ້</translation></message>
++    <message>
++        <source>SSL handshake failed</source>
++        <translation>ການຈັບມື SSL ລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Too many redirects</source>
++        <translation>ການໂອນທີ່ຫຼາຍເກີນໄປ</translation></message>
++    <message>
++        <source>Insecure redirect</source>
++        <translation>ການໂອນທີ່ບໍ່ປອດໄພ</translation></message>
++</context>
++<context>
++    <name>QHttpSocketEngine</name>
++    <message>
++        <source>Did not receive HTTP response from proxy</source>
++        <translation>ບໍ່ໄດ້ຮັບການຕອບສະໜອງ HTTP ຈາກ proxy</translation></message>
++    <message>
++        <source>Error parsing authentication request from proxy</source>
++        <translation>ຜິດພາດໃນການວິເຄາະຄຳຂໍການຢັ້ງຢືນຈາກພຣອກຊີ</translation></message>
++    <message>
++        <source>Authentication required</source>
++        <translation>ຕ້ອງການການຢືນຢັນຕົວຕົນ</translation></message>
++    <message>
++        <source>Proxy denied connection</source>
++        <translation>ພຣອກຊີປະຕິເສດການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Error communicating with HTTP proxy</source>
++        <translation>ຜິດພາດໃນການຕິດຕໍ່ກັບ HTTP proxy</translation></message>
++    <message>
++        <source>Proxy server not found</source>
++        <translation>ບໍ່ພົບເຊີບເວີພຣອກຊີ</translation></message>
++    <message>
++        <source>Proxy connection refused</source>
++        <translation>ການເຊື່ອມຕໍ່ພຣອກຊີຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>Proxy server connection timed out</source>
++        <translation>ການເຊື່ອມຕໍ່ໂປຣກຊີເຊີບເວີໝົດເວລາ</translation></message>
++    <message>
++        <source>Proxy connection closed prematurely</source>
++        <translation>ການເຊື່ອມຕໍ່ພຣອກຊີຖືກປິດກ່ອນເວລາ</translation></message>
++</context>
++<context>
++    <name>QIBaseDriver</name>
++    <message>
++        <source>Error opening database</source>
++        <translation>ຜິດພາດໃນການເປີດຖານຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Could not start transaction</source>
++        <translation>ບໍ່ສາມາດເລີ່ມທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to commit transaction</source>
++        <translation>ບໍ່ສາມາດສົ່ງການເຮັດທຸລະກຳ</translation></message>
++    <message>
++        <source>Unable to rollback transaction</source>
++        <translation>ບໍ່ສາມາດກັບຄືນການເຮັດທຸລະກຳ</translation></message>
++</context>
++<context>
++    <name>QIBaseResult</name>
++    <message>
++        <source>Unable to create BLOB</source>
++        <translation>ບໍ່ສາມາດສ້າງ BLOB ໄດ້</translation></message>
++    <message>
++        <source>Unable to write BLOB</source>
++        <translation>ບໍ່ສາມາດຂຽນ BLOB</translation></message>
++    <message>
++        <source>Unable to open BLOB</source>
++        <translation>ບໍ່ສາມາດເປີດ BLOB ໄດ້</translation></message>
++    <message>
++        <source>Unable to read BLOB</source>
++        <translation>ບໍ່ສາມາດອ່ານ BLOB ໄດ້</translation></message>
++    <message>
++        <source>Could not find array</source>
++        <translation>ບໍ່ສາມາດຊອກຫາແອຣ໌ເລຍໄດ້</translation></message>
++    <message>
++        <source>Could not get array data</source>
++        <translation>ບໍ່ສາມາດເອົາຂໍ້ມູນອາເຣໄດ້</translation></message>
++    <message>
++        <source>Could not get query info</source>
++        <translation>ບໍ່ສາມາດເກັບຂໍ້ມູນຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Could not start transaction</source>
++        <translation>ບໍ່ສາມາດເລີ່ມທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to commit transaction</source>
++        <translation>ບໍ່ສາມາດສົ່ງການເຮັດທຸລະກຳ</translation></message>
++    <message>
++        <source>Could not allocate statement</source>
++        <translation>ບໍ່ສາມາດຈັດສະເພາະຄຳຖະແຫຼງ</translation></message>
++    <message>
++        <source>Could not prepare statement</source>
++        <translation>ບໍ່ສາມາດກະກຽມຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Could not describe input statement</source>
++        <translation>ບໍ່ສາມາດອະທິບາຍຄຳຖາມປ້ອນຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Could not describe statement</source>
++        <translation>ບໍ່ສາມາດອະທິບາຍຄຳຖະແຫຼງ</translation></message>
++    <message>
++        <source>Unable to close statement</source>
++        <translation>ບໍ່ສາມາດປິດຄຳຖະແຫຼງທີ່ໄດ້</translation></message>
++    <message>
++        <source>Unable to execute query</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Could not fetch next item</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນລາຍການຕໍ່ໄປໄດ້</translation></message>
++    <message>
++        <source>Could not get statement info</source>
++        <translation>ບໍ່ສາມາດເກັບຂໍ້ມູນຄຳຖະແຫຼງ</translation></message>
++</context>
++<context>
++    <name>QIODevice</name>
++    <message>
++        <source>file to open is a directory</source>
++        <translation>ໄຟລ໌ທີ່ຈະເປີດແມ່ນໂຟນເດີ</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Permission denied</source>
++        <translation>ອະນຸຍາດຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>Too many open files</source>
++        <translation>ໄຟລ໌ເປີດຫຼາຍເກີນໄປ</translation></message>
++    <message>
++        <source>No such file or directory</source>
++        <translation>ບໍ່ມີໄຟລ໌ ຫຼື ໂຟນເດີນັ້ນ</translation></message>
++    <message>
++        <source>No space left on device</source>
++        <translation>ບໍ່ມີພື້ນທີ່ເຫຼືອໃນອຸປະກອນ</translation></message>
++</context>
++<context>
++    <name>QImageReader</name>
++    <message>
++        <source>Invalid device</source>
++        <translation>ອຸປະກອນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>File not found</source>
++        <translation>ບໍ່ພົບໄຟລ໌</translation></message>
++    <message>
++        <source>Unsupported image format</source>
++        <translation>ຮູບແບບຮູບພາບບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>Unable to read image data</source>
++        <translation>ບໍ່ສາມາດອ່ານຂໍ້ມູນຮູບພາບໄດ້</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QImageWriter</name>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Device is not set</source>
++        <translation>ອຸປະກອນບໍ່ໄດ້ຖືກຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>Cannot open device for writing: %1</source>
++        <translation>ບໍ່ສາມາດເປີດອຸປະກອນສຳລັບການຂຽນໄດ້: %1</translation></message>
++    <message>
++        <source>Device not writable</source>
++        <translation>ອຸປະກອນບໍ່ສາມາດຂຽນໄດ້</translation></message>
++    <message>
++        <source>Unsupported image format</source>
++        <translation>ຮູບແບບຮູບພາບບໍ່ຖືກຮອງຮັບ</translation></message>
++    <message>
++        <source>Image is empty</source>
++        <translation>ຮູບພາບຫວ່າງເປົ່າ</translation></message>
++</context>
++<context>
++    <name>QInputDialog</name>
++    <message>
++        <source>Enter a value:</source>
++        <translation>ປ້ອນຄ່າ:</translation></message>
++</context>
++<context>
++    <name>QJsonParseError</name>
++    <message>
++        <source>no error occurred</source>
++        <translation>ບໍ່ມີຂໍ້ຜິດພາດເກີດຂຶ້ນ</translation></message>
++    <message>
++        <source>unterminated object</source>
++        <translation>ວັດຖຸທີ່ບໍ່ສິ້ນສຸດ</translation></message>
++    <message>
++        <source>missing name separator</source>
++        <translation>ຂາດຕົວຄັດແຍກຊື່</translation></message>
++    <message>
++        <source>unterminated array</source>
++        <translation>ອາເຣທີ່ບໍ່ສິ້ນສຸດ</translation></message>
++    <message>
++        <source>missing value separator</source>
++        <translation>ຄ່າທີ່ຂາດຫາຍໄປ</translation></message>
++    <message>
++        <source>illegal value</source>
++        <translation>ຄ່າທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>invalid termination by number</source>
++        <translation>ການຢຸດຕິດຕາມທີ່ບໍ່ຖືກຕ້ອງໂດຍຈຳນວນ</translation></message>
++    <message>
++        <source>illegal number</source>
++        <translation>ເລກທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>invalid escape sequence</source>
++        <translation>ລຳດັບການຫນີທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>invalid UTF8 string</source>
++        <translation>ສະຕຣິງ UTF8 ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>unterminated string</source>
++        <translation>ສະຕຣິງທີ່ບໍ່ສິ້ນສຸດ</translation></message>
++    <message>
++        <source>object is missing after a comma</source>
++        <translation>ວັດຖຸຫາຍໄປຫຼັງຈາກຈຸດ</translation></message>
++    <message>
++        <source>too deeply nested document</source>
++        <translation>ເອກະສານທີ່ຊ້ອນກັນເລິກເກີນໄປ</translation></message>
++    <message>
++        <source>too large document</source>
++        <translation>ເອກະສານໃຫຍ່ເກີນໄປ</translation></message>
++    <message>
++        <source>garbage at the end of the document</source>
++        <translation>ຂີ້ເຫຍື້ອຢູ່ທ້າຍເອກະສານ</translation></message>
++</context>
++<context>
++    <name>QKeySequenceEdit</name>
++    <message>
++        <source>Press shortcut</source>
++        <translation>ກົດທາງລັດ</translation></message>
++    <message>
++        <source>%1, ...</source>
++        <extracomment>This text is an "unfinished" shortcut, expands like "Ctrl+A, ..."</extracomment>
++        <translation>%1, ...</translation></message>
++</context>
++<context>
++    <name>QLibrary</name>
++    <message>
++        <source>'%1' is not an ELF object (%2)</source>
++        <translation>'%1' ບໍ່ແມ່ນວັດຖຸ ELF (%2)</translation></message>
++    <message>
++        <source>file too small</source>
++        <translation>ໄຟລ໌ນ້ອຍເກີນໄປ</translation></message>
++    <message>
++        <source>'%1' is not an ELF object</source>
++        <translation>'%1' ບໍ່ແມ່ນວັດຖຸ ELF</translation></message>
++    <message>
++        <source>'%1' is an invalid ELF object (%2)</source>
++        <translation>'%1' ແມ່ນວັດຖຸ ELF ທີ່ບໍ່ຖືກຕ້ອງ (%2)</translation></message>
++    <message>
++        <source>odd cpu architecture</source>
++        <translation>ສະຖາປັດຕະຍະກຳ CPU ທີ່ບໍ່ປົກກະຕິ</translation></message>
++    <message>
++        <source>wrong cpu architecture</source>
++        <translation>ສຳລັບສະຖາປັດຕະຍະກຳ CPU ທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>odd endianness</source>
++        <translation>ຄວາມແປກປະຫຼາດຂອງລະບົບຈັດລຽງຂໍ້ມູນ</translation></message>
++    <message>
++        <source>unexpected e_shsize</source>
++        <translation>ບໍ່ຄາດຄິດ e_shsize</translation></message>
++    <message>
++        <source>unexpected e_shentsize</source>
++        <translation>ບໍ່ຄາດຄິດ e_shentsize</translation></message>
++    <message numerus="yes">
++        <source>announced %n section(s), each %1 byte(s), exceed file size</source>
++        <translation>
++            <numerusform>ປະກາດ %n ພາກ, ແຕ່ລະພາກ %1 ໄບຕ໌, ເກີນຂະໜາດໄຟລ໌</numerusform>
++        </translation></message>
++    <message>
++        <source>shstrtab section header seems to be at %1</source>
++        <translation>ສ່ວນຫົວຂໍ້ shstrtab ເບິ່ງຄືວ່າຢູ່ທີ່ %1</translation></message>
++    <message>
++        <source>string table seems to be at %1</source>
++        <translation>ຕາຕະລາງສະຕຣິງເບິ່ງຄືວ່າຢູ່ທີ່ %1</translation></message>
++    <message>
++        <source>section name %1 of %2 behind end of file</source>
++        <translation>ພາກສ່ວນຊື່ %1 ຂອງ %2 ຢູ່ຫຼັງສຸດຂອງໄຟລ໌</translation></message>
++    <message>
++        <source>empty .rodata. not a library.</source>
++        <translation>ຫວ່າງເປົ່າ .rodata. ບໍ່ແມ່ນຫໍສະໝຸດ.</translation></message>
++    <message>
++        <source>missing section data. This is not a library.</source>
++        <translation>ຂໍ້ມູນພາກສ່ວນທີ່ຂາດຫາຍໄປ. ນີ້ບໍ່ແມ່ນຫໍສະໝຸດ.</translation></message>
++    <message>
++        <source>Failed to extract plugin meta data from '%1'</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນ meta ຂອງ plugin ຈາກ '%1'</translation></message>
++    <message>
++        <source>The shared library was not found.</source>
++        <translation>ຫໍສະໝຸດທີ່ແບ່ງປັນບໍ່ພົບເຫັນ.</translation></message>
++    <message>
++        <source>The file '%1' is not a valid Qt plugin.</source>
++        <translation>ໄຟລ໌ '%1' ບໍ່ແມ່ນປລັອກອິນ Qt ທີ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>The plugin '%1' uses incompatible Qt library. (%2.%3.%4) [%5]</source>
++        <translation>ປລັອກອິນ '%1' ໃຊ້ຄອບບັນຊີ Qt ທີ່ບໍ່ສາມາດໃຊ້ຮ່ວມກັນໄດ້. (%2.%3.%4) [%5]</translation></message>
++    <message>
++        <source>The plugin '%1' uses incompatible Qt library. (Cannot mix debug and release libraries.)</source>
++        <translation>ປລັອກອິນ '%1' ໃຊ້ຄອບບັນຊີ Qt ທີ່ບໍ່ສາມາດໃຊ້ຮ່ວມກັນໄດ້. (ບໍ່ສາມາດປະສົມຄອບບັນຊີ debug ແລະ release ໄດ້.)</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Cannot load library %1: %2</source>
++        <translation>ບໍ່ສາມາດໂຫຼດຫໍສະໝຸດ %1: %2</translation></message>
++    <message>
++        <source>Cannot unload library %1: %2</source>
++        <translation>ບໍ່ສາມາດຖອນຫໍສະໝຸດ %1: %2</translation></message>
++    <message>
++        <source>Cannot resolve symbol "%1" in %2: %3</source>
++        <translation>ບໍ່ສາມາດແກ້ໄຂສັນຍາລັກ "%1" ໃນ %2: %3</translation></message>
++    <message>
++        <source>'%1' is not a valid Mach-O binary (%2)</source>
++        <translation>'%1' ບໍ່ແມ່ນໄຟລ໌ Mach-O ທີ່ຖືກຕ້ອງ (%2)</translation></message>
++    <message>
++        <source>file is corrupt</source>
++        <translation>ໄຟລ໌ເສຍຫາຍ</translation></message>
++    <message>
++        <source>no suitable architecture in fat binary</source>
++        <translation>ບໍ່ມີໂຄງສ້າງທີ່ເໝາະສົມໃນໄຟລ໌ຖານຂໍ້ມູນໄຂມັນ</translation></message>
++    <message>
++        <source>invalid magic %1</source>
++        <translation>ບໍ່ຖືກຕ້ອງ magic %1</translation></message>
++    <message>
++        <source>wrong architecture</source>
++        <translation>ສະຖາປັດຕະຍະກຳຜິດ</translation></message>
++    <message>
++        <source>not a dynamic library</source>
++        <translation>ບໍ່ແມ່ນຫໍສະໝຸດແບບໄດນາມິກ</translation></message>
++    <message>
++        <source>'%1' is not a Qt plugin</source>
++        <translation>'%1' ບໍ່ແມ່ນແພລກອິນ Qt</translation></message>
++</context>
++<context>
++    <name>QLineEdit</name>
++    <message>
++        <source>&amp;Undo</source>
++        <translation>&amp;ກັບຄືນ</translation></message>
++    <message>
++        <source>&amp;Redo</source>
++        <translation>&amp;ດໍາເນີນການຄືນໃໝ່</translation></message>
++    <message>
++        <source>Cu&amp;t</source>
++        <translation>ຕັດ</translation></message>
++    <message>
++        <source>&amp;Copy</source>
++        <translation>&amp;ສຳເນົາ</translation></message>
++    <message>
++        <source>&amp;Paste</source>
++        <translation>&amp;ວາງ</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Select All</source>
++        <translation>ເລືອກທັງໝົດ</translation></message>
++</context>
++<context>
++    <name>QLocalServer</name>
++    <message>
++        <source>%1: Name error</source>
++        <translation>%1: ຂໍ້ຜິດພາດຊື່</translation></message>
++    <message>
++        <source>%1: Permission denied</source>
++        <translation>%1: ບໍ່ອະນຸຍາດ</translation></message>
++    <message>
++        <source>%1: Address in use</source>
++        <translation>%1: ທີ່ຢູ່ກຳລັງໃຊ້ຢູ່</translation></message>
++    <message>
++        <source>%1: Unknown error %2</source>
++        <translation>%1: ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ %2</translation></message>
++</context>
++<context>
++    <name>QLocalSocket</name>
++    <message>
++        <source>%1: Connection refused</source>
++        <translation>%1: ການເຊື່ອມຕໍ່ຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>%1: Remote closed</source>
++        <translation>%1: ການເຊື່ອມຕໍ່ທາງໄກຖືກປິດ</translation></message>
++    <message>
++        <source>%1: Invalid name</source>
++        <translation>%1: ຊື່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>%1: Socket access error</source>
++        <translation>%1: ຂໍ້ຜິດພາດໃນການເຂົ້າເຖິງຊັອກເກັດ</translation></message>
++    <message>
++        <source>%1: Socket resource error</source>
++        <translation>%1: ຂໍ້ຜິດພາດຊັອກເກັດ</translation></message>
++    <message>
++        <source>%1: Socket operation timed out</source>
++        <translation>%1: ການດຳເນີນງານຂອງຊັອກເກັດໝົດເວລາ</translation></message>
++    <message>
++        <source>%1: Datagram too large</source>
++        <translation>%1: ຂໍ້ມູນດາຕາກຣາມໃຫຍ່ເກີນໄປ</translation></message>
++    <message>
++        <source>%1: Connection error</source>
++        <translation>%1: ຂໍ້ຜິດພາດການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>%1: The socket operation is not supported</source>
++        <translation>%1: ການດຳເນີນງານຂອງຊັອກເກັດບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation></message>
++    <message>
++        <source>%1: Operation not permitted when socket is in this state</source>
++        <translation>%1: ການດຳເນີນງານບໍ່ອະນຸຍາດໃນເວລາທີ່ຊັອກເກັດຢູ່ໃນສະພາບນີ້</translation></message>
++    <message>
++        <source>%1: Unknown error</source>
++        <translation>%1: ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Trying to connect while connection is in progress</source>
++        <translation>ພະຍາຍາມເຊື່ອມຕໍ່ຂະນະທີ່ການເຊື່ອມຕໍ່ກຳລັງດຳເນີນຢູ່</translation></message>
++    <message>
++        <source>%1: Unknown error %2</source>
++        <translation>%1: ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ %2</translation></message>
++    <message>
++        <source>%1: Access denied</source>
++        <translation>%1: ການເຂົ້າເຖິງຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>Socket is not connected</source>
++        <translation>ຊ໊ອກເກັດບໍ່ໄດ້ເຊື່ອມຕໍ່</translation></message>
++</context>
++<context>
++    <name>QMYSQLDriver</name>
++    <message>
++        <source>Unable to allocate a MYSQL object</source>
++        <translation>ບໍ່ສາມາດຈັດສັນວັດຖຸ MYSQL ໄດ້</translation></message>
++    <message>
++        <source>Unable to open database '%1'</source>
++        <translation>ບໍ່ສາມາດເປີດຖານຂໍ້ມູນ '%1' ໄດ້</translation></message>
++    <message>
++        <source>Unable to connect</source>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ໄດ້</translation></message>
++    <message>
++        <source>Unable to begin transaction</source>
++        <translation>ບໍ່ສາມາດເລີ່ມທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to commit transaction</source>
++        <translation>ບໍ່ສາມາດດຳເນີນການທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to rollback transaction</source>
++        <translation>ບໍ່ສາມາດກັບຄືນການເຮັດທຸລະກຳ</translation></message>
++</context>
++<context>
++    <name>QMYSQLResult</name>
++    <message>
++        <source>Unable to fetch data</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນໄດ້</translation></message>
++    <message>
++        <source>Unable to execute query</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Unable to store result</source>
++        <translation>ບໍ່ສາມາດເກັບຮັກຜົນໄດ້</translation></message>
++    <message>
++        <source>Unable to execute next query</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖາມຕໍ່ໄປໄດ້</translation></message>
++    <message>
++        <source>Unable to store next result</source>
++        <translation>ບໍ່ສາມາດເກັບຮັກສາຜົນໄດ້ຮັບຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Unable to prepare statement</source>
++        <translation>ບໍ່ສາມາດກະກຽມຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Unable to reset statement</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າຄຳຖະແຫຼງຄືນໃໝ່ໄດ້</translation></message>
++    <message>
++        <source>Unable to bind value</source>
++        <translation>ບໍ່ສາມາດຜູກມູນຄ່າໄດ້</translation></message>
++    <message>
++        <source>Unable to execute statement</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖະແຫຼງ</translation></message>
++    <message>
++        <source>Unable to bind outvalues</source>
++        <translation>ບໍ່ສາມາດຜູກມູນຄ່າອອກໄດ້</translation></message>
++    <message>
++        <source>Unable to store statement results</source>
++        <translation>ບໍ່ສາມາດເກັບຮັກສາຜົນການສະທ້ອນ</translation></message>
++</context>
++<context>
++    <name>QMdiArea</name>
++    <message>
++        <source>(Untitled)</source>
++        <translation>(ບໍ່ມີຊື່)</translation></message>
++</context>
++<context>
++    <name>QMdiSubWindow</name>
++    <message>
++        <source>- [%1]</source>
++        <translation>- [%1]</translation></message>
++    <message>
++        <source>%1 - [%2]</source>
++        <translation>%1 - [%2]</translation></message>
++    <message>
++        <source>Minimize</source>
++        <translation>ຫຼຸດຂະໜາດນ້ອຍສຸດ</translation></message>
++    <message>
++        <source>Maximize</source>
++        <translation>ເພີ່ມຂະຫຍາຍໃຫ້ໃຫຍ່ທີ່ສຸດ</translation></message>
++    <message>
++        <source>Unshade</source>
++        <translatorcomment>根据我翻译窗口管理器时的经验来看，可能是点击后将窗体缩成只有一个标题栏的操作。Shade 指的是百叶窗，模仿百叶窗收起。</translatorcomment>
++        <translation>ບໍ່ມີຮົ່ມ</translation></message>
++    <message>
++        <source>Shade</source>
++        <translatorcomment>根据我翻译窗口管理器时的经验来看，可能是点击后将窗体缩成只有一个标题栏的操作。Shade 指的是百叶窗，模仿百叶窗收起。</translatorcomment>
++        <translation>ເງົາ</translation></message>
++    <message>
++        <source>Restore Down</source>
++        <translation>ຟື້ນຟູລົງ</translation></message>
++    <message>
++        <source>Restore</source>
++        <translation>ຟື້ນຟູ</translation></message>
++    <message>
++        <source>Close</source>
++        <translation>ປິດ</translation></message>
++    <message>
++        <source>Help</source>
++        <translation>ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>Menu</source>
++        <translation>ເມນູ</translation></message>
++    <message>
++        <source>&amp;Restore</source>
++        <translation>&amp;ຟື້ນຟູ</translation></message>
++    <message>
++        <source>&amp;Move</source>
++        <translation>&amp;ຍ້າຍ</translation></message>
++    <message>
++        <source>&amp;Size</source>
++        <translation>&amp;ຂະໜາດ</translation></message>
++    <message>
++        <source>Mi&amp;nimize</source>
++        <translation>ຫຼຸດຂະໜາດນ້ອຍສຸດ</translation></message>
++    <message>
++        <source>Ma&amp;ximize</source>
++        <translation>ເພີ່ມຂະຫຍາຍໃຫ້ໃຫຍ່ທີ່ສຸດ</translation></message>
++    <message>
++        <source>Stay on &amp;Top</source>
++        <translation>ຢູ່ເທິງ &amp;Top</translation></message>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;ປິດ</translation></message>
++</context>
++<context>
++    <name>QMessageBox</name>
++    <message>
++        <source>Show Details...</source>
++        <translation>ສະແດງລາຍລະອຽດ...</translation></message>
++    <message>
++        <source>Hide Details...</source>
++        <translation>ຊ່ອນລາຍລະອຽດ...</translation></message>
++    <message>
++        <source>&lt;h3&gt;About Qt&lt;/h3&gt;&lt;p&gt;This program uses Qt version %1.&lt;/p&gt;</source>
++        <translation>&lt;h3&gt;ກ່ຽວກັບ Qt&lt;/h3&gt;&lt;p&gt;ໂປຣແກຣມນີ້ໃຊ້ Qt ເວີຊັນ %1.&lt;/p&gt;</translation></message>
++    <message>
++        <source>&lt;p&gt;Qt is a C++ toolkit for cross-platform application development.&lt;/p&gt;&lt;p&gt;Qt provides single-source portability across all major desktop operating systems. It is also available for embedded Linux and other embedded and mobile operating systems.&lt;/p&gt;&lt;p&gt;Qt is available under multiple licensing options designed to accommodate the needs of our various users.&lt;/p&gt;&lt;p&gt;Qt licensed under our commercial license agreement is appropriate for development of proprietary/commercial software where you do not want to share any source code with third parties or otherwise cannot comply with the terms of GNU (L)GPL.&lt;/p&gt;&lt;p&gt;Qt licensed under GNU (L)GPL is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the respective licenses.&lt;/p&gt;&lt;p&gt;Please see &lt;a href="http://%2/"&gt;%2&lt;/a&gt; for an overview of Qt licensing.&lt;/p&gt;&lt;p&gt;Copyright (C) %1 The Qt Company Ltd and other contributors.&lt;/p&gt;&lt;p&gt;Qt and the Qt logo are trademarks of The Qt Company Ltd.&lt;/p&gt;&lt;p&gt;Qt is The Qt Company Ltd product developed as an open source project. See &lt;a href="http://%3/"&gt;%3&lt;/a&gt; for more information.&lt;/p&gt;</source>
++        <extracomment>Leave this text untranslated or include a verbatim copy of it below and note that it is the authoritative version in case of doubt.</extracomment>
++        <translatorcomment>此段文本原本已被翻译为中文，并在此次提交前进行过改进，但在此次提交的讨论中认为这是法律文本，且原有的翻译从未经过 Qt Company 审核，是不安全的，因此决定不作翻译。</translatorcomment>
++        <translation>&lt;p&gt;Qt ເປັນຊຸດເຄື່ອງມື C++ ສຳລັບການພັດທະນາແອັບພລິເຄຊັນຂ້າມແພັດຟອມ.&lt;/p&gt;&lt;p&gt;Qt ສະໜອງການພົດພິໄສດ້ວຍແຫຼ່ງດຽວຂ້າມທົ່ວລະບົບປະຕິບັດການເດັສທັອບຫຼັກທັງໝົດ. ມັນຍັງມີສຳລັບ Linux ທີ່ຝັງຕົວ ແລະ ລະບົບປະຕິບັດການທີ່ຝັງຕົວ ແລະ ໂມບາຍອື່ນໆ.&lt;/p&gt;&lt;p&gt;Qt ມີຢູ່ພາຍໃຕ້ຕົວເລືອກໃບອະນຸຍາດຫຼາຍຮູບແບບ ທີ່ອອກແບບມາເພື່ອຮອງຮັບຄວາມຕ້ອງການຂອງຜູ້ໃຊ້ງານທີ່ຫຼາກຫຼາຍຂອງພວກເຮົາ.&lt;/p&gt;&lt;p&gt;Qt ທີ່ໃຫ້ໃບອະນຸຍາດພາຍໃຕ້ຂໍ້ຕົກລົງໃບອະນຸຍາດທຸລະກິດຂອງພວກເຮົາ ແມ່ນເໝາະສົມກັບການພັດທະນາໂປຣແກຣມທຸລະກິດ/ທຸລະກິດສ່ວນຕົວ ທີ່ທ່ານບໍ່ຕ້ອງການແບ່ງປັນແຫຼ່ງຂໍ້ມູນໃດໆກັບພາກສ່ວນທີສາມ ຫຼື ບໍ່ສາມາດປະຕິບັດຕາມເງື່ອນໄຂຂອງ GNU (L)GPL ໄດ້.&lt;/p&gt;&lt;p&gt;Qt ທີ່ໃຫ້ໃບອະນຸຍາດພາຍໃຕ້ GNU (L)GPL ແມ່ນເໝາະສົມກັບການພັດທະນາແອັບພລິເຄຊັນ Qt ຕາບໃດທີ່ທ່ານສາມາດປະຕິບັດຕາມເງື່ອນໄຂ ແລະ ຂໍ້ກຳນົດຂອງໃບອະນຸຍາດທີ່ກ່ຽວຂ້ອງ.&lt;/p&gt;&lt;p&gt;ກະລຸນາເບິ່ງ &lt;a href="http://%2/"&gt;%2&lt;/a&gt; ສຳລັບພາບລວມຂອງການໃຫ້ໃບອະນຸຍາດ Qt.&lt;/p&gt;&lt;p&gt;ລິຂະສິດ (C) %1 ບໍລິສັດ Qt ຈຳກັດ ແລະ ຜູ້ປະກອບສ່ວນອື່ນໆ.&lt;/p&gt;&lt;p&gt;Qt ແລະ ໂລໂກ້ Qt ແມ່ນເຄື່ອງໝາຍການຄ້າຂອງບໍລິສັດ Qt ຈຳກັດ.&lt;/p&gt;&lt;p&gt;Qt ເປັນຜະລິດຕະພັນຂອງບໍລິສັດ Qt ຈຳກັດ ທີ່ພັດທະນາເປັນໂຄງການແຫຼ່ງເປີດ. ເບິ່ງ &lt;a href="http://%3/"&gt;%3&lt;/a&gt; ສຳລັບຂໍ້ມູນເພີ່ມເຕີມ.&lt;/p&gt;</translation></message>
++    <message>
++        <source>About Qt</source>
++        <translation>ກ່ຽວກັບ Qt</translation></message>
++</context>
++<context>
++    <name>QNativeSocketEngine</name>
++    <message>
++        <source>Unable to initialize non-blocking socket</source>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນຊັອກເກັດທີ່ບໍ່ມີການຂັດຂວາງ</translation></message>
++    <message>
++        <source>Unable to initialize broadcast socket</source>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນຊັອກເກັດການອອກອາກາດ</translation></message>
++    <message>
++        <source>Attempt to use IPv6 socket on a platform with no IPv6 support</source>
++        <translation>ພະຍາຍາມໃຊ້ຊັອກເກັດ IPv6 ໃນແພລດຟອມທີ່ບໍ່ມີການສະໜັບສະໜູນ IPv6</translation></message>
++    <message>
++        <source>The remote host closed the connection</source>
++        <translation>ໂຮສຕົ້ນທາງອື່ນປິດການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Network operation timed out</source>
++        <translation>ການດຳເນີນງານເຄືອຂ່າຍໝົດເວລາ</translation></message>
++    <message>
++        <source>Out of resources</source>
++        <translation>ຂາດແຫຼ່ງຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>Unsupported socket operation</source>
++        <translation>ການດຳເນີນງານຊັອກເກັດບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>Protocol type not supported</source>
++        <translation>ປະເພດຂໍ້ຕົກລົງບໍ່ຖືກຮັບຮອງ</translation></message>
++    <message>
++        <source>Invalid socket descriptor</source>
++        <translation>ຕົວບັນທຶກຊ໊ອກເກັດບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Host unreachable</source>
++        <translation>ໂຮສບບໍ່ສາມາດເຂົ້າເຖິງໄດ້</translation></message>
++    <message>
++        <source>Network unreachable</source>
++        <translation>ເຄືອຂ່າຍບໍ່ສາມາດເຂົ້າເຖິງໄດ້</translation></message>
++    <message>
++        <source>Permission denied</source>
++        <translation>ອະນຸຍາດຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>Connection timed out</source>
++        <translation>ການເຊື່ອມຕໍ່ໝົດເວລາ</translation></message>
++    <message>
++        <source>Connection refused</source>
++        <translation>ການເຊື່ອມຕໍ່ຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>The bound address is already in use</source>
++        <translation>ທີ່ຢູ່ທີ່ຜູກມັດແມ່ນຖືກໃຊ້ແລ້ວ</translation></message>
++    <message>
++        <source>The address is not available</source>
++        <translation>ທີ່ຢູ່ບໍ່ມີ</translation></message>
++    <message>
++        <source>The address is protected</source>
++        <translation>ທີ່ຢູ່ໄດ້ຮັບການປົກປ້ອງ</translation></message>
++    <message>
++        <source>Datagram was too large to send</source>
++        <translation>ຂໍ້ມູນດາດາກຣາມໃຫຍ່ເກີນໄປສຳລັບການສົ່ງ</translation></message>
++    <message>
++        <source>Unable to send a message</source>
++        <translation>ບໍ່ສາມາດສົ່ງຂໍ້ຄວາມໄດ້</translation></message>
++    <message>
++        <source>Unable to receive a message</source>
++        <translation>ບໍ່ສາມາດຮັບຂໍ້ຄວາມໄດ້</translation></message>
++    <message>
++        <source>Unable to write</source>
++        <translation>ບໍ່ສາມາດຂຽນໄດ້</translation></message>
++    <message>
++        <source>Network error</source>
++        <translation>ຂໍ້ຜິດພາດເຄືອຂ່າຍ</translation></message>
++    <message>
++        <source>Another socket is already listening on the same port</source>
++        <translation>ຊັອກເກັດອື່ນແມ່ນກຳລັງຟັງຢູ່ແລ້ວໃນພອດດຽວກັນ</translation></message>
++    <message>
++        <source>Operation on non-socket</source>
++        <translation>ການດຳເນີນການກ່ຽວກັບທີ່ບໍ່ແມ່ນຊ໊ອກເກັດ</translation></message>
++    <message>
++        <source>The proxy type is invalid for this operation</source>
++        <translation>ປະເພດຂອງພຣອກຊີບໍ່ຖືກຕ້ອງສຳລັບການດຳເນີນງານນີ້</translation></message>
++    <message>
++        <source>Temporary error</source>
++        <translation>ຜິດພາດຊົ່ວຄາວ</translation></message>
++    <message>
++        <source>Network dropped connection on reset</source>
++        <translation>ເຄືອຂ່າຍຕັດການເຊື່ອມຕໍ່ໃນການຕັ້ງຄ່າໃຫມ່</translation></message>
++    <message>
++        <source>Connection reset by peer</source>
++        <translation>ການເຊື່ອມຕໍ່ຖືກຣີເຊັດໂດຍຜູ້ໃຊ້ຮ່ວມ</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QNetworkAccessCacheBackend</name>
++    <message>
++        <source>Error opening %1</source>
++        <translation>ຜິດພາດໃນການເປີດ %1</translation></message>
++</context>
++<context>
++    <name>QNetworkAccessDataBackend</name>
++    <message>
++        <source>Invalid URI: %1</source>
++        <translation>URI ບໍ່ຖືກຕ້ອງ: %1</translation></message>
++</context>
++<context>
++    <name>QNetworkAccessDebugPipeBackend</name>
++    <message>
++        <source>Write error writing to %1: %2</source>
++        <translation>ຂຽນຂໍ້ຜິດພາດໃນການຂຽນໄປຫາ %1: %2</translation></message>
++    <message>
++        <source>Socket error on %1: %2</source>
++        <translation>ຂໍ້ຜິດພາດຂອງຊັອກເກັດໃນ %1: %2</translation></message>
++    <message>
++        <source>Remote host closed the connection prematurely on %1</source>
++        <translation>ເຄືອຂ່າຍຫ່າງໄກປິດການເຊື່ອມຕໍ່ກ່ອນເວລາທີ່ %1</translation></message>
++</context>
++<context>
++    <name>QNetworkAccessFileBackend</name>
++    <message>
++        <source>Request for opening non-local file %1</source>
++        <translation>ຮ້ອງຂໍເປີດໄຟລ໌ທີ່ບໍ່ແມ່ນທ້ອງຖິ່ນ %1</translation></message>
++    <message>
++        <source>Error opening %1: %2</source>
++        <translation>ຜິດພາດໃນການເປີດ %1: %2</translation></message>
++    <message>
++        <source>Write error writing to %1: %2</source>
++        <translation>ຂຽນຂໍ້ຜິດພາດໃນການຂຽນໄປຫາ %1: %2</translation></message>
++    <message>
++        <source>Cannot open %1: Path is a directory</source>
++        <translation>ບໍ່ສາມາດເປີດ %1: ເສັ້ນທາງເປັນໂຟນເດີ</translation></message>
++    <message>
++        <source>Read error reading from %1: %2</source>
++        <translation>ອ່ານຜິດພາດອ່ານຈາກ %1: %2</translation></message>
++</context>
++<context>
++    <name>QNetworkAccessFtpBackend</name>
++    <message>
++        <source>No suitable proxy found</source>
++        <translation>ບໍ່ພົບໂປຣກຊີທີ່ເໝາະສົມ</translation></message>
++    <message>
++        <source>Cannot open %1: is a directory</source>
++        <translation>ບໍ່ສາມາດເປີດ %1: ເປັນໂຟນເດີ</translation></message>
++    <message>
++        <source>Logging in to %1 failed: authentication required</source>
++        <translation>ເຂົ້າສູ່ລະບົບ %1 ລົ້ມເຫລວ: ຕ້ອງການການຢືນຢັນ</translation></message>
++    <message>
++        <source>Error while downloading %1: %2</source>
++        <translation>ຜິດພາດໃນຂະນະທີ່ກຳລັງດາວໂຫຼດ %1: %2</translation></message>
++    <message>
++        <source>Error while uploading %1: %2</source>
++        <translation>ຜິດພາດໃນການອັບໂຫຼດ %1: %2</translation></message>
++</context>
++<context>
++    <name>QNetworkAccessManager</name>
++    <message>
++        <source>Network access is disabled.</source>
++        <translation>ການເຂົ້າເຖິງເຄືອຂ່າຍຖືກປິດໃຊ້ງານ.</translation></message>
++</context>
++<context>
++    <name>QNetworkReply</name>
++    <message>
++        <source>Error transferring %1 - server replied: %2</source>
++        <translation>ຜິດພາດໃນການໂອນ %1 - ເຊີບເວີຕອບກັບ: %2</translation></message>
++    <message>
++        <source>Network session error.</source>
++        <translation>ຂໍ້ຜິດພາດໃນການເຊື່ອມຕໍ່ເຄືອຂ່າຍ.</translation></message>
++    <message>
++        <source>Background request not allowed.</source>
++        <translation>ການຮ້ອງຂໍພື້ນຫຼັງບໍ່ອະນຸຍາດ.</translation></message>
++    <message>
++        <source>backend start error.</source>
++        <translation>ຂໍ້ຜິດພາດເລີ່ມຕົ້ນດ້ານຫຼັງ.</translation></message>
++    <message>
++        <source>Temporary network failure.</source>
++        <translation>ຄວາມລົ້ມເຫຼວຂອງເຄືອຂ່າຍຊົ່ວຄາວ.</translation></message>
++    <message>
++        <source>Protocol "%1" is unknown</source>
++        <translation>ພິທັກໂຄນ "%1" ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QNetworkReplyHttpImpl</name>
++    <message>
++        <source>Operation canceled</source>
++        <translation>ການດຳເນີນງານຖືກຍົກເລີກ</translation></message>
++    <message>
++        <source>No suitable proxy found</source>
++        <translation>ບໍ່ພົບໂປຣກຊີທີ່ເໝາະສົມ</translation></message>
++</context>
++<context>
++    <name>QNetworkReplyImpl</name>
++    <message>
++        <source>Operation canceled</source>
++        <translation>ການດຳເນີນງານຖືກຍົກເລີກ</translation></message>
++</context>
++<context>
++    <name>QNetworkSession</name>
++    <message>
++        <source>Invalid configuration.</source>
++        <translation>ການຕັ້ງຄ່າບໍ່ຖືກຕ້ອງ.</translation></message>
++</context>
++<context>
++    <name>QNetworkSessionPrivateImpl</name>
++    <message>
++        <source>Unknown session error.</source>
++        <translation>ຂໍ້ຜິດພາດກ່ຽວກັບຊີຊັນທີ່ບໍ່ຮູ້ຈັກ.</translation></message>
++    <message>
++        <source>The session was aborted by the user or system.</source>
++        <translation>ເຊສຊັນຖືກຍົກເລີກໂດຍຜູ້ໃຊ້ຫຼືລະບົບ.</translation></message>
++    <message>
++        <source>The requested operation is not supported by the system.</source>
++        <translation>ການດຳເນີນການທີ່ຮ້ອງຂໍບໍ່ໄດ້ຮັບການສະໜັບສະໜູນຈາກລະບົບ.</translation></message>
++    <message>
++        <source>The specified configuration cannot be used.</source>
++        <translation>ການຕັ້ງຄ່າທີ່ລະບຸໄວ້ບໍ່ສາມາດນຳໃຊ້ໄດ້.</translation></message>
++    <message>
++        <source>Roaming was aborted or is not possible.</source>
++        <translation>ການໃຊ້ບໍລິການຮອມມິງຖືກຍົກເລີກ ຫຼື ບໍ່ສາມາດໃຊ້ໄດ້.</translation></message>
++</context>
++<context>
++    <name>QOCIDriver</name>
++    <message>
++        <source>Unable to initialize</source>
++        <comment>QOCIDriver</comment>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນໄດ້</translation></message>
++    <message>
++        <source>Unable to logon</source>
++        <translation>ບໍ່ສາມາດເຂົ້າສູ່ລະບົບໄດ້</translation></message>
++    <message>
++        <source>Unable to begin transaction</source>
++        <translation>ບໍ່ສາມາດເລີ່ມທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to commit transaction</source>
++        <translation>ບໍ່ສາມາດດຳເນີນການທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to rollback transaction</source>
++        <translation>ບໍ່ສາມາດກັບຄືນການເຮັດທຸລະກຳ</translation></message>
++</context>
++<context>
++    <name>QOCIResult</name>
++    <message>
++        <source>Unable to bind column for batch execute</source>
++        <translation>ບໍ່ສາມາດຜູກມັດຖັນສຳລັບການປະຕິບັດແບບຊຸດ</translation></message>
++    <message>
++        <source>Unable to execute batch statement</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳສັ່ງແບບຊຸດໄດ້</translation></message>
++    <message>
++        <source>Unable to goto next</source>
++        <translation>ບໍ່ສາມາດໄປຕໍ່ໄດ້</translation></message>
++    <message>
++        <source>Unable to alloc statement</source>
++        <translation>ບໍ່ສາມາດຈັດສະແດງຄຳຖະແຫຼງ</translation></message>
++    <message>
++        <source>Unable to prepare statement</source>
++        <translation>ບໍ່ສາມາດກະກຽມຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Unable to get statement type</source>
++        <translation>ບໍ່ສາມາດໄດ້ຮັບປະເພດຄຳຖະແຫຼງ</translation></message>
++    <message>
++        <source>Unable to bind value</source>
++        <translation>ບໍ່ສາມາດຜູກມູນຄ່າໄດ້</translation></message>
++    <message>
++        <source>Unable to execute statement</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖະແຫຼງ</translation></message>
++</context>
++<context>
++    <name>QODBCDriver</name>
++    <message>
++        <source>Unable to connect</source>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ໄດ້</translation></message>
++    <message>
++        <source>Unable to connect - Driver doesn't support all functionality required</source>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ໄດ້ - ໄດຣເວີບໍ່ຮອງຮັບທຸກຟັງຊັນທີ່ຕ້ອງການ</translation></message>
++    <message>
++        <source>Unable to disable autocommit</source>
++        <translation>ບໍ່ສາມາດປິດການຄຳນວນອັດຕະໂນມັດ</translation></message>
++    <message>
++        <source>Unable to commit transaction</source>
++        <translation>ບໍ່ສາມາດສົ່ງການເຮັດທຸລະກຳ</translation></message>
++    <message>
++        <source>Unable to rollback transaction</source>
++        <translation>ບໍ່ສາມາດກັບຄືນການເຮັດທຸລະກຳ</translation></message>
++    <message>
++        <source>Unable to enable autocommit</source>
++        <translation>ບໍ່ສາມາດເປີດໃຊ້ການສົ່ງຂໍ້ມູນອັດຕະໂນມັດ</translation></message>
++</context>
++<context>
++    <name>QODBCResult</name>
++    <message>
++        <source>QODBCResult::reset: Unable to set 'SQL_CURSOR_STATIC' as statement attribute. Please check your ODBC driver configuration</source>
++        <translation>QODBCResult::reset: ບໍ່ສາມາດຕັ້ງຄ່າ 'SQL_CURSOR_STATIC' ເປັນຄຸນລັກສະນະຄຳສັ່ງ. ກະລຸນາກວດສອບການຕັ້ງຄ່າໄດຣເວີ ODBC ຂອງທ່ານ</translation></message>
++    <message>
++        <source>Unable to execute statement</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖະແຫຼງ</translation></message>
++    <message>
++        <source>Unable to fetch</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນໄດ້</translation></message>
++    <message>
++        <source>Unable to fetch next</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນຕໍ່ໄປໄດ້</translation></message>
++    <message>
++        <source>Unable to fetch first</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນທຳອິດໄດ້</translation></message>
++    <message>
++        <source>Unable to fetch previous</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນກ່ອນໜ້າໄດ້</translation></message>
++    <message>
++        <source>Unable to fetch last</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນຫຼ້າສຸດໄດ້</translation></message>
++    <message>
++        <source>Unable to prepare statement</source>
++        <translation>ບໍ່ສາມາດກະກຽມຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Unable to bind variable</source>
++        <translation>ບໍ່ສາມາດຜູກຕົວແປໄດ້</translation></message>
++</context>
++<context>
++    <name>QPSQLDriver</name>
++    <message>
++        <source>Unable to connect</source>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ໄດ້</translation></message>
++    <message>
++        <source>Could not begin transaction</source>
++        <translation>ບໍ່ສາມາດເລີ່ມທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Could not commit transaction</source>
++        <translation>ບໍ່ສາມາດຍື່ນການເຮັດທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Could not rollback transaction</source>
++        <translation>ບໍ່ສາມາດກັບຄືນການເຮັດທຸລະກຳ</translation></message>
++    <message>
++        <source>Unable to subscribe</source>
++        <translation>ບໍ່ສາມາດສະໝັກໄດ້</translation></message>
++    <message>
++        <source>Unable to unsubscribe</source>
++        <translation>ບໍ່ສາມາດຍົກເລີກການສະໝັກຮັບຂ່າວສານໄດ້</translation></message>
++</context>
++<context>
++    <name>QPSQLResult</name>
++    <message>
++        <source>Query results lost - probably discarded on executing another SQL query.</source>
++        <translation>ຜົນການຄົ້ນຫາສູນຫາຍ - ອາດຈະຖືກຍົກເລີກໃນການປະຕິບັດຄຳສັ່ງ SQL ອື່ນ.</translation></message>
++    <message>
++        <source>Unable to create query</source>
++        <translation>ບໍ່ສາມາດສ້າງຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Unable to get result</source>
++        <translation>ບໍ່ສາມາດໄດ້ຮັບຜົນ</translation></message>
++    <message>
++        <source>Unable to send query</source>
++        <translation>ບໍ່ສາມາດສົ່ງຄຳຖາມໄດ້</translation></message>
++    <message>
++        <source>Unable to prepare statement</source>
++        <translation>ບໍ່ສາມາດກະກຽມຄຳຖາມໄດ້</translation></message>
++</context>
++<context>
++    <name>QPageSetupWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Paper</source>
++        <translation>ເຈ້ຍ</translation></message>
++    <message>
++        <source>Page size:</source>
++        <translation>ຂະໜາດໜ້າ:</translation></message>
++    <message>
++        <source>Width:</source>
++        <translation>ກວ້າງ:</translation></message>
++    <message>
++        <source>Height:</source>
++        <translation>ຄວາມສູງ:</translation></message>
++    <message>
++        <source>Paper source:</source>
++        <translation>ແຫຼ່ງທີ່ມາ:</translation></message>
++    <message>
++        <source>Orientation</source>
++        <translation>ທິດທາງ</translation></message>
++    <message>
++        <source>Portrait</source>
++        <translation>ພາບພົດ</translation></message>
++    <message>
++        <source>Landscape</source>
++        <translation>ພູມສັນຖານ</translation></message>
++    <message>
++        <source>Reverse landscape</source>
++        <translation>ປ່ຽນພາບທິດທາງພື້ນຖານ</translation></message>
++    <message>
++        <source>Reverse portrait</source>
++        <translation>ພາບພິມກັບກັນ</translation></message>
++    <message>
++        <source>Margins</source>
++        <translation>ຂອບ</translation></message>
++    <message>
++        <source>top margin</source>
++        <translation>ຂອບເທິງ</translation></message>
++    <message>
++        <source>left margin</source>
++        <translation>ຂອບຊ້າຍ</translation></message>
++    <message>
++        <source>right margin</source>
++        <translation>ຂອບຂວາງ</translation></message>
++    <message>
++        <source>bottom margin</source>
++        <translation>ຂອບລຸ່ມ</translation></message>
++    <message>
++        <source>Page Layout</source>
++        <translation>ແບບຮູບແບບໜ້າ</translation></message>
++    <message>
++        <source>Page order:</source>
++        <translation>ລຳດັບໜ້າ:</translation></message>
++    <message>
++        <source>Pages per sheet:</source>
++        <translation>ໜ້າຕໍ່ເອກະສານ:</translation></message>
++    <message>
++        <source>Millimeters (mm)</source>
++        <translation>ມິລີແມັດ (ມມ)</translation></message>
++    <message>
++        <source>Inches (in)</source>
++        <translation>ນິ້ວ (ນິ້ວ)</translation></message>
++    <message>
++        <source>Points (pt)</source>
++        <translation>ຈຸດ (pt)</translation></message>
++    <message>
++        <source>Pica (P̸)</source>
++        <translation>ພິກາ (P̸)</translation></message>
++    <message>
++        <source>Didot (DD)</source>
++        <translation>ດີດອດ (DD)</translation></message>
++    <message>
++        <source>Cicero (CC)</source>
++        <translation>ຊີເຊໂຣ (CC)</translation></message>
++    <message>
++        <source>Custom</source>
++        <translation>ປັບແຕ່ງ</translation></message>
++    <message>
++        <source>mm</source>
++        <extracomment>Unit 'Millimeter'</extracomment>
++        <translation>ມມ</translation></message>
++    <message>
++        <source>pt</source>
++        <extracomment>Unit 'Points'</extracomment>
++        <translation>pt</translation></message>
++    <message>
++        <source>in</source>
++        <extracomment>Unit 'Inch'</extracomment>
++        <translation>ໃນ</translation></message>
++    <message>
++        <source>P̸</source>
++        <extracomment>Unit 'Pica'</extracomment>
++        <translation>P̸</translation></message>
++    <message>
++        <source>DD</source>
++        <extracomment>Unit 'Didot'</extracomment>
++        <translation>DD</translation></message>
++    <message>
++        <source>CC</source>
++        <extracomment>Unit 'Cicero'</extracomment>
++        <translation>ຊີຊີ</translation></message>
++</context>
++<context>
++    <name>QPageSize</name>
++    <message>
++        <source>Custom (%1mm x %2mm)</source>
++        <extracomment>Custom size name in millimeters</extracomment>
++        <translation>ປັບແຕ່ງ (%1mm x %2mm)</translation></message>
++    <message>
++        <source>Custom (%1pt x %2pt)</source>
++        <extracomment>Custom size name in points</extracomment>
++        <translation>ປັບແຕ່ງ (%1pt x %2pt)</translation></message>
++    <message>
++        <source>Custom (%1in x %2in)</source>
++        <extracomment>Custom size name in inches</extracomment>
++        <translation>ປັບແຕ່ງ (%1in x %2in)</translation></message>
++    <message>
++        <source>Custom (%1pc x %2pc)</source>
++        <extracomment>Custom size name in picas</extracomment>
++        <translation>ກຳນົດເອງ (%1pc x %2pc)</translation></message>
++    <message>
++        <source>Custom (%1DD x %2DD)</source>
++        <extracomment>Custom size name in didots</extracomment>
++        <translation>ປັບແຕ່ງ (%1DD x %2DD)</translation></message>
++    <message>
++        <source>Custom (%1CC x %2CC)</source>
++        <extracomment>Custom size name in ciceros</extracomment>
++        <translation>ປັບແຕ່ງ (%1CC x %2CC)</translation></message>
++    <message>
++        <source>%1 x %2 in</source>
++        <extracomment>Page size in 'Inch'.</extracomment>
++        <translation>%1 x %2 ໃນ</translation></message>
++    <message>
++        <source>A0</source>
++        <translation>A0</translation></message>
++    <message>
++        <source>A1</source>
++        <translation>A1</translation></message>
++    <message>
++        <source>A2</source>
++        <translation>A2</translation></message>
++    <message>
++        <source>A3</source>
++        <translation>A3</translation></message>
++    <message>
++        <source>A4</source>
++        <translation>A4</translation></message>
++    <message>
++        <source>A5</source>
++        <translation>A5</translation></message>
++    <message>
++        <source>A6</source>
++        <translation>A6</translation></message>
++    <message>
++        <source>A7</source>
++        <translation>A7</translation></message>
++    <message>
++        <source>A8</source>
++        <translation>A8</translation></message>
++    <message>
++        <source>A9</source>
++        <translation>A9</translation></message>
++    <message>
++        <source>A10</source>
++        <translation>A10</translation></message>
++    <message>
++        <source>B0</source>
++        <translation>B0</translation></message>
++    <message>
++        <source>B1</source>
++        <translation>B1</translation></message>
++    <message>
++        <source>B2</source>
++        <translation>ບີ 2</translation></message>
++    <message>
++        <source>B3</source>
++        <translation>B3</translation></message>
++    <message>
++        <source>B4</source>
++        <translation>ບີ 4</translation></message>
++    <message>
++        <source>B5</source>
++        <translation>B5</translation></message>
++    <message>
++        <source>B6</source>
++        <translation>B6</translation></message>
++    <message>
++        <source>B7</source>
++        <translation>B7</translation></message>
++    <message>
++        <source>B8</source>
++        <translation>B8</translation></message>
++    <message>
++        <source>B9</source>
++        <translation>B9</translation></message>
++    <message>
++        <source>B10</source>
++        <translation>B10</translation></message>
++    <message>
++        <source>Executive (7.5 x 10 in)</source>
++        <translation>ຜູ້ບໍລິຫານ (7.5 x 10 ນິ້ວ)</translation></message>
++    <message>
++        <source>Executive (7.25 x 10.5 in)</source>
++        <translation>ຜູ້ບໍລິຫານ (7.25 x 10.5 ນິ້ວ)</translation></message>
++    <message>
++        <source>Folio (8.27 x 13 in)</source>
++        <translation>ໂຟລິໂອ (8.27 x 13 ນິ້ວ)</translation></message>
++    <message>
++        <source>Legal</source>
++        <translation>ກົດໝາຍ</translation></message>
++    <message>
++        <source>Letter / ANSI A</source>
++        <translation>ຈົດໝາຍ / ANSI A</translation></message>
++    <message>
++        <source>Tabloid / ANSI B</source>
++        <translation>ຫນັງສືພິມຂ່າວສັ້ນ / ANSI B</translation></message>
++    <message>
++        <source>Ledger / ANSI B</source>
++        <translation>ບັນຊີ / ANSI B</translation></message>
++    <message>
++        <source>Custom</source>
++        <translation>ປັບແຕ່ງ</translation></message>
++    <message>
++        <source>A3 Extra</source>
++        <translation>A3 ພິເສດ</translation></message>
++    <message>
++        <source>A4 Extra</source>
++        <translation>A4 ພິເສດ</translation></message>
++    <message>
++        <source>A4 Plus</source>
++        <translation>A4 ພລັສ</translation></message>
++    <message>
++        <source>A4 Small</source>
++        <translation>A4 ນ້ອຍ</translation></message>
++    <message>
++        <source>A5 Extra</source>
++        <translation>A5 ພິເສດ</translation></message>
++    <message>
++        <source>B5 Extra</source>
++        <translation>B5 ພິເສດ</translation></message>
++    <message>
++        <source>JIS B0</source>
++        <translation>JIS B0</translation></message>
++    <message>
++        <source>JIS B1</source>
++        <translation>JIS B1</translation></message>
++    <message>
++        <source>JIS B2</source>
++        <translation>JIS B2</translation></message>
++    <message>
++        <source>JIS B3</source>
++        <translation>JIS B3</translation></message>
++    <message>
++        <source>JIS B4</source>
++        <translation>JIS B4</translation></message>
++    <message>
++        <source>JIS B5</source>
++        <translation>JIS B5</translation></message>
++    <message>
++        <source>JIS B6</source>
++        <translation>JIS B6</translation></message>
++    <message>
++        <source>JIS B7</source>
++        <translation>JIS B7</translation></message>
++    <message>
++        <source>JIS B8</source>
++        <translation>JIS B8</translation></message>
++    <message>
++        <source>JIS B9</source>
++        <translation>JIS B9</translation></message>
++    <message>
++        <source>JIS B10</source>
++        <translation>JIS B10</translation></message>
++    <message>
++        <source>ANSI C</source>
++        <translation>ANSI C</translation></message>
++    <message>
++        <source>ANSI D</source>
++        <translation>ANSI D</translation></message>
++    <message>
++        <source>ANSI E</source>
++        <translation>ANSI E</translation></message>
++    <message>
++        <source>Legal Extra</source>
++        <translation>ກົດໝາຍພິເສດ</translation></message>
++    <message>
++        <source>Letter Extra</source>
++        <translation>ຈົດໝາຍ Extra</translation></message>
++    <message>
++        <source>Letter Plus</source>
++        <translation>ຈົດໝາຍ Plus</translation></message>
++    <message>
++        <source>Letter Small</source>
++        <translation>ຕົວອັກສອນນ້ອຍ</translation></message>
++    <message>
++        <source>Tabloid Extra</source>
++        <translation>ປຶ້ມພິມຂ່າວສານພິເສດ</translation></message>
++    <message>
++        <source>Architect A</source>
++        <translation>ສະຖາປະນິກ ອາ</translation></message>
++    <message>
++        <source>Architect B</source>
++        <translation>ສະຖາປະນິກ ບີ</translation></message>
++    <message>
++        <source>Architect C</source>
++        <translation>ສະຖາປະນິກ C</translation></message>
++    <message>
++        <source>Architect D</source>
++        <translation>ສະຖາປະນິກ D</translation></message>
++    <message>
++        <source>Architect E</source>
++        <translation>ສະຖາປະນິກ E</translation></message>
++    <message>
++        <source>Note</source>
++        <translation>ຫມາຍເຫດ</translation></message>
++    <message>
++        <source>Quarto</source>
++        <translation>ຄວາຕໍ</translation></message>
++    <message>
++        <source>Statement</source>
++        <translation>ຖະແຫຼງການ</translation></message>
++    <message>
++        <source>Super A</source>
++        <translation>ຊູເປີ ເອ</translation></message>
++    <message>
++        <source>Super B</source>
++        <translation>ຊູເປີ ບີ</translation></message>
++    <message>
++        <source>Postcard</source>
++        <translation>ບັດຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Double Postcard</source>
++        <translation>ບັດໂປສຕະກາດສອງໜ້າ</translation></message>
++    <message>
++        <source>PRC 16K</source>
++        <translation>PRC 16K</translation></message>
++    <message>
++        <source>PRC 32K</source>
++        <translation>PRC 32K</translation></message>
++    <message>
++        <source>PRC 32K Big</source>
++        <translation>PRC 32K ໃຫຍ່</translation></message>
++    <message>
++        <source>Fan-fold US (14.875 x 11 in)</source>
++        <translation>ພິມພັບພັນສະຫະລັດ (14.875 x 11 ນິ້ວ)</translation></message>
++    <message>
++        <source>Fan-fold German (8.5 x 12 in)</source>
++        <translation>ພິມພັບພັນເຢຍລະມັນ (8.5 x 12 ນິ້ວ)</translation></message>
++    <message>
++        <source>Fan-fold German Legal (8.5 x 13 in)</source>
++        <translation>ພິມພັບພັນເຢຍລະມັນທາງກົດໝາຍ (8.5 x 13 ນິ້ວ)</translation></message>
++    <message>
++        <source>Envelope B4</source>
++        <translation>ຊອງຈົດໝາຍ B4</translation></message>
++    <message>
++        <source>Envelope B5</source>
++        <translation>ຊອງຈົດໝາຍ B5</translation></message>
++    <message>
++        <source>Envelope B6</source>
++        <translation>ຊອງຈົດໝາຍ B6</translation></message>
++    <message>
++        <source>Envelope C0</source>
++        <translation>ຊອງຈົດໝາຍ C0</translation></message>
++    <message>
++        <source>Envelope C1</source>
++        <translation>ຊອງຈົດໝາຍ C1</translation></message>
++    <message>
++        <source>Envelope C2</source>
++        <translation>ຊອງຈົດໝາຍ C2</translation></message>
++    <message>
++        <source>Envelope C3</source>
++        <translation>ຊອງຈົດໝາຍ C3</translation></message>
++    <message>
++        <source>Envelope C4</source>
++        <translation>ຊອງຈົດໝາຍ C4</translation></message>
++    <message>
++        <source>Envelope C5</source>
++        <translation>ຊອງຈົດໝາຍ C5</translation></message>
++    <message>
++        <source>Envelope C6</source>
++        <translation>ຊອງຈົດໝາຍ C6</translation></message>
++    <message>
++        <source>Envelope C65</source>
++        <translation>ຊອງຈົດໝາຍ C65</translation></message>
++    <message>
++        <source>Envelope C7</source>
++        <translation>ຊອງຈົດໝາຍ C7</translation></message>
++    <message>
++        <source>Envelope DL</source>
++        <translation>ຊອງຈົດໝາຍ DL</translation></message>
++    <message>
++        <source>Envelope US 9</source>
++        <translation>ຊອງຈົດໝາຍ ສະຫະລັດ 9</translation></message>
++    <message>
++        <source>Envelope US 10</source>
++        <translation>ຊອງຈົດໝາຍ ສະຫະລັດ 10</translation></message>
++    <message>
++        <source>Envelope US 11</source>
++        <translation>ຊອງຈົດໝາຍ ສະຫະລັດ 11</translation></message>
++    <message>
++        <source>Envelope US 12</source>
++        <translation>ຊອງຈົດໝາຍ ສະຫະລັດ 12</translation></message>
++    <message>
++        <source>Envelope US 14</source>
++        <translation>ຊອງຈົດໝາຍ ສະຫະລັດ 14</translation></message>
++    <message>
++        <source>Envelope Monarch</source>
++        <translation>ຊອງຈົດໝາຍ Monarch</translation></message>
++    <message>
++        <source>Envelope Personal</source>
++        <translation>ຊອງຈົດໝາຍສ່ວນຕົວ</translation></message>
++    <message>
++        <source>Envelope Chou 3</source>
++        <translation>ຊອງຈົວ 3</translation></message>
++    <message>
++        <source>Envelope Chou 4</source>
++        <translation>ຊອງຈົວ 4</translation></message>
++    <message>
++        <source>Envelope Invite</source>
++        <translation>ກະຕ່ານຳເຖິງ</translation></message>
++    <message>
++        <source>Envelope Italian</source>
++        <translation>ຊອງຈົດໝາຍອີຕາລີ</translation></message>
++    <message>
++        <source>Envelope Kaku 2</source>
++        <translation>ຊອງຈົດໝາຍ Kaku 2</translation></message>
++    <message>
++        <source>Envelope Kaku 3</source>
++        <translation>ຊອງຈົດໝາຍ Kaku 3</translation></message>
++    <message>
++        <source>Envelope PRC 1</source>
++        <translation>ຊອງຈົດໝາຍ PRC 1</translation></message>
++    <message>
++        <source>Envelope PRC 2</source>
++        <translation>ຊອງຈົດໝາຍ PRC 2</translation></message>
++    <message>
++        <source>Envelope PRC 3</source>
++        <translation>ຊອງຈົດໝາຍ PRC 3</translation></message>
++    <message>
++        <source>Envelope PRC 4</source>
++        <translation>ຊອງຈົດໝາຍ PRC 4</translation></message>
++    <message>
++        <source>Envelope PRC 5</source>
++        <translation>ຊອງຈົດໝາຍ PRC 5</translation></message>
++    <message>
++        <source>Envelope PRC 6</source>
++        <translation>ຊອງຈົດໝາຍ PRC 6</translation></message>
++    <message>
++        <source>Envelope PRC 7</source>
++        <translation>ຊອງຈົດໝາຍ PRC 7</translation></message>
++    <message>
++        <source>Envelope PRC 8</source>
++        <translation>ຊອງຈົດໝາຍ PRC 8</translation></message>
++    <message>
++        <source>Envelope PRC 9</source>
++        <translation>ຊອງຈົດໝາຍ PRC 9</translation></message>
++    <message>
++        <source>Envelope PRC 10</source>
++        <translation>ຊອງຈົດໝາຍ PRC 10</translation></message>
++    <message>
++        <source>Envelope You 4</source>
++        <translation>ຊອງຈົດໝາຍ ທ່ານ 4</translation></message>
++</context>
++<context>
++    <name>QPlatformTheme</name>
++    <message>
++        <source>OK</source>
++        <translation>ຕົກລົງ</translation></message>
++    <message>
++        <source>Save</source>
++        <translation>ບັນທຶກ</translation></message>
++    <message>
++        <source>Save All</source>
++        <translation>ບັນທຶກທັງໝົດ</translation></message>
++    <message>
++        <source>Open</source>
++        <translation>ເປີດ</translation></message>
++    <message>
++        <source>&amp;Yes</source>
++        <translation>&amp;ແມ່ນແລ້ວ</translation></message>
++    <message>
++        <source>Yes to &amp;All</source>
++        <translation>ແມ່ນສຳລັບ &amp;ທັງໝົດ</translation></message>
++    <message>
++        <source>&amp;No</source>
++        <translation>&amp;ບໍ່</translation></message>
++    <message>
++        <source>N&amp;o to All</source>
++        <translation>ບໍ່ຕໍ່ທຸກຄົນ</translation></message>
++    <message>
++        <source>Abort</source>
++        <translation>ຍົກເລີກ</translation></message>
++    <message>
++        <source>Retry</source>
++        <translation>ລອງໃໝ່</translation></message>
++    <message>
++        <source>Ignore</source>
++        <translation>ລະເວັ້ນ</translation></message>
++    <message>
++        <source>Close</source>
++        <translation>ປິດ</translation></message>
++    <message>
++        <source>Cancel</source>
++        <translation>ຍົກເລີກ</translation></message>
++    <message>
++        <source>Discard</source>
++        <translation>ຖິ້ມ</translation></message>
++    <message>
++        <source>Help</source>
++        <translation>ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>Apply</source>
++        <translation>ນຳໃຊ້</translation></message>
++    <message>
++        <source>Reset</source>
++        <translation>ລີເຊັດ</translation></message>
++    <message>
++        <source>Restore Defaults</source>
++        <translation>ກູ້ຄືນຄ່າເລີ່ມຕົ້ນ</translation></message>
++</context>
++<context>
++    <name>QPluginLoader</name>
++    <message>
++        <source>The plugin was not loaded.</source>
++        <translation>ປລັອກອິນບໍ່ໄດ້ຖືກໂຫຼດ.</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QPrintDialog</name>
++    <message>
++        <source>Print</source>
++        <translation>ພິມ</translation></message>
++    <message>
++        <source>Left to Right, Top to Bottom</source>
++        <translation>ຊ້າຍຫາຂວາ, ເທິງຫາລຸ່ມ</translation></message>
++    <message>
++        <source>Left to Right, Bottom to Top</source>
++        <translation>ຊ້າຍຫາຂວາ, ລຸ່ມຫາບົນ</translation></message>
++    <message>
++        <source>Right to Left, Bottom to Top</source>
++        <translation>ຂວາໄປຊ້າຍ, ລຸ່ມໄປເທິງ</translation></message>
++    <message>
++        <source>Right to Left, Top to Bottom</source>
++        <translation>ຂວາໄປຊ້າຍ, ເທິງໄປລຸ່ມ</translation></message>
++    <message>
++        <source>Bottom to Top, Left to Right</source>
++        <translation>ລຸ່ມສູ່ເທິງ, ຊ້າຍສູ່ຂວາ</translation></message>
++    <message>
++        <source>Bottom to Top, Right to Left</source>
++        <translation>ລຸ່ມສູ່ເທິງ, ຂວາສູ່ຊ້າຍ</translation></message>
++    <message>
++        <source>Top to Bottom, Left to Right</source>
++        <translation>ຂ້າງເທິງຫາຂ້າງລຸ່ມ, ຊ້າຍຫາຂວາ</translation></message>
++    <message>
++        <source>Top to Bottom, Right to Left</source>
++        <translation>ຈາກເທິງຫາລຸ່ມ, ຈາກຂວາຫາຊ້າຍ</translation></message>
++    <message>
++        <source>1 (1x1)</source>
++        <translation>1 (1x1)</translation></message>
++    <message>
++        <source>2 (2x1)</source>
++        <translation>2 (2x1)</translation></message>
++    <message>
++        <source>4 (2x2)</source>
++        <translation>4 (2x2)</translation></message>
++    <message>
++        <source>6 (2x3)</source>
++        <translation>6 (2x3)</translation></message>
++    <message>
++        <source>9 (3x3)</source>
++        <translation>9 (3x3)</translation></message>
++    <message>
++        <source>16 (4x4)</source>
++        <translation>16 (4x4)</translation></message>
++    <message>
++        <source>All Pages</source>
++        <translation>ທຸກໆໜ້າ</translation></message>
++    <message>
++        <source>Odd Pages</source>
++        <translation>ໜ້າຄີກ</translation></message>
++    <message>
++        <source>Even Pages</source>
++        <translation>ໜ້າຄູ່</translation></message>
++    <message>
++        <source>&amp;Options &gt;&gt;</source>
++        <translation>&amp;lt;ຕົວເລືອກ &amp;gt;&amp;gt;</translation></message>
++    <message>
++        <source>&amp;Print</source>
++        <translation>&amp;ພິມ</translation></message>
++    <message>
++        <source>&amp;Options &lt;&lt;</source>
++        <translation>&amp;lt;ຕົວເລືອກ &lt;&lt;</translation></message>
++    <message>
++        <source>Invalid Pages Definition</source>
++        <translation>ຄໍານິຍາມຫນ້າທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>%1 does not follow the correct syntax. Please use ',' to separate ranges and pages, '-' to define ranges and make sure ranges do not intersect with each other.</source>
++        <translatorcomment>区隔逗号是半角的，不能改成全角</translatorcomment>
++        <translation>%1 ບໍ່ປະຕິບັດຕາມໂຄງສ້າງທາງໄວຍາກອນທີ່ຖືກຕ້ອງ. ກະລຸນາໃຊ້ ',' ເພື່ອແຍກຊ່ວງແລະໜ້າ, '-' ເພື່ອກຳນົດຊ່ວງແລະໃຫ້ແນ່ໃຈວ່າຊ່ວງຕ່າງໆບໍ່ຕັດກັນ.</translation></message>
++    <message>
++        <source>Duplex Settings Conflicts</source>
++        <translation>ການຕັ້ງຄ່າດູແພລ໌ຂັດກັນ</translation></message>
++    <message>
++        <source>There are conflicts in duplex settings. Do you want to fix them?</source>
++        <translation>ມີຂໍ້ຂັດແຍ່ງໃນການຕັ້ງຄ່າ duplex. ທ່ານຕ້ອງການແກ້ໄຂບໍ?</translation></message>
++    <message>
++        <source>Print to File (PDF)</source>
++        <translation>ພິມເປັນໄຟລ໌ (PDF)</translation></message>
++    <message>
++        <source>Local file</source>
++        <translation>ໄຟລ໌ທ້ອງຖິ່ນ</translation></message>
++    <message>
++        <source>Write PDF file</source>
++        <translation>ຂຽນເອກະສານ PDF</translation></message>
++    <message>
++        <source>Print To File ...</source>
++        <translation>ພິມໄປຍັງໄຟລ໌ ...</translation></message>
++    <message>
++        <source>%1 is a directory.
++Please choose a different file name.</source>
++        <translation>%1 ແມ່ນໄດເລັກທໍລີ.
++ກະລຸນາເລືອກຊື່ໄຟລ໌ອື່ນ.</translation></message>
++    <message>
++        <source>File %1 is not writable.
++Please choose a different file name.</source>
++        <translation>ໄຟລ໌ %1 ບໍ່ສາມາດຂຽນໄດ້.
++ກະລຸນາເລືອກຊື່ໄຟລ໌ອື່ນ.</translation></message>
++    <message>
++        <source>%1 already exists.
++Do you want to overwrite it?</source>
++        <translation>%1 ແມ່ນມີຢູ່ແລ້ວ.
++ທ່ານຕ້ອງການຂຽນທັບມັນບໍ?</translation></message>
++    <message>
++        <source>Options 'Pages Per Sheet' and 'Page Set' cannot be used together.
++Please turn one of those options off.</source>
++        <translation>ຕົວເລືອກ 'ຫນ້າຕໍ່ແຜ່ນ' ແລະ 'ຊຸດຫນ້າ' ບໍ່ສາມາດນໍາໃຊ້ຮ່ວມກັນໄດ້.
++ກະລຸນາປິດຕົວເລືອກເຫຼົ່ານີ້ອັນໃດອັນຫນຶ່ງ.</translation></message>
++    <message>
++        <source>The 'From' value cannot be greater than the 'To' value.</source>
++        <translation>ຄ່າ 'ຈາກ' ບໍ່ສາມາດຫຼາຍກວ່າຄ່າ 'ເຖິງ' ໄດ້.</translation></message>
++    <message>
++        <source>OK</source>
++        <translation>ຕົກລົງ</translation></message>
++    <message>
++        <source>Automatic</source>
++        <translation>ອັດຕະໂນມັດ</translation></message>
++</context>
++<context>
++    <name>QPrintPreviewDialog</name>
++    <message>
++        <source>Page Setup</source>
++        <translation>ຕັ້ງຄ່າໜ້າ</translation></message>
++    <message>
++        <source>%1%</source>
++        <translation>%1%</translation></message>
++    <message>
++        <source>Print Preview</source>
++        <translation>ພິມຕົວຢ່າງ</translation></message>
++    <message>
++        <source>Next page</source>
++        <translation>ຫນ້າຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Previous page</source>
++        <translation>ຫນ້າກ່ອນ</translation></message>
++    <message>
++        <source>First page</source>
++        <translation>ຫນ້າທໍາອິດ</translation></message>
++    <message>
++        <source>Last page</source>
++        <translation>ຫນ້າສຸດທ້າຍ</translation></message>
++    <message>
++        <source>Fit width</source>
++        <translation>ກັ່ນຕອງຕາມຄວາມກວ້າງ</translation></message>
++    <message>
++        <source>Fit page</source>
++        <translation>ປັບໜ້າ</translation></message>
++    <message>
++        <source>Zoom in</source>
++        <translation>ຂະຫຍາຍຂະໜາດ</translation></message>
++    <message>
++        <source>Zoom out</source>
++        <translation>ຂະຫຍາຍອອກ</translation></message>
++    <message>
++        <source>Portrait</source>
++        <translation>ພາບພົດ</translation></message>
++    <message>
++        <source>Landscape</source>
++        <translation>ພູມສັນຖານ</translation></message>
++    <message>
++        <source>Show single page</source>
++        <translation>ສະແດງຫນ້າດຽວ</translation></message>
++    <message>
++        <source>Show facing pages</source>
++        <translation>ສະແດງໜ້າທີ່ຢູ່ຕິດກັນ</translation></message>
++    <message>
++        <source>Show overview of all pages</source>
++        <translation>ສະແດງພາບລວມຂອງທຸກໆໜ້າ</translation></message>
++    <message>
++        <source>Print</source>
++        <translation>ພິມ</translation></message>
++    <message>
++        <source>Page setup</source>
++        <translation>ຕັ້ງຄ່າໜ້າ</translation></message>
++    <message>
++        <source>Export to PDF</source>
++        <translation>ສົ່ງອອກເປັນ PDF</translation></message>
++</context>
++<context>
++    <name>QPrintPropertiesDialog</name>
++    <message>
++        <source>Printer Properties</source>
++        <translation>ຄຸນສົມບັດຂອງພິມເຕີ</translation></message>
++    <message>
++        <source>Job Options</source>
++        <translation>ຕົວເລືອກວຽກ</translation></message>
++    <message>
++        <source>Page Setup Conflicts</source>
++        <translation>ການຕັ້ງຄ່າໜ້າຂັດກັນ</translation></message>
++    <message>
++        <source>There are conflicts in page setup options. Do you want to fix them?</source>
++        <translation>ມີຂໍ້ຂັດແຍ່ງໃນຕົວເລືອກການຕັ້ງຄ່າໜ້າ. ທ່ານຕ້ອງການແກ້ໄຂບໍ?</translation></message>
++    <message>
++        <source>Advanced Option Conflicts</source>
++        <translation>ຕົວເລືອກຂັ້ນສູງທີ່ຂັດແຍ້ງກັນ</translation></message>
++    <message>
++        <source>There are conflicts in some advanced options. Do you want to fix them?</source>
++        <translation>ມີຂໍ້ຂັດແຍ່ງໃນບາງຕົວເລືອກຂັ້ນສູງ. ທ່ານຕ້ອງການແກ້ໄຂບໍ?</translation></message>
++</context>
++<context>
++    <name>QPrintPropertiesWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Page</source>
++        <translation>ໜ້າ</translation></message>
++    <message>
++        <source>Advanced</source>
++        <translation>ຂັ້ນສູງ</translation></message>
++    <message>
++        <source>There are conflicts in some options. Please fix them.</source>
++        <translation>ມີຂໍ້ຂັດແຍ່ງໃນບາງຕົວເລືອກ. ກະລຸນາແກ້ໄຂພວກມັນ.</translation></message>
++</context>
++<context>
++    <name>QPrintSettingsOutput</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Copies</source>
++        <translation>ສຳເນົາ</translation></message>
++    <message>
++        <source>Print range</source>
++        <translation>ພິມຊ່ວງ</translation></message>
++    <message>
++        <source>Print all</source>
++        <translation>ພິມທັງໝົດ</translation></message>
++    <message>
++        <source>Pages from</source>
++        <translation>ໜ້າຈາກ</translation></message>
++    <message>
++        <source>to</source>
++        <translation>ເປັນ</translation></message>
++    <message>
++        <source>Pages</source>
++        <translation>ໜ້າ</translation></message>
++    <message>
++        <source>Specify pages or ranges separated by commas. Ranges are specified by two numbers separated by a hyphen. E.g: 3,5-7,9 prints pages 3, 5, 6, 7 and 9.</source>
++        <translation>ກຳນົດໜ້າຫຼືຊ່ວງທີ່ຕ້ອງການໂດຍຄວາມແຍກດ້ວຍຈຸດຄົມມະນາຄົມ. ຊ່ວງທີ່ກຳນົດໂດຍສອງເລກທີ່ແຍກດ້ວຍຂີດຕໍ່. ຕົວຢ່າງ: 3,5-7,9 ພິມໜ້າ 3, 5, 6, 7 ແລະ 9.</translation></message>
++    <message>
++        <source>Current Page</source>
++        <translation>ຫນ້າປັດຈຸບັນ</translation></message>
++    <message>
++        <source>Selection</source>
++        <translation>ການເລືອກ</translation></message>
++    <message>
++        <source>Page Set:</source>
++        <translation>ຕັ້ງຄ່າໜ້າ:</translation></message>
++    <message>
++        <source>Output Settings</source>
++        <translation>ການຕັ້ງຄ່າຜົນຜະລິດ</translation></message>
++    <message>
++        <source>Copies:</source>
++        <translation>ສຳເນົາ:</translation></message>
++    <message>
++        <source>Collate</source>
++        <translation>ຈັດລຽນ</translation></message>
++    <message>
++        <source>Reverse</source>
++        <translation>ປີ້ນກັບ</translation></message>
++    <message>
++        <source>Options</source>
++        <translation>ຕົວເລືອກ</translation></message>
++    <message>
++        <source>Color Mode</source>
++        <translation>ໂໝດສີ</translation></message>
++    <message>
++        <source>Color</source>
++        <translation>ສີ</translation></message>
++    <message>
++        <source>Grayscale</source>
++        <translation>ສີຂີວອ່ອນ</translation></message>
++    <message>
++        <source>Duplex Printing</source>
++        <translation>ພິມສອງດ້ານ</translation></message>
++    <message>
++        <source>None</source>
++        <translation>ບໍ່ມີ</translation></message>
++    <message>
++        <source>Long side</source>
++        <translation>ຂ້າງຍາວ</translation></message>
++    <message>
++        <source>Short side</source>
++        <translation>ຂ້າງສັ້ນ</translation></message>
++    <message>
++        <source>Double Sided Printing</source>
++        <translation>ພິມສອງດ້ານ</translation></message>
++    <message>
++        <source>Off</source>
++        <translation>ປິດ</translation></message>
++    <message>
++        <source>Long side binding</source>
++        <translation>ຜູກຂ້າງຍາວ</translation></message>
++    <message>
++        <source>Short side binding</source>
++        <translation>ຜູກຂ້າງສັ້ນ</translation></message>
++</context>
++<context>
++    <name>QPrintWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>Printer</source>
++        <translation>ຈັດພິມ</translation></message>
++    <message>
++        <source>&amp;Name:</source>
++        <translation>&amp;ຊື່:</translation></message>
++    <message>
++        <source>P&amp;roperties</source>
++        <translation>ຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>Location:</source>
++        <translation>ສະຖານທີ່:</translation></message>
++    <message>
++        <source>Preview</source>
++        <translation>ການລອງເບິ່ງ</translation></message>
++    <message>
++        <source>Type:</source>
++        <translation>ປະເພດ:</translation></message>
++    <message>
++        <source>Output &amp;file:</source>
++        <translation>ຜົນລັບ &amp;file:</translation></message>
++    <message>
++        <source>...</source>
++        <translation>...</translation></message>
++</context>
++<context>
++    <name>QProcess</name>
++    <message>
++        <source>Process failed to start</source>
++        <translation>ຂະບວນການລົ້ມເຫລວໃນການເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Process crashed</source>
++        <translation>ຂະບວນການລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Process operation timed out</source>
++        <translation>ການດຳເນີນງານຂະບວນການໝົດເວລາ</translation></message>
++    <message>
++        <source>Error reading from process</source>
++        <translation>ຜິດພາດໃນການອ່ານຈາກຂະບວນການ</translation></message>
++    <message>
++        <source>Error writing to process</source>
++        <translation>ຂໍ້ຜິດພາດໃນການຂຽນໄປຫາຂະບວນການ</translation></message>
++    <message>
++        <source>No program defined</source>
++        <translation>ບໍ່ມີໂປຣແກຣມທີ່ກຳນົດໄວ້</translation></message>
++    <message>
++        <source>Could not open input redirection for reading</source>
++        <translation>ບໍ່ສາມາດເປີດການປ່ຽນເສັ້ນທາງອິນພຸດເພື່ອອ່ານໄດ້</translation></message>
++    <message>
++        <source>Resource error (fork failure): %1</source>
++        <translation>ຂໍ້ຜິດພາດດ້ານຊັບພະຍາກອນ (ການສ້າງຂະບວນການລົ້ມເຫລວ): %1</translation></message>
++    <message>
++        <source>Could not open output redirection for writing</source>
++        <translation>ບໍ່ສາມາດເປີດການໂອນຜົນຜະລິດເພື່ອຂຽນໄດ້</translation></message>
++    <message>
++        <source>Process failed to start: %1</source>
++        <translation>ຂະບວນການລົ້ມເຫລວໃນການເລີ່ມຕົ້ນ: %1</translation></message>
++</context>
++<context>
++    <name>QProgressDialog</name>
++    <message>
++        <source>Cancel</source>
++        <translation>ຍົກເລີກ</translation></message>
++</context>
++<context>
++    <name>QRegExp</name>
++    <message>
++        <source>no error occurred</source>
++        <translation>ບໍ່ມີຂໍ້ຜິດພາດເກີດຂຶ້ນ</translation></message>
++    <message>
++        <source>disabled feature used</source>
++        <translation>ຄຸນສົມບັດທີ່ຖືກປິດໃຊ້</translation></message>
++    <message>
++        <source>bad char class syntax</source>
++        <translation>ຂໍ້ຜິດພາດໃນການຂຽນຄຳສັ່ງຂອງຊັບຊ້ອນຕົວອັກສອນ</translation></message>
++    <message>
++        <source>bad lookahead syntax</source>
++        <translation>ວັດຖຸພາບການຄາດຄະເນທີ່ບໍ່ດີ</translation></message>
++    <message>
++        <source>lookbehinds not supported, see QTBUG-2371</source>
++        <translation>lookbehinds ບໍ່ຖືກສະຫນັບສະຫນູນ, ເບິ່ງ QTBUG-2371</translation></message>
++    <message>
++        <source>bad repetition syntax</source>
++        <translation>ວິທີການຄຳສັບທີ່ຊ້ຳກັນບໍ່ດີ</translation></message>
++    <message>
++        <source>invalid octal value</source>
++        <translation>ຄ່າອອກຕະລັດບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>missing left delim</source>
++        <translation>ຂາດຂອບຊ້າຍ</translation></message>
++    <message>
++        <source>unexpected end</source>
++        <translation>ບໍ່ຄາດຄິດວ່າຈະສິ້ນສຸດ</translation></message>
++    <message>
++        <source>met internal limit</source>
++        <translation>ເຖິງຂອບເຂດພາຍໃນ</translation></message>
++    <message>
++        <source>invalid interval</source>
++        <translation>ຊ່ວງເວລາບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>invalid category</source>
++        <translation>ປະເພດບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QRegularExpression</name>
++    <message>
++        <source>no error</source>
++        <translation>ບໍ່ມີຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>\ at end of pattern</source>
++        <translation>\ ຢູ່ທ້າຍຂອງຮູບແບບ</translation></message>
++    <message>
++        <source>\c at end of pattern</source>
++        <translation>\c ຢູ່ທ້າຍຂອງຮູບແບບ</translation></message>
++    <message>
++        <source>unrecognized character follows \</source>
++        <translation>ຕົວອັກສອນທີ່ບໍ່ຮູ້ຈັກຕາມຫຼັງ \</translation></message>
++    <message>
++        <source>numbers out of order in {} quantifier</source>
++        <translation>ຕົວເລກອອກຈາກລຳດັບໃນ {} ປະລິມານ</translation></message>
++    <message>
++        <source>number too big in {} quantifier</source>
++        <translation>ຈຳນວນໃຫຍ່ເກີນໄປໃນ {} ປະລິມານ</translation></message>
++    <message>
++        <source>missing terminating ] for character class</source>
++        <translation>ຂາດເຄື່ອງໝາຍປິດ ] ສຳລັບຊັ້ນຕົວອັກສອນ</translation></message>
++    <message>
++        <source>invalid escape sequence in character class</source>
++        <translation>ລຳດັບການຫນີທີ່ບໍ່ຖືກຕ້ອງໃນຊັ້ນຕົວອັກສອນ</translation></message>
++    <message>
++        <source>range out of order in character class</source>
++        <translation>ລະດັບອອກຈາກລຳດັບໃນຫ້ອງຮຽນຕົວອັກສອນ</translation></message>
++    <message>
++        <source>quantifier does not follow a repeatable item</source>
++        <translation>ປະລິມານບໍ່ຕິດຕາມລາຍການທີ່ສາມາດເຮັດຊ້ຳໄດ້</translation></message>
++    <message>
++        <source>internal error: unexpected repeat</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ: ການຊ້ຳຄືນທີ່ບໍ່ຄາດຄິດ</translation></message>
++    <message>
++        <source>unrecognized character after (? or (?-</source>
++        <translation>ບໍ່ຮູ້ຈັກຕົວອັກສອນຫຼັງຈາກ (? ຫຼື (?-</translation></message>
++    <message>
++        <source>POSIX named classes are supported only within a class</source>
++        <translation>ຊັ້ນຮຽນທີ່ຖືກຕັ້ງຊື່ POSIX ຖືກສະຫນັບສະຫນູນພາຍໃນຊັ້ນຮຽນເທົ່ານັ້ນ</translation></message>
++    <message>
++        <source>POSIX collating elements are not supported</source>
++        <translation>ອົງປະກອບການຈັດລຽງ POSIX ບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation></message>
++    <message>
++        <source>missing closing parenthesis</source>
++        <translation>ຂາດວົງເປີດປິດ</translation></message>
++    <message>
++        <source>reference to non-existent subpattern</source>
++        <translation>ອ້າງອີງເຖິງຮູບແບບຍ່ອຍທີ່ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>pattern passed as NULL</source>
++        <translation>ຮູບແບບທີ່ຖືກສົ່ງມາເປັນ NULL</translation></message>
++    <message>
++        <source>unrecognised compile-time option bit(s)</source>
++        <translation>ບໍ່ຮັບຮູ້ຕົວເລືອກບິດທີ່ປະມວນຜົນໃນເວລາປະກອບ</translation></message>
++    <message>
++        <source>missing ) after (?# comment</source>
++        <translation>ຂາດ ) ຫຼັງຈາກ (?# ຄຳອະທິບາຍ</translation></message>
++    <message>
++        <source>parentheses are too deeply nested</source>
++        <translation>ວົງເລັບຖືກຊ້ອນກັນເລິກເກີນໄປ</translation></message>
++    <message>
++        <source>regular expression is too large</source>
++        <translation>regular expression ໃຫຍ່ເກີນໄປ</translation></message>
++    <message>
++        <source>failed to allocate heap memory</source>
++        <translation>ບໍ່ສາມາດຈັດເກັບຫນ່ວຍຄວາມຈຳໄດ້</translation></message>
++    <message>
++        <source>unmatched closing parenthesis</source>
++        <translation>ວົງເລັບປິດທີ່ບໍ່ກົງກັນ</translation></message>
++    <message>
++        <source>internal error: code overflow</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ: ລະຫັດເກີນຂອບເຂດ</translation></message>
++    <message>
++        <source>letter or underscore expected after (?&lt; or (?'</source>
++        <translation>ຕົວອັກສອນ ຫຼື ຂີດຕໍ່າທີ່ຄາດຫວັງຫຼັງຈາກ (?&lt; ຫຼື (?'</translation></message>
++    <message>
++        <source>lookbehind assertion is not fixed length</source>
++        <translation>ການຢືນຢັນ lookbehind ບໍ່ແມ່ນຄວາມຍາວທີ່ຕັ້ງໄວ້</translation></message>
++    <message>
++        <source>malformed number or name after (?(</source>
++        <translation>ຕົວເລກຫຼືຊື່ບໍ່ຖືກຕ້ອງຫຼັງຈາກ (?(</translation></message>
++    <message>
++        <source>conditional group contains more than two branches</source>
++        <translation>ກຸ່ມເງື່ອນໄຂປະກອບມີສາຂາຫຼາຍກວ່າສອງສາຂາ</translation></message>
++    <message>
++        <source>assertion expected after (?( or (?(?C)</source>
++        <translation>ການຢືນຢັນຄາດຫວັງຫຼັງຈາກ (?( ຫຼື (?(?C)</translation></message>
++    <message>
++        <source>(?R or (?[+-]digits must be followed by )</source>
++        <translation>(?R ຫຼື (?[+-]ຕົວເລກ ຕ້ອງຖືກຕິດຕາມດ້ວຍ )</translation></message>
++    <message>
++        <source>unknown POSIX class name</source>
++        <translation>ບໍ່ຮູ້ຊື່ຫ້ອງຮຽນ POSIX</translation></message>
++    <message>
++        <source>internal error in pcre2_study(): should not occur</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນໃນ pcre2_study(): ບໍ່ຄວນເກີດຂຶ້ນ</translation></message>
++    <message>
++        <source>this version of PCRE2 does not have Unicode support</source>
++        <translation>ລຸ້ນນີ້ຂອງ PCRE2 ບໍ່ມີການສະໜັບສະໜູນ Unicode</translation></message>
++    <message>
++        <source>parentheses are too deeply nested (stack check)</source>
++        <translation>ວົງເລັບຖືກຊ້ອນເລິກເກີນໄປ (ການກວດສອບສະຕ໋ອກ)</translation></message>
++    <message>
++        <source>character code point value in \x{} or \o{} is too large</source>
++        <translation>ຄ່າຈຸດລະຫັດຕົວອັກສອນໃນ \x{} ຫຼື \o{} ໃຫຍ່ເກີນໄປ</translation></message>
++    <message>
++        <source>invalid condition (?(0)</source>
++        <translation>ເງື່ອນໄຂບໍ່ຖືກຕ້ອງ (?(0)</translation></message>
++    <message>
++        <source>\C is not allowed in a lookbehind assertion</source>
++        <translation>\C ບໍ່ອະນຸຍາດໃຫ້ໃຊ້ໃນການກວດສອບ lookbehind</translation></message>
++    <message>
++        <source>PCRE does not support \L, \l, \N{name}, \U, or \u</source>
++        <translation>PCRE ບໍ່ສະໜັບສະໜູນ \L, \l, \N{name}, \U, ຫຼື \u</translation></message>
++    <message>
++        <source>number after (?C is greater than 255</source>
++        <translation>ຈຳນວນຫຼັງຈາກ (?C ແມ່ນຫຼາຍກວ່າ 255</translation></message>
++    <message>
++        <source>closing parenthesis for (?C expected</source>
++        <translation>ວົງເປີດສຳລັບ (?C ທີ່ຄາດຫວັງ</translation></message>
++    <message>
++        <source>invalid escape sequence in (*VERB) name</source>
++        <translation>ລຳດັບການຫນີທີ່ບໍ່ຖືກຕ້ອງໃນຊື່ (*VERB)</translation></message>
++    <message>
++        <source>unrecognized character after (?P</source>
++        <translation>ບໍ່ຮູ້ຈັກຕົວອັກສອນຫຼັງ (?P</translation></message>
++    <message>
++        <source>syntax error in subpattern name (missing terminator)</source>
++        <translation>ຂໍ້ຜິດພາດໃນການຂຽນຊື່ຮູບແບບຍ່ອຍ (ຂາດຕົວຢຸດ)</translation></message>
++    <message>
++        <source>two named subpatterns have the same name (PCRE2_DUPNAMES not set)</source>
++        <translation>ສອງຮູບແບບຍ່ອຍທີ່ຖືກຕັ້ງຊື່ມີຊື່ດຽວກັນ (PCRE2_DUPNAMES ບໍ່ໄດ້ຖືກຕັ້ງຄ່າ)</translation></message>
++    <message>
++        <source>group name must start with a non-digit</source>
++        <translation>ຊື່ກຸ່ມຕ້ອງເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນທີ່ບໍ່ແມ່ນຕົວເລກ</translation></message>
++    <message>
++        <source>this version of PCRE2 does not have support for \P, \p, or \X</source>
++        <translation>ລຸ້ນ PCRE2 ນີ້ບໍ່ມີການສະໜັບສະໜູນສໍາລັບ \P, \p, ຫຼື \X</translation></message>
++    <message>
++        <source>malformed \P or \p sequence</source>
++        <translation>ລຳດັບ \P ຫຼື \p ທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>unknown property name after \P or \p</source>
++        <translation>ຊື່ຄຸນສົມບັດທີ່ບໍ່ຮູ້ຈັກຫຼັງຈາກ \P ຫຼື \p</translation></message>
++    <message>
++        <source>subpattern name is too long (maximum 10000 characters)</source>
++        <translation>ຊື່ຂອງຮູບແບບຍ່ອຍຍາວເກີນໄປ (ສູງສຸດ 10000 ຕົວອັກສອນ)</translation></message>
++    <message>
++        <source>too many named subpatterns (maximum 256)</source>
++        <translation>ມີຊື່ຂອງຮູບແບບຍ່ອຍຫຼາຍເກີນໄປ (ສູງສຸດ 256)</translation></message>
++    <message>
++        <source>invalid range in character class</source>
++        <translation>ຊ່ວງບໍ່ຖືກຕ້ອງໃນຊັ້ນຕົວອັກສອນ</translation></message>
++    <message>
++        <source>octal value is greater than \377 in 8-bit non-UTF-8 mode</source>
++        <translation>ຄ່າອອກຕັລແມ່ນຫຼາຍກວ່າ \377 ໃນໂໝດທີ່ບໍ່ແມ່ນ UTF-8 8-bit</translation></message>
++    <message>
++        <source>internal error: overran compiling workspace</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ: ລະຫັດການຄຳນວນເກີນຂອບເຂດຂອງພື້ນທີ່ເຮັດວຽກ</translation></message>
++    <message>
++        <source>internal error: previously-checked referenced subpattern not found</source>
++        <translation>ຜິດພາດພາຍໃນ: ບໍ່ພົບຮູບແບບຍ່ອຍທີ່ອ້າງອີງກ່ອນໜ້ານີ້</translation></message>
++    <message>
++        <source>DEFINE group contains more than one branch</source>
++        <translation>ກຸ່ມ DEFINE ມີຫຼາຍກວ່າໜຶ່ງສາຂາ</translation></message>
++    <message>
++        <source>missing opening brace after \o</source>
++        <translation>ຂາດເຄື່ອງໝາຍວົງປີກກາປິດຫຼັງຈາກ \o</translation></message>
++    <message>
++        <source>internal error: unknown newline setting</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ: ການຕັ້ງຄ່າຂອງບັນທຶກໃໝ່ທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>\g is not followed by a braced, angle-bracketed, or quoted name/number or by a plain number</source>
++        <translation>\g ບໍ່ໄດ້ຕາມດ້ວຍຊື່/ເລກທີ່ມີວົງເລັບ, ມຸມວົງເລັບ, ຫຼືອ້າງອີງ ຫຼືໂດຍເລກທົ່ວໄປ</translation></message>
++    <message>
++        <source>a numbered reference must not be zero</source>
++        <translation>ການອ້າງອີງເລກຕ້ອງບໍ່ເປັນສູນ</translation></message>
++    <message>
++        <source>an argument is not allowed for (*ACCEPT), (*FAIL), or (*COMMIT)</source>
++        <translation>ອາກິວເມັນບໍ່ອະນຸຍາດໃຫ້ສໍາລັບ (*ACCEPT), (*FAIL), ຫຼື (*COMMIT)</translation></message>
++    <message>
++        <source>(*VERB) not recognized or malformed</source>
++        <translation>(*ຄຳກິລິຍາ) ບໍ່ຮັບຮູ້ ຫຼື ມີຮູບແບບບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>number is too big</source>
++        <translation>ຈຳນວນໃຫຍ່ເກີນໄປ</translation></message>
++    <message>
++        <source>subpattern name expected</source>
++        <translation>ຊື່ຂອງຮູບແບບຍ່ອຍທີ່ຄາດຫວັງ</translation></message>
++    <message>
++        <source>digit expected after (?+</source>
++        <translation>ຕົວເລກທີ່ຄາດຫວັງຫຼັງຈາກ (?+</translation></message>
++    <message>
++        <source>non-octal character in \o{} (closing brace missing?)</source>
++        <translation>ຕົວອັກສອນທີ່ບໍ່ແມ່ນໂອກຕໍ່ໃນ \o{} (ວົງປີກກາປິດຫາຍໄປ?)</translation></message>
++    <message>
++        <source>different names for subpatterns of the same number are not allowed</source>
++        <translation>ຊື່ທີ່ແຕກຕ່າງກັນສຳລັບຮູບແບບຍ່ອຍຂອງເລກດຽວກັນບໍ່ອະນຸຍາດ</translation></message>
++    <message>
++        <source>(*MARK) must have an argument</source>
++        <translation>(*MARK) ຕ້ອງມີອາກິວເມນ</translation></message>
++    <message>
++        <source>non-hex character in \x{} (closing brace missing?)</source>
++        <translation>ຕົວອັກສອນທີ່ບໍ່ແມ່ນເລກສິບຫົກໃນ \x{} (ວົງປີກກາປິດບໍ່ມີ?)</translation></message>
++    <message>
++        <source>\c must be followed by a printable ASCII character</source>
++        <translation>\c ຕ້ອງຖືກຕິດຕາມດ້ວຍຕົວອັກສອນ ASCII ທີ່ສາມາດພິມໄດ້</translation></message>
++    <message>
++        <source>\c must be followed by a letter or one of [\]^_?</source>
++        <translation>\c ຕ້ອງຖືກຕິດຕາມດ້ວຍຕົວອັກສອນ ຫຼື ໜຶ່ງໃນ [\]^_?</translation></message>
++    <message>
++        <source>\k is not followed by a braced, angle-bracketed, or quoted name</source>
++        <translation>\k ບໍ່ຖືກຕ້ອງຕາມດ້ວຍຊື່ທີ່ມີວົງເລັບ, ມຸມວົງເລັບ, ຫຼືຊື່ທີ່ຖືກອ້າງອີງ</translation></message>
++    <message>
++        <source>internal error: unknown opcode in find_fixedlength()</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ: ບໍ່ຮູ້ opcode ໃນ find_fixedlength()</translation></message>
++    <message>
++        <source>\N is not supported in a class</source>
++        <translation>\N ບໍ່ຖືກຮອງຮັບໃນຫ້ອງຮຽນ</translation></message>
++    <message>
++        <source>SPARE ERROR</source>
++        <translation>ຂໍ້ຜິດພາດສຳຮອງ</translation></message>
++    <message>
++        <source>disallowed Unicode code point (&gt;= 0xd800 &amp;&amp; &lt;= 0xdfff)</source>
++        <translation>ບໍ່ອະນຸຍາດຈຸດລະຫັດ Unicode (&gt;= 0xd800 &amp;&amp; &lt;= 0xdfff)</translation></message>
++    <message>
++        <source>using UTF is disabled by the application</source>
++        <translation>ການໃຊ້ UTF ຖືກປິດໂດຍແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>using UCP is disabled by the application</source>
++        <translation>ການໃຊ້ UCP ຖືກປິດໂດຍແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>name is too long in (*MARK), (*PRUNE), (*SKIP), or (*THEN)</source>
++        <translation>ຊື່ຍາວເກີນໄປໃນ (*MARK), (*PRUNE), (*SKIP), ຫຼື (*THEN)</translation></message>
++    <message>
++        <source>character code point value in \u.... sequence is too large</source>
++        <translation>ຄ່າຈຸດລະຫັດຕົວອັກສອນໃນລຳດັບ \u.... ໃຫຍ່ເກີນໄປ</translation></message>
++    <message>
++        <source>digits missing in \x{} or \o{}</source>
++        <translation>ຕົວເລກຫາຍໄປໃນ \x{} ຫຼື \o{}</translation></message>
++    <message>
++        <source>syntax error in (?(VERSION condition</source>
++        <translation>ຂໍ້ຜິດພາດ syntax ໃນ (?(VERSION condition</translation></message>
++    <message>
++        <source>escape sequence is invalid in character class</source>
++        <translation>escape sequence ບໍ່ຖືກຕ້ອງໃນ character class</translation></message>
++    <message>
++        <source>missing closing parenthesis for condition</source>
++        <translation>ຂາດວົງເປີດສຳລັບເງື່ອນໄຂ</translation></message>
++    <message>
++        <source>a relative value of zero is not allowed</source>
++        <translation>ຄ່າທີ່ກ່ຽວຂ້ອງຂອງສູນບໍ່ອະນຸຍາດ</translation></message>
++    <message>
++        <source>conditional subpattern contains more than two branches</source>
++        <translation>ສະພາບຍ່ອຍຮູບແບບມີຫຼາຍກວ່າສອງສາຂາ</translation></message>
++    <message>
++        <source>digit expected after (?+ or (?-</source>
++        <translation>ຕົວເລກທີ່ຄາດຫວັງຫຼັງຈາກ (?+ ຫຼື (?-</translation></message>
++    <message>
++        <source>lookbehind is too complicated</source>
++        <translation>lookbehind ແມ່ນສັບສົນເກີນໄປ</translation></message>
++    <message>
++        <source>\C is not allowed in a lookbehind assertion in UTF-16 mode</source>
++        <translation>\C ບໍ່ອະນຸຍາດໃຫ້ໃຊ້ໃນການກວດສອບ lookbehind ໃນໂໝດ UTF-16</translation></message>
++    <message>
++        <source>PCRE2 does not support \F, \L, \l, \N{name}, \U, or \u</source>
++        <translation>PCRE2 ບໍ່ຮອງຮັບ \F, \L, \l, \N{name}, \U, ຫຼື \u</translation></message>
++    <message>
++        <source>syntax error in subpattern name (missing terminator?)</source>
++        <translation>ຂໍ້ຜິດພາດໃນການຂຽນຊື່ຮູບແບບຍ່ອຍ (ຂາດຕົວຢຸດ?)</translation></message>
++    <message>
++        <source>subpattern name must start with a non-digit</source>
++        <translation>ຊື່ຂອງຮູບແບບຍ່ອຍຕ້ອງເລີ່ມຕົ້ນດ້ວຍຕົວເລກທີ່ບໍ່ແມ່ນຕົວເລກ</translation></message>
++    <message>
++        <source>subpattern name is too long (maximum 32 code units)</source>
++        <translation>ຊື່ຂອງຮູບແບບຍ່ອຍຍາວເກີນໄປ (ສູງສຸດ 32 ຫົວໜ່ວຍລະຫັດ)</translation></message>
++    <message>
++        <source>too many named subpatterns (maximum 10000)</source>
++        <translation>ມີຊື່ຮູບແບບຍ່ອຍຫຼາຍເກີນໄປ (ສູງສຸດ 10000)</translation></message>
++    <message>
++        <source>DEFINE subpattern contains more than one branch</source>
++        <translation>ກໍານົດລະບົບຍ່ອຍປະກອບມີຫຼາຍກວ່າຫນຶ່ງສາຂາ</translation></message>
++    <message>
++        <source>(?R (recursive pattern call) must be followed by a closing parenthesis</source>
++        <translation>(?R (ຮູບແບບການເອີ້ນຊໍ້າ) ຕ້ອງຖືກຕິດຕາມດ້ວຍວົງເລັບປິດ)</translation></message>
++    <message>
++        <source>obsolete error (should not occur)</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ລ້າສະໄຫມ (ບໍ່ຄວນເກີດຂຶ້ນ)</translation></message>
++    <message>
++        <source>subpattern number is too big</source>
++        <translation>ຈຳນວນຂອງຮູບແບບຍ່ອຍເກີນຂະໜາດ</translation></message>
++    <message>
++        <source>internal error: parsed pattern overflow</source>
++        <translation>ຜິດພາດພາຍໃນ: ການວິເຄາະຮູບແບບເກີນຂອບເຂດ</translation></message>
++    <message>
++        <source>internal error: unknown meta code in check_lookbehinds()</source>
++        <translation>ຜິດພາດພາຍໃນ: ລະຫັດ meta ທີ່ບໍ່ຮູ້ຈັກໃນ check_lookbehinds()</translation></message>
++    <message>
++        <source>callout string is too long</source>
++        <translation>ສະຕຣິງການເອີ້ນອອກຍາວເກີນໄປ</translation></message>
++    <message>
++        <source>digits missing in \x{} or \o{} or \N{U+}</source>
++        <translation>ຕົວເລກຫາຍໄປໃນ \x{} ຫຼື \o{} ຫຼື \N{U+}</translation></message>
++    <message>
++        <source>syntax error or number too big in (?(VERSION condition</source>
++        <translation>ຂໍ້ຜິດພາດ syntax ຫຼື ຕົວເລກໃຫຍ່ເກີນໄປໃນ (?(VERSION condition</translation></message>
++    <message>
++        <source>internal error: unknown opcode in auto_possessify()</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ: ບໍ່ຮູ້ opcode ໃນ auto_possessify()</translation></message>
++    <message>
++        <source>missing terminating delimiter for callout with string argument</source>
++        <translation>ຂາດຕົວຈຳກັດສິ້ນສຸດສຳລັບການເອີ້ນອອກດ້ວຍອາກິວເມນຕ໌ສະຕຣິງ</translation></message>
++    <message>
++        <source>unrecognized string delimiter follows (?C</source>
++        <translation>ບໍ່ຮູ້ຈັກຕົວຈຳກັດສະຕຣິງຕາມຫຼັງ (?C</translation></message>
++    <message>
++        <source>using \C is disabled by the application</source>
++        <translation>ການໃຊ້ \C ຖືກປິດໂດຍແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>(?| and/or (?J: or (?x: parentheses are too deeply nested</source>
++        <translation>(?| ແລະ/ຫຼື (?J: ຫຼື (?x: ວົງເລັບຖືກຊ້ອນເລິກເກີນໄປ</translation></message>
++    <message>
++        <source>using \C is disabled in this PCRE2 library</source>
++        <translation>ການໃຊ້ \C ຖືກປິດໃຊ້ງານໃນຫໍສະໝຸດ PCRE2 ນີ້</translation></message>
++    <message>
++        <source>regular expression is too complicated</source>
++        <translation>regular expression ສັບຊ້ອນເກີນໄປ</translation></message>
++    <message>
++        <source>lookbehind assertion is too long</source>
++        <translation>ການອ້າງອີງ lookbehind ຍາວເກີນໄປ</translation></message>
++    <message>
++        <source>pattern string is longer than the limit set by the application</source>
++        <translation>ສະຕຣິງຮູບແບບຍາວກວ່າຂອບເຂດທີ່ກໍານົດໄວ້ໂດຍແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>internal error: unknown code in parsed pattern</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ: ລະຫັດທີ່ບໍ່ຮູ້ຈັກໃນຮູບແບບທີ່ວິເຄາະ</translation></message>
++    <message>
++        <source>internal error: bad code value in parsed_skip()</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ: ຄ່າລະຫັດບໍ່ຖືກຕ້ອງໃນ parsed_skip()</translation></message>
++    <message>
++        <source>PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES is not allowed in UTF-16 mode</source>
++        <translation>PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES ບໍ່ອະນຸຍາດໃນໂໝດ UTF-16</translation></message>
++    <message>
++        <source>invalid option bits with PCRE2_LITERAL</source>
++        <translation>ຕົວເລືອກບິດບໍ່ຖືກຕ້ອງກັບ PCRE2_LITERAL</translation></message>
++    <message>
++        <source>\N{U+dddd} is supported only in Unicode (UTF) mode</source>
++        <translation>\N{U+dddd} ຖືກສະໜັບສະໜູນພຽງແຕ່ໃນໂໝດ Unicode (UTF)</translation></message>
++    <message>
++        <source>invalid hyphen in option setting</source>
++        <translation>ການຕັ້ງຄ່າຕົວເລືອກມີເຄື່ອງໝາຍຂີດບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>(*alpha_assertion) not recognized</source>
++        <translation>(*alpha_assertion) ບໍ່ໄດ້ຮັບການຮັບຮູ້</translation></message>
++    <message>
++        <source>script runs require Unicode support, which this version of PCRE2 does not have</source>
++        <translation>ສະຄຣິບຕ້ອງການການສະໜັບສະໜູນ Unicode, ເຊິ່ງລຸ້ນນີ້ຂອງ PCRE2 ບໍ່ມີ</translation></message>
++    <message>
++        <source>too many capturing groups (maximum 65535)</source>
++        <translation>ກຸ່ມຈັບຫຼາຍເກີນໄປ (ສູງສຸດ 65535)</translation></message>
++    <message>
++        <source>atomic assertion expected after (?( or (?(?C)</source>
++        <translation>ການອ້າງອີງອະຕອມຖືກຄາດຫວັງຫຼັງຈາກ (?( ຫຼື (?(?C)</translation></message>
++    <message>
++        <source>no match</source>
++        <translation>ບໍ່ມີການກົງກັນ</translation></message>
++    <message>
++        <source>partial match</source>
++        <translation>ການຈັບຄູ່ບາງສ່ວນ</translation></message>
++    <message>
++        <source>UTF-8 error: 1 byte missing at end</source>
++        <translation>ຜິດພາດ UTF-8: 1 ໄບຕ໌ຫາຍໄປທີ່ທ້າຍ</translation></message>
++    <message>
++        <source>UTF-8 error: 2 bytes missing at end</source>
++        <translation>UTF-8 ຜິດພາດ: 2 ໄບຕ໌ຫາຍໄປທີ່ທ້າຍ</translation></message>
++    <message>
++        <source>UTF-8 error: 3 bytes missing at end</source>
++        <translation>ຜິດພາດ UTF-8: ຂາດ 3 ໄບຕ໌ທີ່ທ້າຍ</translation></message>
++    <message>
++        <source>UTF-8 error: 4 bytes missing at end</source>
++        <translation>ຜິດພາດ UTF-8: 4 ໄບຕ໌ຫາຍໄປທີ່ທ້າຍ</translation></message>
++    <message>
++        <source>UTF-8 error: 5 bytes missing at end</source>
++        <translation>ຜິດພາດ UTF-8: 5 ໄບຕ໌ຂາດຫາຍໄປທີ່ທ້າຍ</translation></message>
++    <message>
++        <source>UTF-8 error: byte 2 top bits not 0x80</source>
++        <translation>UTF-8 ຜິດພາດ: ໄບທີ 2 ບິດເທິງບໍ່ແມ່ນ 0x80</translation></message>
++    <message>
++        <source>UTF-8 error: byte 3 top bits not 0x80</source>
++        <translation>UTF-8 ຜິດພາດ: ໄບທີ 3 ບິດເທິງບໍ່ແມ່ນ 0x80</translation></message>
++    <message>
++        <source>UTF-8 error: byte 4 top bits not 0x80</source>
++        <translation>UTF-8 ຜິດພາດ: ໄບທີ 4 ບິດເທິງສຸດບໍ່ແມ່ນ 0x80</translation></message>
++    <message>
++        <source>UTF-8 error: byte 5 top bits not 0x80</source>
++        <translation>ຜິດພາດ UTF-8: ບິດທີ່ 5 ບໍ່ແມ່ນ 0x80</translation></message>
++    <message>
++        <source>UTF-8 error: byte 6 top bits not 0x80</source>
++        <translation>UTF-8 ຜິດພາດ: ໄບທີ 6 ບິດເທິງບໍ່ແມ່ນ 0x80</translation></message>
++    <message>
++        <source>UTF-8 error: 5-byte character is not allowed (RFC 3629)</source>
++        <translation>UTF-8 ຜິດພາດ: ຕົວອັກສອນ 5-byte ບໍ່ອະນຸຍາດ (RFC 3629)</translation></message>
++    <message>
++        <source>UTF-8 error: 6-byte character is not allowed (RFC 3629)</source>
++        <translation>UTF-8 ຜິດພາດ: ຕົວອັກສອນ 6-byte ບໍ່ອະນຸຍາດ (RFC 3629)</translation></message>
++    <message>
++        <source>UTF-8 error: code points greater than 0x10ffff are not defined</source>
++        <translation>ຜິດພາດ UTF-8: ຈຸດລະຫັດທີ່ຫຼາຍກວ່າ 0x10ffff ບໍ່ໄດ້ຖືກກໍານົດ</translation></message>
++    <message>
++        <source>UTF-8 error: code points 0xd800-0xdfff are not defined</source>
++        <translation>UTF-8 ຜິດພາດ: ລະຫັດຈຸດ 0xd800-0xdfff ບໍ່ໄດ້ຖືກກຳນົດ</translation></message>
++    <message>
++        <source>UTF-8 error: overlong 2-byte sequence</source>
++        <translation>UTF-8 ຜິດພາດ: ລຳດັບ 2-byte ຍາວເກີນໄປ</translation></message>
++    <message>
++        <source>UTF-8 error: overlong 3-byte sequence</source>
++        <translation>ຜິດພາດ UTF-8: ລຳດັບ 3 ໄບຕ໌ຍາວເກີນໄປ</translation></message>
++    <message>
++        <source>UTF-8 error: overlong 4-byte sequence</source>
++        <translation>ຜິດພາດ UTF-8: ລຳດັບ 4-byte ຍາວເກີນໄປ</translation></message>
++    <message>
++        <source>UTF-8 error: overlong 5-byte sequence</source>
++        <translation>ຜິດພາດ UTF-8: ລຳດັບ 5-byte ຍາວເກີນໄປ</translation></message>
++    <message>
++        <source>UTF-8 error: overlong 6-byte sequence</source>
++        <translation>ຜິດພາດ UTF-8: ລຳດັບ 6 ໄບຍາວເກີນໄປ</translation></message>
++    <message>
++        <source>UTF-8 error: isolated byte with 0x80 bit set</source>
++        <translation>ຜິດພາດ UTF-8: ໄບທີ່ຢູ່ດ່ຽວທີ່ຕັ້ງບິດ 0x80</translation></message>
++    <message>
++        <source>UTF-8 error: illegal byte (0xfe or 0xff)</source>
++        <translation>UTF-8 ຜິດພາດ: ໄບຕ໌ທີ່ບໍ່ຖືກຕ້ອງ (0xfe ຫຼື 0xff)</translation></message>
++    <message>
++        <source>UTF-16 error: missing low surrogate at end</source>
++        <translation>UTF-16 ຜິດພາດ: ຂາດຕົວຕໍ່ຫາຍໃນຕອນທ້າຍ</translation></message>
++    <message>
++        <source>UTF-16 error: invalid low surrogate</source>
++        <translation>UTF-16 ຜິດພາດ: ຕົວແທນຕ່ຳບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>UTF-16 error: isolated low surrogate</source>
++        <translation>UTF-16 ຜິດພາດ: ຕົວແທນຕ່ຳທີ່ຢູ່ດ່ຽວ</translation></message>
++    <message>
++        <source>UTF-32 error: code points 0xd800-0xdfff are not defined</source>
++        <translation>UTF-32 ຜິດພາດ: ລະຫັດຈຸດ 0xd800-0xdfff ບໍ່ໄດ້ຖືກກຳນົດ</translation></message>
++    <message>
++        <source>UTF-32 error: code points greater than 0x10ffff are not defined</source>
++        <translation>UTF-32 ຜິດພາດ: ຈຸດລະຫັດທີ່ໃຫຍ່ກວ່າ 0x10ffff ບໍ່ໄດ້ຖືກກໍານົດ</translation></message>
++    <message>
++        <source>bad data value</source>
++        <translation>ຂໍ້ມູນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>patterns do not all use the same character tables</source>
++        <translation>ຮູບແບບບໍ່ໄດ້ໃຊ້ຕາຕະລາງຕົວອັກສອນດຽວກັນທັງໝົດ</translation></message>
++    <message>
++        <source>magic number missing</source>
++        <translation>ໝາຍເລກວິເສດຫາຍໄປ</translation></message>
++    <message>
++        <source>pattern compiled in wrong mode: 8/16/32-bit error</source>
++        <translation>ຮູບແບບທີ່ຖືກຄັດລອກໃນໂໝດທີ່ຜິດພາດ: ຂໍ້ຜິດພາດ 8/16/32-bit</translation></message>
++    <message>
++        <source>bad offset value</source>
++        <translation>ຄ່າອອບເຊັດບໍ່ດີ</translation></message>
++    <message>
++        <source>bad option value</source>
++        <translation>ຄ່າຕົວເລືອກບໍ່ດີ</translation></message>
++    <message>
++        <source>invalid replacement string</source>
++        <translation>ສະຕຣິງທີ່ທົດແທນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>bad offset into UTF string</source>
++        <translation>ຕຳແໜ່ງບໍ່ຖືກຕ້ອງໃນສະຕຣິງ UTF</translation></message>
++    <message>
++        <source>callout error code</source>
++        <translation>ລະຫັດຜິດພາດການເອີ້ນອອກ</translation></message>
++    <message>
++        <source>invalid data in workspace for DFA restart</source>
++        <translation>ຂໍ້ມູນບໍ່ຖືກຕ້ອງໃນພື້ນທີ່ເຮັດວຽກສໍາລັບການເລີ່ມຕົ້ນ DFA ໃໝ່</translation></message>
++    <message>
++        <source>too much recursion for DFA matching</source>
++        <translation>ການກົດຊ້ອນຫຼາຍເກີນໄປສຳລັບການຈັບຄູ່ DFA</translation></message>
++    <message>
++        <source>backreference condition or recursion test is not supported for DFA matching</source>
++        <translation>ການທົດສອບສະພາບການອ້າງອີງກັບຫຼັງ ຫຼື ການທົດສອບການເຮັດຊ້ຳ ບໍ່ຖືກສະຫນັບສະຫນູນສຳລັບການຈັບຄູ່ DFA</translation></message>
++    <message>
++        <source>function is not supported for DFA matching</source>
++        <translation>ຟັງຊັນນີ້ບໍ່ຖືກຮອງຮັບສຳລັບການຈັບຄູ່ DFA</translation></message>
++    <message>
++        <source>pattern contains an item that is not supported for DFA matching</source>
++        <translation>ຮູບແບບມີລາຍການທີ່ບໍ່ຖືກສະໜັບສະໜູນສຳລັບການຈັບຄູ່ DFA</translation></message>
++    <message>
++        <source>workspace size exceeded in DFA matching</source>
++        <translation>ຂະໜາດພື້ນທີ່ເຮັດວຽກເກີນຂອບເຂດໃນການຈັບຄູ່ DFA</translation></message>
++    <message>
++        <source>internal error - pattern overwritten?</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ - ຮູບແບບຖືກຂຽນທັບແລ້ວ?</translation></message>
++    <message>
++        <source>bad JIT option</source>
++        <translation>ຕົວເລືອກ JIT ບໍ່ດີ</translation></message>
++    <message>
++        <source>JIT stack limit reached</source>
++        <translation>ໄດ້ຮັບຂີດຈຳກັດສະເຕັກ JIT</translation></message>
++    <message>
++        <source>match limit exceeded</source>
++        <translation>ຈຳກັດການຈັບຄູ່ເກີນ</translation></message>
++    <message>
++        <source>no more memory</source>
++        <translation>ບໍ່ມີຫນ່ວຍຄວາມຈຳເພີ່ມເຕີມ</translation></message>
++    <message>
++        <source>unknown substring</source>
++        <translation>ບໍ່ຮູ້ສະຕຣິງຍ່ອຍ</translation></message>
++    <message>
++        <source>non-unique substring name</source>
++        <translation>ຊື່ສະເພາະຍ່ອຍທີ່ບໍ່ເປັນເອກະລັກ</translation></message>
++    <message>
++        <source>NULL argument passed</source>
++        <translation>ອາກິວເມັນ NULL ຖືກສົ່ງ</translation></message>
++    <message>
++        <source>nested recursion at the same subject position</source>
++        <translation>ການກັບຄືນຊ້ຳຊ້ອນຢູ່ຕຳແໜ່ງຫົວຂໍ້ດຽວກັນ</translation></message>
++    <message>
++        <source>matching depth limit exceeded</source>
++        <translation>ຂີດຈຳກັດຄວາມເລິກຂອງການຈັບຄູ່ເກີນ</translation></message>
++    <message>
++        <source>match with end before start or start moved backwards is not supported</source>
++        <translation>ການຈັບຄູ່ກັບຈຸດສິ້ນສຸດກ່ອນຈຸດເລີ່ມຕົ້ນ ຫຼື ຈຸດເລີ່ມຕົ້ນຖືກຍ້າຍກັບມາດ້ານຫຼັງ ບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation></message>
++    <message>
++        <source>bad serialized data</source>
++        <translation>ຂໍ້ມູນທີ່ຖືກຈັດລຽງລໍາດັບບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>heap limit exceeded</source>
++        <translation>ຂອບເຂດຮີບເກີນ</translation></message>
++    <message>
++        <source>invalid syntax</source>
++        <translation>ວັກຕອນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>internal error - duplicate substitution match</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ - ການຈັບຄູ່ການທົດແທນຊໍ້າ</translation></message>
++    <message>
++        <source>PCRE2_MATCH_INVALID_UTF is not supported for DFA matching</source>
++        <translation>PCRE2_MATCH_INVALID_UTF ບໍ່ໄດ້ຮັບການສະໜັບສະໜູນສຳລັບການຈັບຄູ່ DFA</translation></message>
++    <message>
++        <source>recursion limit exceeded</source>
++        <translation>ຂີດຈຳກັດການເອີ້ນຄືນຕົວເອງເກີນ</translation></message>
++    <message>
++        <source>requested value is not available</source>
++        <translation>ຄ່າທີ່ຮ້ອງຂໍບໍ່ມີ</translation></message>
++    <message>
++        <source>requested value is not set</source>
++        <translation>ຄ່າທີ່ຮ້ອງຂໍບໍ່ໄດ້ຖືກຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>offset limit set without PCRE2_USE_OFFSET_LIMIT</source>
++        <translation>ກຳນົດຂອບເຂດອອບເຊັດໂດຍບໍ່ມີ PCRE2_USE_OFFSET_LIMIT</translation></message>
++    <message>
++        <source>bad escape sequence in replacement string</source>
++        <translation>ລຳດັບການຫນີທີ່ບໍ່ດີໃນສະຕຣິງການທົດແທນ</translation></message>
++    <message>
++        <source>expected closing curly bracket in replacement string</source>
++        <translation>ຄາດຫວັງວ່າຈະມີວົງປີກກາປິດໃນສະຕຣິງທີ່ທົດແທນ</translation></message>
++    <message>
++        <source>bad substitution in replacement string</source>
++        <translation>ການທົດແທນສະຕຣິງທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>match with end before start is not supported</source>
++        <translation>ການຈັບຄູ່ກັບຈຸດສິ້ນສຸດກ່ອນຈຸດເລີ່ມຕົ້ນບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation></message>
++    <message>
++        <source>too many replacements (more than INT_MAX)</source>
++        <translation>ມີການປ່ຽນແທນຫຼາຍເກີນໄປ (ຫຼາຍກວ່າ INT_MAX)</translation></message>
++</context>
++<context>
++    <name>QSQLite2Driver</name>
++    <message>
++        <source>Error opening database</source>
++        <translation>ຜິດພາດໃນການເປີດຖານຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Unable to begin transaction</source>
++        <translation>ບໍ່ສາມາດເລີ່ມທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to commit transaction</source>
++        <translation>ບໍ່ສາມາດດຳເນີນການທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to rollback transaction</source>
++        <translation>ບໍ່ສາມາດກັບຄືນການເຮັດທຸລະກຳ</translation></message>
++</context>
++<context>
++    <name>QSQLite2Result</name>
++    <message>
++        <source>Unable to fetch results</source>
++        <translation>ບໍ່ສາມາດດຶງຜົນໄດ້ຮັບ</translation></message>
++    <message>
++        <source>Unable to execute statement</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖະແຫຼງ</translation></message>
++</context>
++<context>
++    <name>QSQLiteDriver</name>
++    <message>
++        <source>Error opening database</source>
++        <translation>ຜິດພາດໃນການເປີດຖານຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Error closing database</source>
++        <translation>ຜິດພາດໃນການປິດຖານຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Unable to begin transaction</source>
++        <translation>ບໍ່ສາມາດເລີ່ມທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to commit transaction</source>
++        <translation>ບໍ່ສາມາດດຳເນີນການທຸລະກຳໄດ້</translation></message>
++    <message>
++        <source>Unable to rollback transaction</source>
++        <translation>ບໍ່ສາມາດກັບຄືນການເຮັດທຸລະກຳ</translation></message>
++</context>
++<context>
++    <name>QSQLiteResult</name>
++    <message>
++        <source>Unable to fetch row</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນແຖວໄດ້</translation></message>
++    <message>
++        <source>No query</source>
++        <translation>ບໍ່ມີຄຳຖາມ</translation></message>
++    <message>
++        <source>Unable to execute statement</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳຖະແຫຼງ</translation></message>
++    <message>
++        <source>Unable to execute multiple statements at a time</source>
++        <translation>ບໍ່ສາມາດປະຕິບັດຄຳສັ່ງຫຼາຍຄຳພ້ອມກັນໄດ້</translation></message>
++    <message>
++        <source>Unable to reset statement</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າຄຳຖະແຫຼງຄືນໃໝ່</translation></message>
++    <message>
++        <source>Unable to bind parameters</source>
++        <translation>ບໍ່ສາມາດຜູກພາຣາມີເຕີໄດ້</translation></message>
++    <message>
++        <source>Parameter count mismatch</source>
++        <translation>ຈຳນວນພາຣາມີເຕີບໍ່ກົງກັນ</translation></message>
++</context>
++<context>
++    <name>QSaveFile</name>
++    <message>
++        <source>Existing file %1 is not writable</source>
++        <translation>ມີໄຟລ໌ %1 ທີ່ມີຢູ່ແລ້ວ ບໍ່ສາມາດຂຽນໄດ້</translation></message>
++    <message>
++        <source>Filename refers to a directory</source>
++        <translation>ຊື່ໄຟລ໌ຊີ້ໃຫ້ເຫັນເຖິງໂຟນເດີ</translation></message>
++    <message>
++        <source>QSaveFile cannot open '%1' without direct write fallback enabled.</source>
++        <translation>QSaveFile ບໍ່ສາມາດເປີດ '%1' ໄດ້ໂດຍບໍ່ເປີດໃຊ້ການສະຫຼັບການຂຽນໂດຍກົງ.</translation></message>
++    <message>
++        <source>QSaveFile cannot open '%1' without direct write fallback enabled: path contains an Alternate Data Stream specifier</source>
++        <translation>QSaveFile ບໍ່ສາມາດເປີດ '%1' ໂດຍບໍ່ເປີດໃຊ້ການສະຫຼັບການຂຽນໂດຍກົງໄດ້: ເສັ້ນທາງມີຕົວກຳນົດສະຕຣີມຂໍ້ມູນທາງເລືອກ</translation></message>
++    <message>
++        <source>Writing canceled by application</source>
++        <translation>ການຂຽນຖືກຍົກເລີກໂດຍແອັບພລິເຄຊັນ</translation></message>
++</context>
++<context>
++    <name>QScrollBar</name>
++    <message>
++        <source>Scroll here</source>
++        <translation>ເລື່ອນທີ່ນີ້</translation></message>
++    <message>
++        <source>Left edge</source>
++        <translation>ຂອບຊ້າຍ</translation></message>
++    <message>
++        <source>Top</source>
++        <translation>ດ້ານເທິງ</translation></message>
++    <message>
++        <source>Right edge</source>
++        <translation>ຂວາ</translation></message>
++    <message>
++        <source>Bottom</source>
++        <translation>ລຸ່ມ</translation></message>
++    <message>
++        <source>Page left</source>
++        <translation>ໜ້າທີ່ຖືກປະຖິ້ມ</translation></message>
++    <message>
++        <source>Page up</source>
++        <translation>ຫນ້າຂຶ້ນ</translation></message>
++    <message>
++        <source>Page right</source>
++        <translation>ໜ້າຂວາ</translation></message>
++    <message>
++        <source>Page down</source>
++        <translation>ຫນ້າລົງ</translation></message>
++    <message>
++        <source>Scroll left</source>
++        <translation>ເລື່ອນໄປຊ້າຍ</translation></message>
++    <message>
++        <source>Scroll up</source>
++        <translation>ເລື່ອນຂຶ້ນ</translation></message>
++    <message>
++        <source>Scroll right</source>
++        <translation>ເລື່ອນໄປທາງຂວາ</translation></message>
++    <message>
++        <source>Scroll down</source>
++        <translation>ເລື່ອນລົງ</translation></message>
++</context>
++<context>
++    <name>QSctpSocket</name>
++    <message>
++        <source>The remote host closed the connection</source>
++        <translation>ໂຮສຕົ້ນທາງອື່ນປິດການເຊື່ອມຕໍ່</translation></message>
++</context>
++<context>
++    <name>QSharedMemory</name>
++    <message>
++        <source>%1: unable to set key on lock</source>
++        <translation>%1: ບໍ່ສາມາດຕັ້ງຄີໃນລັອກໄດ້</translation></message>
++    <message>
++        <source>%1: create size is less then 0</source>
++        <translation>%1: ຂະໜາດການສ້າງແມ່ນນ້ອຍກວ່າ 0</translation></message>
++    <message>
++        <source>%1: unable to lock</source>
++        <translation>%1: ບໍ່ສາມາດລັອກໄດ້</translation></message>
++    <message>
++        <source>%1: unable to unlock</source>
++        <translation>%1: ບໍ່ສາມາດປົດລັອກໄດ້</translation></message>
++    <message>
++        <source>%1: key is empty</source>
++        <translation>%1: ກະແຈຫວ່າງເປົ່າ</translation></message>
++    <message>
++        <source>%1: bad name</source>
++        <translation>%1: ຊື່ບໍ່ດີ</translation></message>
++    <message>
++        <source>%1: UNIX key file doesn't exist</source>
++        <translation>%1: ໄຟລ໌ກະແຈ UNIX ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>%1: ftok failed</source>
++        <translation>%1: ftok ລົ້ມເຫຼວ</translation></message>
++    <message>
++        <source>%1: unable to make key</source>
++        <translation>%1: ບໍ່ສາມາດສ້າງກະແຈໄດ້</translation></message>
++    <message>
++        <source>%1: system-imposed size restrictions</source>
++        <translation>%1: ຂໍ້ຈຳກັດຂະໜາດທີ່ລະບົບກຳນົດ</translation></message>
++    <message>
++        <source>%1: not attached</source>
++        <translation>%1: ບໍ່ໄດ້ຕິດຕັ້ງ</translation></message>
++    <message>
++        <source>%1: permission denied</source>
++        <translation>%1: ອະນຸຍາດຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>%1: already exists</source>
++        <translation>%1: ມີຢູ່ແລ້ວ</translation></message>
++    <message>
++        <source>%1: doesn't exist</source>
++        <translation>%1: ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>%1: out of resources</source>
++        <translation>%1: ຂາດແຫຼ່ງຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>%1: unknown error %2</source>
++        <translation>%1: ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ %2</translation></message>
++    <message>
++        <source>%1: invalid size</source>
++        <translation>%1: ຂະໜາດບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>%1: key error</source>
++        <translation>%1: ຂໍ້ຜິດພາດຂອງກະແຈ</translation></message>
++    <message>
++        <source>%1: size query failed</source>
++        <translation>%1: ການສອບຖາມຂະໜາດລົ້ມເຫລວ</translation></message>
++</context>
++<context>
++    <name>QShortcut</name>
++    <message>
++        <source>Space</source>
++        <extracomment>This and all following "incomprehensible" strings in QShortcut context are key names. Please use the localized names appearing on actual keyboards or whatever is commonly used.</extracomment>
++        <translation>ອະວະກາດ</translation></message>
++    <message>
++        <source>Esc</source>
++        <translation>ອອກ</translation></message>
++    <message>
++        <source>Tab</source>
++        <translation>ແຖບ</translation></message>
++    <message>
++        <source>Backtab</source>
++        <translation>ກັບຄືນໄປຫາແຖບ</translation></message>
++    <message>
++        <source>Backspace</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Return</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Enter</source>
++        <translation>ໃສ່</translation></message>
++    <message>
++        <source>Ins</source>
++        <translation>ພາສາລາວ</translation></message>
++    <message>
++        <source>Del</source>
++        <translation>ດີລ</translation></message>
++    <message>
++        <source>Pause</source>
++        <translation>ຢຸດຊົ່ວຄາວ</translation></message>
++    <message>
++        <source>Print</source>
++        <translation>ພິມ</translation></message>
++    <message>
++        <source>SysReq</source>
++        <translation>ລະບົບຮຽກຮ້ອງ</translation></message>
++    <message>
++        <source>Home</source>
++        <translation>ໜ້າຫຼັກ</translation></message>
++    <message>
++        <source>End</source>
++        <translation>ສິ້ນສຸດ</translation></message>
++    <message>
++        <source>Left</source>
++        <translation>ຊ້າຍ</translation></message>
++    <message>
++        <source>Up</source>
++        <translation>ຂຶ້ນ</translation></message>
++    <message>
++        <source>Right</source>
++        <translation>ຂວາ</translation></message>
++    <message>
++        <source>Down</source>
++        <translation>ລົງ</translation></message>
++    <message>
++        <source>PgUp</source>
++        <translation>PgUp</translation></message>
++    <message>
++        <source>PgDown</source>
++        <translation>PgDown</translation></message>
++    <message>
++        <source>CapsLock</source>
++        <translation>CapsLock</translation></message>
++    <message>
++        <source>NumLock</source>
++        <translation>NumLock</translation></message>
++    <message>
++        <source>ScrollLock</source>
++        <translation>ScrollLock</translation></message>
++    <message>
++        <source>Menu</source>
++        <translation>ເມນູ</translation></message>
++    <message>
++        <source>Help</source>
++        <translation>ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>Back</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Forward</source>
++        <translation>ສົ່ງຕໍ່</translation></message>
++    <message>
++        <source>Stop</source>
++        <translation>ຢຸດ</translation></message>
++    <message>
++        <source>Refresh</source>
++        <translation>ຟື້ນຟູ</translation></message>
++    <message>
++        <source>Volume Down</source>
++        <translation>ຫຼຸດລະດັບສຽງ</translation></message>
++    <message>
++        <source>Volume Mute</source>
++        <translation>ປິດສຽງ</translation></message>
++    <message>
++        <source>Volume Up</source>
++        <translation>ປັບສຽງໃຫ້ດັງຂຶ້ນ</translation></message>
++    <message>
++        <source>Bass Boost</source>
++        <translation>ກະຕິດສຽງຕ່ຳ</translation></message>
++    <message>
++        <source>Bass Up</source>
++        <translation>ບັດສອງ</translation></message>
++    <message>
++        <source>Bass Down</source>
++        <translation>ບັດດັງຕ່ໍາ</translation></message>
++    <message>
++        <source>Treble Up</source>
++        <translation>ປັບສຽງສູງຂຶ້ນ</translation></message>
++    <message>
++        <source>Treble Down</source>
++        <translation>ຫຼຸດລົງສາມເທົ່າ</translation></message>
++    <message>
++        <source>Media Play</source>
++        <translation>ການຫຼິ້ນມີເດຍ</translation></message>
++    <message>
++        <source>Media Stop</source>
++        <translation>ຢຸດສື່</translation></message>
++    <message>
++        <source>Media Previous</source>
++        <translation>ສື່ກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>Media Next</source>
++        <translation>ສື່ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Media Record</source>
++        <translation>ບັນທຶກສື່</translation></message>
++    <message>
++        <source>Media Pause</source>
++        <extracomment>Media player pause button</extracomment>
++        <translation>ຢຸດຊົດພາບ</translation></message>
++    <message>
++        <source>Toggle Media Play/Pause</source>
++        <extracomment>Media player button to toggle between playing and paused</extracomment>
++        <translation>ປ່ຽນການຫຼິ້ນ/ຢຸດຊົງພາບສຽງ</translation></message>
++    <message>
++        <source>Home Page</source>
++        <translation>ໜ້າຫຼັກ</translation></message>
++    <message>
++        <source>Favorites</source>
++        <translation>ລາຍການທີ່ມັກ</translation></message>
++    <message>
++        <source>Search</source>
++        <translation>ຄົ້ນຫາ</translation></message>
++    <message>
++        <source>Standby</source>
++        <translation>ລໍຖ້າ</translation></message>
++    <message>
++        <source>Open URL</source>
++        <translation>ເປີດ URL</translation></message>
++    <message>
++        <source>Launch Mail</source>
++        <translation>ລະດັບອີເມວ</translation></message>
++    <message>
++        <source>Launch Media</source>
++        <translation>ລະເບີດມີເດຍ</translation></message>
++    <message>
++        <source>Launch (0)</source>
++        <translation>ລຸກຂຶ້ນ (0)</translation></message>
++    <message>
++        <source>Launch (1)</source>
++        <translation>ລຸກຂຶ້ນ (1)</translation></message>
++    <message>
++        <source>Launch (2)</source>
++        <translation>ລຸກຂຶ້ນ (2)</translation></message>
++    <message>
++        <source>Launch (3)</source>
++        <translation>ລຸກຂຶ້ນ (3)</translation></message>
++    <message>
++        <source>Launch (4)</source>
++        <translation>ລະ​ເຊີດ (4)</translation></message>
++    <message>
++        <source>Launch (5)</source>
++        <translation>ລຸກຂຶ້ນ (5)</translation></message>
++    <message>
++        <source>Launch (6)</source>
++        <translation>ລຸກຂຶ້ນ (6)</translation></message>
++    <message>
++        <source>Launch (7)</source>
++        <translation>ລຸກຂຶ້ນ (7)</translation></message>
++    <message>
++        <source>Launch (8)</source>
++        <translation>ລະ​ເວັບ (8)</translation></message>
++    <message>
++        <source>Launch (9)</source>
++        <translation>ລຸກຂຶ້ນ (9)</translation></message>
++    <message>
++        <source>Launch (A)</source>
++        <translation>ລະ​ເບີດ (A)</translation></message>
++    <message>
++        <source>Launch (B)</source>
++        <translation>ລະເບີດ (B)</translation></message>
++    <message>
++        <source>Launch (C)</source>
++        <translation>ລະເບີດ (C)</translation></message>
++    <message>
++        <source>Launch (D)</source>
++        <translation>ລະເບີດ (D)</translation></message>
++    <message>
++        <source>Launch (E)</source>
++        <translation>ລະເບີດ (E)</translation></message>
++    <message>
++        <source>Launch (F)</source>
++        <translation>ລຸ່ນ (F)</translation></message>
++    <message>
++        <source>Launch (G)</source>
++        <translation>ລະ​ເວັບ (G)</translation></message>
++    <message>
++        <source>Launch (H)</source>
++        <translation>ລະເບີດ (H)</translation></message>
++    <message>
++        <source>Monitor Brightness Up</source>
++        <translation>ກວດສອບຄວາມສະຫວ່າງຂອງຈໍສູງຂຶ້ນ</translation></message>
++    <message>
++        <source>Monitor Brightness Down</source>
++        <translation>ຄວາມສະຫວ່າງຂອງຈໍຫຼຸດລົງ</translation></message>
++    <message>
++        <source>Keyboard Light On/Off</source>
++        <translation>ເປີດ/ປິດແສງຄີບອດ</translation></message>
++    <message>
++        <source>Keyboard Brightness Up</source>
++        <translation>ຄວາມສະຫວ່າງຂອງຄີບອດເພີ່ມຂຶ້ນ</translation></message>
++    <message>
++        <source>Keyboard Brightness Down</source>
++        <translation>ຄວາມສະຫວ່າງຄີບອດລົງ</translation></message>
++    <message>
++        <source>Power Off</source>
++        <translation>ປິດໄຟຟ້າ</translation></message>
++    <message>
++        <source>Wake Up</source>
++        <translation>ຕື່ນເຊົ້າ</translation></message>
++    <message>
++        <source>Eject</source>
++        <translation>ຂັບອອກ</translation></message>
++    <message>
++        <source>Screensaver</source>
++        <translation>ຫນ້າຈໍພັກ</translation></message>
++    <message>
++        <source>WWW</source>
++        <translation>ວວວ</translation></message>
++    <message>
++        <source>Sleep</source>
++        <translation>ນອນ</translation></message>
++    <message>
++        <source>LightBulb</source>
++        <translation>ຫລອດໄຟ</translation></message>
++    <message>
++        <source>Shop</source>
++        <translation>ຮ້ານຄ້າ</translation></message>
++    <message>
++        <source>History</source>
++        <translation>ປະຫວັດສາດ</translation></message>
++    <message>
++        <source>Add Favorite</source>
++        <translation>ເພີ່ມລາຍການທີ່ມັກ</translation></message>
++    <message>
++        <source>Hot Links</source>
++        <translation>ລິງຄ໌ຮ້ອນ</translation></message>
++    <message>
++        <source>Adjust Brightness</source>
++        <translation>ປັບຄວາມສະຫວ່າງ</translation></message>
++    <message>
++        <source>Finance</source>
++        <translation>ການເງິນ</translation></message>
++    <message>
++        <source>Community</source>
++        <translation>ຊຸມຊົນ</translation></message>
++    <message>
++        <source>Media Rewind</source>
++        <translation>ກັບຄືນສື່</translation></message>
++    <message>
++        <source>Back Forward</source>
++        <translation>ກັບຄືນ ໄປໜ້າ</translation></message>
++    <message>
++        <source>Application Left</source>
++        <translation>ແອັບພລິເຄຊັນຊ້າຍ</translation></message>
++    <message>
++        <source>Application Right</source>
++        <translation>ສິດທິຂອງແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>Book</source>
++        <translation>ປຶ້ມ</translation></message>
++    <message>
++        <source>CD</source>
++        <translation>ດີວີດີ</translation></message>
++    <message>
++        <source>Calculator</source>
++        <translation>ຈັດການຄິດໄລ່</translation></message>
++    <message>
++        <source>Calendar</source>
++        <translation>ປະຕິທິນ</translation></message>
++    <message>
++        <source>Clear</source>
++        <translation>ລ້າງ</translation></message>
++    <message>
++        <source>Clear Grab</source>
++        <translation>ລຶບການຈັບ</translation></message>
++    <message>
++        <source>Close</source>
++        <translation>ປິດ</translation></message>
++    <message>
++        <source>Adjust contrast</source>
++        <translation>ປັບຄວາມແຕກຕ່າງ</translation></message>
++    <message>
++        <source>Copy</source>
++        <translation>ສຳເນົາ</translation></message>
++    <message>
++        <source>Cut</source>
++        <translation>ຕັດ</translation></message>
++    <message>
++        <source>Display</source>
++        <translation>ສະແດງ</translation></message>
++    <message>
++        <source>DOS</source>
++        <translation>DOS</translation></message>
++    <message>
++        <source>Documents</source>
++        <translation>ເອກະສານ</translation></message>
++    <message>
++        <source>Spreadsheet</source>
++        <translation>ຕາຕະລາງ</translation></message>
++    <message>
++        <source>Browser</source>
++        <translation>ບຣາວເຊີ</translation></message>
++    <message>
++        <source>Game</source>
++        <translation>ເກມ</translation></message>
++    <message>
++        <source>Go</source>
++        <translation>ໄປ</translation></message>
++    <message>
++        <source>iTouch</source>
++        <translation>iTouch</translation></message>
++    <message>
++        <source>Logoff</source>
++        <translation>ອອກຈາກລະບົບ</translation></message>
++    <message>
++        <source>Market</source>
++        <translation>ຕະຫຼາດ</translation></message>
++    <message>
++        <source>Meeting</source>
++        <translation>ການປະຊຸມ</translation></message>
++    <message>
++        <source>Memo</source>
++        <translation>ເມົາ</translation></message>
++    <message>
++        <source>Keyboard Menu</source>
++        <translation>ເມນູຄີບອດ</translation></message>
++    <message>
++        <source>Menu PB</source>
++        <translation>ເມນູ PB</translation></message>
++    <message>
++        <source>My Sites</source>
++        <translation>ເວັບໄຊຂອງຂ້ອຍ</translation></message>
++    <message>
++        <source>News</source>
++        <translation>ຂ່າວ</translation></message>
++    <message>
++        <source>Home Office</source>
++        <translation>ຫ້ອງການທີ່ບ້ານ</translation></message>
++    <message>
++        <source>Option</source>
++        <translation>ທາງເລືອກ</translation></message>
++    <message>
++        <source>Paste</source>
++        <translation>ວາງ</translation></message>
++    <message>
++        <source>Phone</source>
++        <translation>ໂທລະສັບ</translation></message>
++    <message>
++        <source>Reply</source>
++        <translation>ຕອບກັບ</translation></message>
++    <message>
++        <source>Reload</source>
++        <translation>ໂຫຼດຄືນໃໝ່</translation></message>
++    <message>
++        <source>Rotate Windows</source>
++        <translation>ຫມຸນປ່ອງຢ້ຽມ</translation></message>
++    <message>
++        <source>Rotation PB</source>
++        <translation>ການຫມູນວຽນ PB</translation></message>
++    <message>
++        <source>Rotation KB</source>
++        <translation>ການປັບຫັນ KB</translation></message>
++    <message>
++        <source>Save</source>
++        <translation>ບັນທຶກ</translation></message>
++    <message>
++        <source>Send</source>
++        <translation>ສົ່ງ</translation></message>
++    <message>
++        <source>Spellchecker</source>
++        <translation>ກວດກາການສະກົດຄຳ</translation></message>
++    <message>
++        <source>Split Screen</source>
++        <translation>ແບ່ງຫນ້າຈໍ</translation></message>
++    <message>
++        <source>Support</source>
++        <translation>ສະຫນັບສະຫນູນ</translation></message>
++    <message>
++        <source>Task Panel</source>
++        <translation>ກະດານວຽກ</translation></message>
++    <message>
++        <source>Terminal</source>
++        <translation>ເທີມິນແລ</translation></message>
++    <message>
++        <source>To-do list</source>
++        <translation>ລາຍການທີ່ຕ້ອງເຮັດ</translation></message>
++    <message>
++        <source>Tools</source>
++        <translation>ເຄື່ອງມື</translation></message>
++    <message>
++        <source>Travel</source>
++        <translation>ທ່ອງທ່ຽວ</translation></message>
++    <message>
++        <source>Video</source>
++        <translation>ວິດີໂອ</translation></message>
++    <message>
++        <source>Word Processor</source>
++        <translation>ຕົວປະມວນຄຳ</translation></message>
++    <message>
++        <source>XFer</source>
++        <translation>XFer</translation></message>
++    <message>
++        <source>Zoom In</source>
++        <translation>ຂະຫຍາຍຂະໜາດ</translation></message>
++    <message>
++        <source>Zoom Out</source>
++        <translation>ຂະຫຍາຍອອກ</translation></message>
++    <message>
++        <source>Away</source>
++        <translation>ຫ່າງ</translation></message>
++    <message>
++        <source>Messenger</source>
++        <translation>ເມສເຊັນເຈີ</translation></message>
++    <message>
++        <source>WebCam</source>
++        <translation>ກ້ອງເວັບ</translation></message>
++    <message>
++        <source>Mail Forward</source>
++        <translation>ຈົດໝາຍສົ່ງຕໍ່</translation></message>
++    <message>
++        <source>Pictures</source>
++        <translation>ຮູບພາບ</translation></message>
++    <message>
++        <source>Music</source>
++        <translation>ດົນຕີ</translation></message>
++    <message>
++        <source>Battery</source>
++        <translation>ແບັດເຕີຣີ</translation></message>
++    <message>
++        <source>Bluetooth</source>
++        <translation>ບລູທູດ</translation></message>
++    <message>
++        <source>Wireless</source>
++        <translation>ບໍ່ມີສາຍ</translation></message>
++    <message>
++        <source>Ultra Wide Band</source>
++        <translation>ຄວາມກວ້າງຂອງແບນທີ່ກວ້າງຂວາງສຸດ</translation></message>
++    <message>
++        <source>Media Fast Forward</source>
++        <translation>ສື່ການເລັ່ງໄປຂ້າງໜ້າ</translation></message>
++    <message>
++        <source>Audio Repeat</source>
++        <translation>ຊ້ຳຄືນສຽງ</translation></message>
++    <message>
++        <source>Audio Random Play</source>
++        <translation>ສຽງສຸ່ມສຽງ</translation></message>
++    <message>
++        <source>Subtitle</source>
++        <translation>ຄຳບັນຍາຍ</translation></message>
++    <message>
++        <source>Audio Cycle Track</source>
++        <translation>ວົງຈອນຕິດຕາມສຽງ</translation></message>
++    <message>
++        <source>Time</source>
++        <translation>ເວລາ</translation></message>
++    <message>
++        <source>Hibernate</source>
++        <translation>Hibernate</translation></message>
++    <message>
++        <source>View</source>
++        <translation>ເບິ່ງ</translation></message>
++    <message>
++        <source>Top Menu</source>
++        <translation>ເມນູດ້ານເທິງ</translation></message>
++    <message>
++        <source>Power Down</source>
++        <translation>ປິດພະລັງງານ</translation></message>
++    <message>
++        <source>Suspend</source>
++        <translation>ຢຸດຊົ່ວຄາວ</translation></message>
++    <message>
++        <source>Microphone Mute</source>
++        <translation>ປິດສຽງໄມໂຄຣໂຟນ</translation></message>
++    <message>
++        <source>Red</source>
++        <translation>ສີແດງ</translation></message>
++    <message>
++        <source>Green</source>
++        <translation>ຂຽວ</translation></message>
++    <message>
++        <source>Yellow</source>
++        <translation>ສີເຫຼືອງ</translation></message>
++    <message>
++        <source>Blue</source>
++        <translation>ຟ້າ</translation></message>
++    <message>
++        <source>Channel Up</source>
++        <translation>ຊ່ອງທາງຂຶ້ນ</translation></message>
++    <message>
++        <source>Channel Down</source>
++        <translation>ຊ່ອງທາງລົງ</translation></message>
++    <message>
++        <source>Guide</source>
++        <translation>ຄູ່ມື</translation></message>
++    <message>
++        <source>Info</source>
++        <translation>ຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Settings</source>
++        <translation>ການຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>Microphone Volume Up</source>
++        <translation>ປັບສຽງໄມໂຄຣໂຟນໃຫ້ດັງຂຶ້ນ</translation></message>
++    <message>
++        <source>Microphone Volume Down</source>
++        <translation>ລົດລະດັບສຽງໄມໂຄຣໂຟນ</translation></message>
++    <message>
++        <source>New</source>
++        <translation>ໃໝ່</translation></message>
++    <message>
++        <source>Open</source>
++        <translation>ເປີດ</translation></message>
++    <message>
++        <source>Find</source>
++        <translation>ຊອກຫາ</translation></message>
++    <message>
++        <source>Undo</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Redo</source>
++        <translation>ເຮັດຄືນ</translation></message>
++    <message>
++        <source>Print Screen</source>
++        <translation>ພິມຫນ້າຈໍ</translation></message>
++    <message>
++        <source>Page Up</source>
++        <translation>ຫນ້າຂຶ້ນ</translation></message>
++    <message>
++        <source>Page Down</source>
++        <translation>ຫນ້າລົງ</translation></message>
++    <message>
++        <source>Caps Lock</source>
++        <translation>ປຸ່ມ Caps Lock</translation></message>
++    <message>
++        <source>Num Lock</source>
++        <translation>Num Lock</translation></message>
++    <message>
++        <source>Number Lock</source>
++        <translation>ລັອກເລກ</translation></message>
++    <message>
++        <source>Scroll Lock</source>
++        <translation>ລ໋ອກການເລື່ອນ</translation></message>
++    <message>
++        <source>Insert</source>
++        <translation>ໃສ່</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Escape</source>
++        <translation>ຫນີ</translation></message>
++    <message>
++        <source>System Request</source>
++        <translation>ການຮ້ອງຂໍຂອງລະບົບ</translation></message>
++    <message>
++        <source>Select</source>
++        <translation>ເລືອກ</translation></message>
++    <message>
++        <source>Yes</source>
++        <translation>ແມ່ນແລ້ວ</translation></message>
++    <message>
++        <source>No</source>
++        <translation>ບໍ່</translation></message>
++    <message>
++        <source>Context1</source>
++        <translation>ບັນທຶກບັນຫາ</translation></message>
++    <message>
++        <source>Context2</source>
++        <translation>ບໍລິບົດ2</translation></message>
++    <message>
++        <source>Context3</source>
++        <translation>ບໍລິບົດ3</translation></message>
++    <message>
++        <source>Context4</source>
++        <translation>ບໍລິບົດ4</translation></message>
++    <message>
++        <source>Call</source>
++        <extracomment>Button to start a call (note: a separate button is used to end the call)</extracomment>
++        <translation>ໂທ</translation></message>
++    <message>
++        <source>Hangup</source>
++        <extracomment>Button to end a call (note: a separate button is used to start the call)</extracomment>
++        <translation>ລົງການໂທ</translation></message>
++    <message>
++        <source>Toggle Call/Hangup</source>
++        <extracomment>Button that will hang up if we're in call, or make a call if we're not.</extracomment>
++        <translation>ປ່ຽນການໂທ/ວາງລົງ</translation></message>
++    <message>
++        <source>Flip</source>
++        <translation>ພິກ</translation></message>
++    <message>
++        <source>Voice Dial</source>
++        <extracomment>Button to trigger voice dialing</extracomment>
++        <translation>ໂທດ້ວຍສຽງ</translation></message>
++    <message>
++        <source>Last Number Redial</source>
++        <extracomment>Button to redial the last number called</extracomment>
++        <translation>ເລກສຸດທ້າຍກັບໂທຄືນ</translation></message>
++    <message>
++        <source>Camera Shutter</source>
++        <extracomment>Button to trigger the camera shutter (take a picture)</extracomment>
++        <translation>ກ້ອງຖ່າຍຮູບ</translation></message>
++    <message>
++        <source>Camera Focus</source>
++        <extracomment>Button to focus the camera</extracomment>
++        <translation>ກ້ອງຖ່າຍຮູບຈຸດສຸມ</translation></message>
++    <message>
++        <source>Kanji</source>
++        <translation>ຄັນຈິ</translation></message>
++    <message>
++        <source>Muhenkan</source>
++        <translation>ມູເຫັນກັນ</translation></message>
++    <message>
++        <source>Henkan</source>
++        <translation>ແປງ</translation></message>
++    <message>
++        <source>Romaji</source>
++        <translation>ໂຣມາຈິ</translation></message>
++    <message>
++        <source>Hiragana</source>
++        <translation>ຮິຣາການາ</translation></message>
++    <message>
++        <source>Katakana</source>
++        <translation>ຄາຕາການາ</translation></message>
++    <message>
++        <source>Hiragana Katakana</source>
++        <translation>ຮິຣາການາ ຄາຕາການາ</translation></message>
++    <message>
++        <source>Zenkaku</source>
++        <translation>ເຊນກາກຸ</translation></message>
++    <message>
++        <source>Hankaku</source>
++        <translation>ຮັງກາກຸ</translation></message>
++    <message>
++        <source>Zenkaku Hankaku</source>
++        <translation>ເຊນກາກຸ ຮັນກາກຸ</translation></message>
++    <message>
++        <source>Touroku</source>
++        <translation>ລົງທະບຽນ</translation></message>
++    <message>
++        <source>Massyo</source>
++        <translation>ມາສຊີໂຢ</translation></message>
++    <message>
++        <source>Kana Lock</source>
++        <translation>ລັອກການາ</translation></message>
++    <message>
++        <source>Kana Shift</source>
++        <translation>ການປ່ຽນການາ</translation></message>
++    <message>
++        <source>Eisu Shift</source>
++        <translation>Eisu Shift</translation></message>
++    <message>
++        <source>Eisu toggle</source>
++        <translation>ປ່ຽນສະຖານະ</translation></message>
++    <message>
++        <source>Code input</source>
++        <translation>ປ້ອນລະຫັດ</translation></message>
++    <message>
++        <source>Multiple Candidate</source>
++        <translation>ຜູ້ສະໝັກຫຼາຍຄົນ</translation></message>
++    <message>
++        <source>Previous Candidate</source>
++        <translation>ຜູ້ສະໝັກກ່ອນໜ້າ</translation></message>
++    <message>
++        <source>Hangul</source>
++        <translation>ຮັງກຸນ</translation></message>
++    <message>
++        <source>Hangul Start</source>
++        <translation>ຮັງກຸນ ເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Hangul End</source>
++        <translation>ຮັງກຸນ ສິ້ນສຸດ</translation></message>
++    <message>
++        <source>Hangul Hanja</source>
++        <translation>ຮັງກຸນ ຮັນຈາ</translation></message>
++    <message>
++        <source>Hangul Jamo</source>
++        <translation>ຮັງກຸນ ຈາໂມ</translation></message>
++    <message>
++        <source>Hangul Romaja</source>
++        <translation>ຮັງກຸນ ໂຣມາຈາ</translation></message>
++    <message>
++        <source>Hangul Jeonja</source>
++        <translation>ຮັງກຸນ ຈອນຈາ</translation></message>
++    <message>
++        <source>Hangul Banja</source>
++        <translation>ຮັງກຸນ ບັນຈາ</translation></message>
++    <message>
++        <source>Hangul PreHanja</source>
++        <translation>ຮັງກຸນ ພຣີຮັນຈາ</translation></message>
++    <message>
++        <source>Hangul PostHanja</source>
++        <translation>ຮັງກຸນ ພັອສທ໌ຮັນຈາ</translation></message>
++    <message>
++        <source>Hangul Special</source>
++        <translation>ພິເສດພາສາເກົາຫຼີ</translation></message>
++    <message>
++        <source>Cancel</source>
++        <translation>ຍົກເລີກ</translation></message>
++    <message>
++        <source>Printer</source>
++        <translation>ຈັດພິມ</translation></message>
++    <message>
++        <source>Execute</source>
++        <translation>ປະຕິບັດ</translation></message>
++    <message>
++        <source>Play</source>
++        <translation>ຫຼິ້ນ</translation></message>
++    <message>
++        <source>Zoom</source>
++        <translation>ຊູມ</translation></message>
++    <message>
++        <source>Exit</source>
++        <translation>ອອກ</translation></message>
++    <message>
++        <source>Touchpad Toggle</source>
++        <translation>ປຸ່ມປິດ/ເປີດ Touchpad</translation></message>
++    <message>
++        <source>Touchpad On</source>
++        <translation>ປິດທັດສະພາດ</translation></message>
++    <message>
++        <source>Touchpad Off</source>
++        <translation>ປິດ Touchpad</translation></message>
++    <message>
++        <source>Ctrl</source>
++        <translation>Ctrl</translation></message>
++    <message>
++        <source>Shift</source>
++        <translation>ປ່ຽນ</translation></message>
++    <message>
++        <source>Alt</source>
++        <translation>Alt</translation></message>
++    <message>
++        <source>Meta</source>
++        <translation>ເມຕາ</translation></message>
++    <message>
++        <source>Num</source>
++        <translation>ຈຳນວນ</translation></message>
++    <message>
++        <source>+</source>
++        <extracomment>Key separator in shortcut string</extracomment>
++        <translation>+</translation></message>
++    <message>
++        <source>F%1</source>
++        <translation>F%1</translation></message>
++</context>
++<context>
++    <name>QSocks5SocketEngine</name>
++    <message>
++        <source>Connection to proxy refused</source>
++        <translation>ການເຊື່ອມຕໍ່ກັບໂປຣກຊີຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>Connection to proxy closed prematurely</source>
++        <translation>ການເຊື່ອມຕໍ່ກັບໂປຣກຊີຖືກປິດກ່ອນເວລາ</translation></message>
++    <message>
++        <source>Proxy host not found</source>
++        <translation>ບໍ່ພົບເຫັນໂຮສ໌ຕໍ່ພົງ</translation></message>
++    <message>
++        <source>Connection to proxy timed out</source>
++        <translation>ເຊື່ອມຕໍ່ກັບພຣອກຊີໝົດເວລາ</translation></message>
++    <message>
++        <source>Proxy authentication failed</source>
++        <translation>ການຢືນຢັນພຣອກຊີລົ້ມເຫຼວ</translation></message>
++    <message>
++        <source>Proxy authentication failed: %1</source>
++        <translation>ການຢືນຢັນພຣອກຊີລົ້ມເຫຼວ: %1</translation></message>
++    <message>
++        <source>SOCKS version 5 protocol error</source>
++        <translation>ຂໍ້ຜິດພາດໃນພິທີການ SOCKS ລຸ້ນ 5</translation></message>
++    <message>
++        <source>General SOCKSv5 server failure</source>
++        <translation>ຄວາມລົ້ມເຫຼວຂອງເຊີບເວີ SOCKSv5 ທົ່ວໄປ</translation></message>
++    <message>
++        <source>Connection not allowed by SOCKSv5 server</source>
++        <translation>ການເຊື່ອມຕໍ່ບໍ່ອະນຸຍາດໂດຍເຊີບເວີ SOCKSv5</translation></message>
++    <message>
++        <source>TTL expired</source>
++        <translation>TTL ໝົດອາຍຸ</translation></message>
++    <message>
++        <source>SOCKSv5 command not supported</source>
++        <translation>ຄຳສັ່ງ SOCKSv5 ບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation></message>
++    <message>
++        <source>Address type not supported</source>
++        <translation>ປະເພດທີ່ຢູ່ບໍ່ຖືກຮອງຮັບ</translation></message>
++    <message>
++        <source>Unknown SOCKSv5 proxy error code 0x%1</source>
++        <translation>ລະຫັດຜິດພາດບໍ່ຮູ້ຈັກຂອງໂປຣກຣາມປະກອບ SOCKSv5 0x%1</translation></message>
++    <message>
++        <source>Network operation timed out</source>
++        <translation>ການດຳເນີນງານເຄືອຂ່າຍໃຊ້ເວລາເກີນກຳນົດ</translation></message>
++</context>
++<context>
++    <name>QSpiAccessibleBridge</name>
++    <message>
++        <source>invalid role</source>
++        <extracomment>Role of an accessible object - the object is in an invalid state or could not be constructed</extracomment>
++        <translation>ບົດບາດບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>title bar</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແຖບຫົວຂໍ້</translation></message>
++    <message>
++        <source>menu bar</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແຖບເມນູ</translation></message>
++    <message>
++        <source>scroll bar</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແຖບເລື່ອນ</translation></message>
++    <message>
++        <source>grip</source>
++        <extracomment>Role of an accessible object - the grip is usually used for resizing another object</extracomment>
++        <translation>ຈັບ</translation></message>
++    <message>
++        <source>sound</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ສຽງ</translation></message>
++    <message>
++        <source>cursor</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ເຄີສໍ</translation></message>
++    <message>
++        <source>text caret</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຕົວຊີ້ຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>alert message</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຂໍ້ຄວາມແຈ້ງເຕືອນ</translation></message>
++    <message>
++        <source>frame</source>
++        <extracomment>Role of an accessible object: a window with frame and title
++----------
++Role of an accessible object</extracomment>
++        <translation>ກອບ</translation></message>
++    <message>
++        <source>filler</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຕື່ມ</translation></message>
++    <message>
++        <source>popup menu</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ລາຍການປັອບອັບ</translation></message>
++    <message>
++        <source>menu item</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ລາຍການເມນູ</translation></message>
++    <message>
++        <source>tool tip</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຄຳແນະນຳເຄື່ອງມື</translation></message>
++    <message>
++        <source>application</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>document</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ເອກະສານ</translation></message>
++    <message>
++        <source>panel</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ກະດານ</translation></message>
++    <message>
++        <source>chart</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ກຣາຟ</translation></message>
++    <message>
++        <source>dialog</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ກ່ອງຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>separator</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແຍກ</translation></message>
++    <message>
++        <source>tool bar</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>status bar</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແຖບສະຖານະ</translation></message>
++    <message>
++        <source>table</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຕາຕະລາງ</translation></message>
++    <message>
++        <source>column header</source>
++        <extracomment>Role of an accessible object - part of a table</extracomment>
++        <translation>ຫົວຂໍ້ຖັນ</translation></message>
++    <message>
++        <source>row header</source>
++        <extracomment>Role of an accessible object - part of a table</extracomment>
++        <translation>ຫົວຂໍ້ແຖວ</translation></message>
++    <message>
++        <source>column</source>
++        <extracomment>Role of an accessible object - part of a table</extracomment>
++        <translation>ຖັນ</translation></message>
++    <message>
++        <source>row</source>
++        <extracomment>Role of an accessible object - part of a table</extracomment>
++        <translation>ແຖວ</translation></message>
++    <message>
++        <source>cell</source>
++        <extracomment>Role of an accessible object - part of a table</extracomment>
++        <translation>ເຊລ</translation></message>
++    <message>
++        <source>link</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ລິ້ງ</translation></message>
++    <message>
++        <source>help balloon</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ບໍລິການບານລູນ</translation></message>
++    <message>
++        <source>assistant</source>
++        <extracomment>Role of an accessible object - a helper dialog</extracomment>
++        <translation>ຜູ້ຊ່ວຍ</translation></message>
++    <message>
++        <source>list</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ລາຍການ</translation></message>
++    <message>
++        <source>list item</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ລາຍການ</translation></message>
++    <message>
++        <source>tree</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຕົ້ນໄມ້</translation></message>
++    <message>
++        <source>tree item</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ລາຍການໄມ້</translation></message>
++    <message>
++        <source>page tab</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແຖບໜ້າ</translation></message>
++    <message>
++        <source>property page</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ໜ້າຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>indicator</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຕົວຊີ້ບອກ</translation></message>
++    <message>
++        <source>graphic</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຮູບພາບ</translation></message>
++    <message>
++        <source>label</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ປ້າຍຊື່</translation></message>
++    <message>
++        <source>text</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>push button</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ກົດປຸ່ມ</translation></message>
++    <message>
++        <source>check box</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ກ່ອງໝາຍທີ່ຕິກ</translation></message>
++    <message>
++        <source>radio button</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ປຸ່ມວົງກົມ</translation></message>
++    <message>
++        <source>combo box</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ກ່ອງລາຍການ</translation></message>
++    <message>
++        <source>progress bar</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແຖບຄວາມຄືບໜ້າ</translation></message>
++    <message>
++        <source>dial</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ໂທ</translation></message>
++    <message>
++        <source>hotkey field</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຟີວດຄີລັດ</translation></message>
++    <message>
++        <source>slider</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ສະໄລເດີ</translation></message>
++    <message>
++        <source>spin box</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ກ່ອງສະປິນ</translation></message>
++    <message>
++        <source>canvas</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຜ້າກັ້ງ</translation></message>
++    <message>
++        <source>animation</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ພາບເຄື່ອນໄຫວ</translation></message>
++    <message>
++        <source>equation</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ສົມຜົນ</translation></message>
++    <message>
++        <source>button with drop down</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ປຸ່ມທີ່ມີລາຍການຫຼຸດລົງ</translation></message>
++    <message>
++        <source>button menu</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ປຸ່ມເມນູ</translation></message>
++    <message>
++        <source>button with drop down grid</source>
++        <extracomment>Role of an accessible object - a button that expands a grid.</extracomment>
++        <translation>ປຸ່ມພ້ອມຕາຕະລາງລົງ</translation></message>
++    <message>
++        <source>space</source>
++        <extracomment>Role of an accessible object - blank space between other objects.</extracomment>
++        <translation>ຊ່ອງຫວ່າງ</translation></message>
++    <message>
++        <source>page tab list</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ລາຍການແທັບໜ້າ</translation></message>
++    <message>
++        <source>clock</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ນາທີ</translation></message>
++    <message>
++        <source>splitter</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແບ່ງອອກ</translation></message>
++    <message>
++        <source>layered pane</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ກະດານຊັ້ນ</translation></message>
++    <message>
++        <source>web document</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ເອກະສານເວັບ</translation></message>
++    <message>
++        <source>paragraph</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>section</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ພາກ</translation></message>
++    <message>
++        <source>color chooser</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຕົວເລືອກສີ</translation></message>
++    <message>
++        <source>footer</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ສ່ວນທ້າຍ</translation></message>
++    <message>
++        <source>form</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ແບບຟອມ</translation></message>
++    <message>
++        <source>heading</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ຫົວຂໍ້</translation></message>
++    <message>
++        <source>note</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ບັນທຶກ</translation></message>
++    <message>
++        <source>complementary content</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ເນື້ອຫາສ້າງສັນ</translation></message>
++    <message>
++        <source>terminal</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ເທີມິນແນລ</translation></message>
++    <message>
++        <source>desktop</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ເດສທັອບ</translation></message>
++    <message>
++        <source>notification</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ການແຈ້ງເຕືອນ</translation></message>
++    <message>
++        <source>unknown</source>
++        <extracomment>Role of an accessible object</extracomment>
++        <translation>ບໍ່ຮູ້</translation></message>
++</context>
++<context>
++    <name>QSslDiffieHellmanParameter</name>
++    <message>
++        <source>No error</source>
++        <translation>ບໍ່ມີຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>Invalid input data</source>
++        <translation>ຂໍ້ມູນປ້ອນເຂົ້າບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The given Diffie-Hellman parameters are deemed unsafe</source>
++        <translation>ພາຣາມີເຕີດີຟີ-ເຮລແມນທີ່ຖືກກຳນົດໄວ້ຖືກພິຈາລະນາວ່າບໍ່ປອດໄພ</translation></message>
++</context>
++<context>
++    <name>QSslSocket</name>
++    <message>
++        <source>Error when setting the OpenSSL configuration (%1)</source>
++        <translation>ຜິດພາດເມື່ອຕັ້ງຄ່າການຕັ້ງຄ່າ OpenSSL (%1)</translation></message>
++    <message>
++        <source>Expecting QByteArray for %1</source>
++        <translation>ຄາດຫວັງ QByteArray ສຳລັບ %1</translation></message>
++    <message>
++        <source>An error occurred attempting to set %1 to %2</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນການພະຍາຍາມຕັ້ງຄ່າ %1 ເປັນ %2</translation></message>
++    <message>
++        <source>Wrong value for %1 (%2)</source>
++        <translation>ຄ່າບໍ່ຖືກສໍາລັບ %1 (%2)</translation></message>
++    <message>
++        <source>Unrecognized command %1 = %2</source>
++        <translation>ຄຳສັ່ງທີ່ບໍ່ຮູ້ຈັກ %1 = %2</translation></message>
++    <message>
++        <source>SSL_CONF_finish() failed</source>
++        <translation>SSL_CONF_finish() ລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>SSL_CONF_CTX_new() failed</source>
++        <translation>SSL_CONF_CTX_new() ລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>OpenSSL version too old, need at least v1.0.2</source>
++        <translation>OpenSSL ລູ້ນເກົ່າເກີນໄປ, ຕ້ອງການຢ່າງໜ້ອຍ v1.0.2</translation></message>
++    <message>
++        <source>Error when setting the elliptic curves (%1)</source>
++        <translation>ຜິດພາດເມື່ອຕັ້ງຄ່າເສັ້ນໂຄ້ງວົງຮູບສາມຫຼ່ຽມ (%1)</translation></message>
++    <message>
++        <source>Error creating SSL context (%1)</source>
++        <translation>ຜິດພາດໃນການສ້າງບໍລິບທີ່ SSL (%1)</translation></message>
++    <message>
++        <source>unsupported protocol</source>
++        <translation>ບໍ່ຮອງຮັບໂປຣໂຕຄອນ</translation></message>
++    <message>
++        <source>Error while setting the minimal protocol version</source>
++        <translation>ຜິດພາດໃນການຕັ້ງຄ່າລຸ້ນໂປຣໂຕຄອນຕ່ຳສຸດ</translation></message>
++    <message>
++        <source>Error while setting the maximum protocol version</source>
++        <translation>ຜິດພາດໃນການຕັ້ງຄ່າລູກເລືອກໂປຣໂຕຄອນສູງສຸດ</translation></message>
++    <message>
++        <source>Invalid or empty cipher list (%1)</source>
++        <translation>ລາຍຊື່ cipher ບໍ່ຖືກຕ້ອງ ຫຼື ຫວ່າງເປົ່າ (%1)</translation></message>
++    <message>
++        <source>Cannot provide a certificate with no key, %1</source>
++        <translation>ບໍ່ສາມາດອອກໃບຢັ້ງຢືນໂດຍບໍ່ມີກະແຈ, %1</translation></message>
++    <message>
++        <source>Error loading local certificate, %1</source>
++        <translation>ຜິດພາດໃນການໂຫຼດໃບຢັ້ງຢືນທ້ອງຖິ່ນ, %1</translation></message>
++    <message>
++        <source>Error loading private key, %1</source>
++        <translation>ຜິດພາດໃນການໂຫຼດລະຫັດສ່ວນຕົວ, %1</translation></message>
++    <message>
++        <source>Private key does not certify public key, %1</source>
++        <translation>ກະແຈສ່ວນຕົວບໍ່ໄດ້ຢັ້ງຢືນກະແຈສາທາລະນະ, %1</translation></message>
++    <message>
++        <source>Diffie-Hellman parameters are not valid</source>
++        <translation>ພາຣາມີເຕີຂອງ Diffie-Hellman ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>OpenSSL version with disabled elliptic curves</source>
++        <translation>OpenSSL ລຸ້ນທີ່ປິດໃຊ້ເສັ້ນໂຄ້ງວົງຮອບ</translation></message>
++    <message>
++        <source>DTLS server requires a 'VerifyNone' mode with your version of OpenSSL</source>
++        <translation>DTLS ເຊີບເວີຕ້ອງການໂໝດ 'VerifyNone' ກັບ OpenSSL ຂອງທ່ານ</translation></message>
++    <message>
++        <source>No error</source>
++        <translation>ບໍ່ມີຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>The issuer certificate could not be found</source>
++        <translation>ໃບຢັ້ງຢືນຂອງຜູ້ອອກບໍ່ສາມາດພົບເຫັນ</translation></message>
++    <message>
++        <source>The certificate signature could not be decrypted</source>
++        <translation>ລາຍເຊັນໃບຢັ້ງຢືນບໍ່ສາມາດຖອດລະຫັດໄດ້</translation></message>
++    <message>
++        <source>The public key in the certificate could not be read</source>
++        <translation>ກະແຈສາທາລະນະໃນໃບຢັ້ງຢືນບໍ່ສາມາດອ່ານໄດ້</translation></message>
++    <message>
++        <source>The signature of the certificate is invalid</source>
++        <translation>ລາຍເຊັນຂອງໃບຢັ້ງຢືນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The certificate is not yet valid</source>
++        <translation>ໃບຢັ້ງຢືນຍັງບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The certificate has expired</source>
++        <translation>ໃບຢັ້ງຢືນໄດ້ໝົດອາຍຸແລ້ວ</translation></message>
++    <message>
++        <source>The certificate's notBefore field contains an invalid time</source>
++        <translation>ໃບຢັ້ງຢືນຂອງຟິວ notBefore ມີເວລາທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The certificate's notAfter field contains an invalid time</source>
++        <translation>ໃບຢັ້ງຢືນຂອງຟິວ notAfter ມີເວລາທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The certificate is self-signed, and untrusted</source>
++        <translation>ໃບຢັ້ງຢືນແມ່ນລົງນາມດ້ວຍຕົນເອງ, ແລະບໍ່ໄດ້ຮັບຄວາມໄວ້ວາງໃຈ</translation></message>
++    <message>
++        <source>The root certificate of the certificate chain is self-signed, and untrusted</source>
++        <translation>ລາຍເຊັນຮາກຂອງລະບົບລາຍເຊັນແມ່ນລາຍເຊັນດ້ວຍຕົນເອງ, ແລະບໍ່ໄດ້ຮັບຄວາມໄວ້ວາງໃຈ</translation></message>
++    <message>
++        <source>The issuer certificate of a locally looked up certificate could not be found</source>
++        <translation>ໃບຢັ້ງຢືນຂອງຜູ້ອອກຂອງໃບຢັ້ງຢືນທີ່ຄົ້ນຫາຢູ່ທ້ອງຖິ່ນບໍ່ສາມາດພົບເຫັນໄດ້</translation></message>
++    <message>
++        <source>No certificates could be verified</source>
++        <translation>ບໍ່ມີໃບຢັ້ງຢືນໃດໆທີ່ສາມາດຢືນຢັນໄດ້</translation></message>
++    <message>
++        <source>One of the CA certificates is invalid</source>
++        <translation>ໜຶ່ງໃນໃບຢັ້ງຢືນ CA ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The basicConstraints path length parameter has been exceeded</source>
++        <translation>ພາລາມິເຕີຄວາມຍາວເສັ້ນທາງ basicConstraints ໄດ້ຖືກເກີນເກນ</translation></message>
++    <message>
++        <source>The supplied certificate is unsuitable for this purpose</source>
++        <translation>ປະກາດສະບັບທີ່ສະໜອງໃຫ້ບໍ່ເໝາະສົມສຳລັບຈຸດປະສົງນີ້</translation></message>
++    <message>
++        <source>The root CA certificate is not trusted for this purpose</source>
++        <translation>ລາຍວັນ CA ຮາກບໍ່ໄດ້ຮັບຄວາມໄວ້ວາງໃຈສຳລັບຈຸດປະສົງນີ້</translation></message>
++    <message>
++        <source>The root CA certificate is marked to reject the specified purpose</source>
++        <translation>ລາຍເຊັນ CA ຕົ້ນຕໍໄດ້ຖືກໝາຍໄວ້ເພື່ອປະຕິເສດຈຸດປະສົງທີ່ກຳນົດໄວ້</translation></message>
++    <message>
++        <source>The current candidate issuer certificate was rejected because its subject name did not match the issuer name of the current certificate</source>
++        <translation>ໃບຢັ້ງຢືນຜູ້ອອກປະຈຸບັນທີ່ຖືກຄັດເລືອກຖືກປະຕິເສດເພາະວ່າຊື່ຂອງຜູ້ຖືກອອກບໍ່ກົງກັບຊື່ຂອງຜູ້ອອກຂອງໃບຢັ້ງຢືນປະຈຸບັນ</translation></message>
++    <message>
++        <source>The current candidate issuer certificate was rejected because its issuer name and serial number was present and did not match the authority key identifier of the current certificate</source>
++        <translation>ປະຈຸບັນ ໃບຢັ້ງຢືນຜູ້ອອກຜູ້ສະໝັກຖືກປະຕິເສດ ເພາະວ່າຊື່ຜູ້ອອກແລະເລກລຳດັບຂອງມັນມີຢູ່ ແລະບໍ່ກົງກັບຕົວຊີ້ບອກກຸນແຈອຳນາດຂອງໃບຢັ້ງຢືນປະຈຸບັນ</translation></message>
++    <message>
++        <source>The peer did not present any certificate</source>
++        <translation>ຄູ່ບໍ່ໄດ້ນຳສະເໜີໃບຢັ້ງຢືນໃດໆ</translation></message>
++    <message>
++        <source>The host name did not match any of the valid hosts for this certificate</source>
++        <translation>ຊື່ເຈົ້າພາບບໍ່ກົງກັບເຈົ້າພາບທີ່ຖືກຕ້ອງໃດໆສຳລັບໃບຢັ້ງຢືນນີ້</translation></message>
++    <message>
++        <source>The peer certificate is blacklisted</source>
++        <translation>ໃບຢັ້ງຢືນຂອງຜູ້ທີ່ທຽບເທົ່າຖືກລົງບັນຊີດໍາ</translation></message>
++    <message>
++        <source>No OCSP status response found</source>
++        <translation>ບໍ່ພົບການຕອບສະຫນອງສະຖານະ OCSP</translation></message>
++    <message>
++        <source>The OCSP status request had invalid syntax</source>
++        <translation>ການຮ້ອງຂໍສະຖານະ OCSP ມີໂຄງສ້າງບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>OCSP response contains an unexpected number of SingleResponse structures</source>
++        <translation>ການຕອບສະຫນອງ OCSP ປະກອບມີຈໍານວນທີ່ບໍ່ຄາດຄິດຂອງໂຄງສ້າງ SingleResponse</translation></message>
++    <message>
++        <source>OCSP responder reached an inconsistent internal state</source>
++        <translation>ຜູ້ຕອບສະຫນອງ OCSP ໄດ້ບັນລຸສະພາບພາຍໃນທີ່ບໍ່ສອດຄ່ອງ</translation></message>
++    <message>
++        <source>OCSP responder was unable to return a status for the requested certificate</source>
++        <translation>ຜູ້ຕອບສະຫນອງ OCSP ບໍ່ສາມາດສົ່ງຄືນສະຖານະສໍາລັບໃບຢັ້ງຢືນທີ່ຮ້ອງຂໍ</translation></message>
++    <message>
++        <source>The server requires the client to sign the OCSP request in order to construct a response</source>
++        <translation>ເຊີບເວີຕ້ອງການໃຫ້ລູກຄ້າເຊັນຄຳຂໍ OCSP ເພື່ອສ້າງຕອບກັບ</translation></message>
++    <message>
++        <source>The client is not authorized to request OCSP status from this server</source>
++        <translation>ລູກຄ້າບໍ່ໄດ້ຮັບອະນຸຍາດໃຫ້ຮ້ອງຂໍສະຖານະ OCSP ຈາກເຊີບເວີນີ້</translation></message>
++    <message>
++        <source>OCSP responder's identity cannot be verified</source>
++        <translation>ຕົວຕອບສະຫນອງ OCSP ບໍ່ສາມາດຢືນຢັນຕົວຕົນໄດ້</translation></message>
++    <message>
++        <source>The identity of a certificate in an OCSP response cannot be established</source>
++        <translation>ຕົວຕົນຂອງໃບຢັ້ງຢືນໃນການຕອບສະໜອງ OCSP ບໍ່ສາມາດຢືນຢັນໄດ້</translation></message>
++    <message>
++        <source>The certificate status response has expired</source>
++        <translation>ການຕອບສະຫນອງສະຖານະໃບຢັ້ງຢືນໄດ້ໝົດອາຍຸແລ້ວ</translation></message>
++    <message>
++        <source>The certificate's status is unknown</source>
++        <translation>ສະຖານະຂອງໃບຢັ້ງຢືນບໍ່ຮູ້</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>TLS initialization failed</source>
++        <translation>TLS ບໍ່ສາມາດເລີ່ມຕົ້ນໄດ້</translation></message>
++    <message>
++        <source>Attempted to use an unsupported protocol.</source>
++        <translation>ພະຍາຍາມໃຊ້ໂປຣໂຕຄອນທີ່ບໍ່ຮອງຮັບ.</translation></message>
++    <message>
++        <source>The TLS/SSL connection has been closed</source>
++        <translation>ການເຊື່ອມຕໍ່ TLS/SSL ໄດ້ຖືກປິດແລ້ວ</translation></message>
++    <message>
++        <source>Error creating SSL session, %1</source>
++        <translation>ຜິດພາດໃນການສ້າງຊິດຊັນ SSL, %1</translation></message>
++    <message>
++        <source>Error creating SSL session: %1</source>
++        <translation>ຜິດພາດໃນການສ້າງຊິດຊັ່ນ SSL: %1</translation></message>
++    <message>
++        <source>Server-side QSslSocket does not support OCSP stapling</source>
++        <translation>ຝ່າຍເຊີບເວີ QSslSocket ບໍ່ສະໜັບສະໜູນ OCSP stapling</translation></message>
++    <message>
++        <source>Failed to enable OCSP stapling</source>
++        <translation>ບໍ່ສາມາດເປີດໃຊ້ OCSP stapling ໄດ້</translation></message>
++    <message>
++        <source>Client-side sockets do not send OCSP responses</source>
++        <translation>ຊອກເຊີດດ້ານລູກຄ້າບໍ່ສົ່ງການຕອບສະຫນອງ OCSP</translation></message>
++    <message>
++        <source>Unable to init SSL Context: %1</source>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນບໍລິບົດ SSL: %1</translation></message>
++    <message>
++        <source>Unable to write data: %1</source>
++        <translation>ບໍ່ສາມາດຂຽນຂໍ້ມູນໄດ້: %1</translation></message>
++    <message>
++        <source>Unable to decrypt data: %1</source>
++        <translation>ບໍ່ສາມາດຖອດລະຫັດຂໍ້ມູນໄດ້: %1</translation></message>
++    <message>
++        <source>Error while reading: %1</source>
++        <translation>ຜິດພາດໃນການອ່ານ: %1</translation></message>
++    <message>
++        <source>Error during SSL handshake: %1</source>
++        <translation>ຜິດພາດໃນລະຫວ່າງການຈັບມື SSL: %1</translation></message>
++    <message>
++        <source>Failed to decode OCSP response</source>
++        <translation>ບໍ່ສາມາດຖອດລະຫັດການຕອບສະໜອງ OCSP ໄດ້</translation></message>
++    <message>
++        <source>Failed to extract basic OCSP response</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນການຕອບສະໜອງ OCSP ພື້ນຖານໄດ້</translation></message>
++    <message>
++        <source>No certificate verification store, cannot verify OCSP response</source>
++        <translation>ບໍ່ມີສາງກວດສອບໃບຢັ້ງຢືນ, ບໍ່ສາມາດກວດສອບການຕອບສະໜອງ OCSP ໄດ້</translation></message>
++    <message>
++        <source>Failed to decode a SingleResponse from OCSP status response</source>
++        <translation>ລົ້ມເຫລວໃນການຖອດລະຫັດ SingleResponse ຈາກການຕອບສະຫນອງສະຖານະ OCSP</translation></message>
++    <message>
++        <source>Failed to extract 'this update time' from the SingleResponse</source>
++        <translation>ບໍ່ສາມາດດຶງຂໍ້ມູນ 'ເວລາອັບເດດນີ້' ຈາກ SingleResponse ໄດ້</translation></message>
++    <message>
++        <source>Insufficient memory</source>
++        <translation>ພື້ນທີ່ຫນ່ວຍຄວາມຈຳບໍ່ພຽງພໍ</translation></message>
++    <message>
++        <source>Internal error</source>
++        <translation>ຂໍ້ຜິດພາດພາຍໃນ</translation></message>
++    <message>
++        <source>An internal handle was invalid</source>
++        <translation>ຮູບແບບພາຍໃນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>An internal token was invalid</source>
++        <translation>ໂທເຄັນພາຍໃນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Access denied</source>
++        <translation>ການເຂົ້າເຖິງຖືກປະຕິເສດ</translation></message>
++    <message>
++        <source>No authority could be contacted for authorization</source>
++        <translation>ບໍ່ມີອຳນາດທີ່ສາມາດຕິດຕໍ່ໄດ້ເພື່ອອະນຸຍາດ</translation></message>
++    <message>
++        <source>No credentials</source>
++        <translation>ບໍ່ມີຂໍ້ມູນການຢືນຢັນ</translation></message>
++    <message>
++        <source>The target is unknown or unreachable</source>
++        <translation>ເປົ້າໝາຍບໍ່ຮູ້ຫຼືບໍ່ສາມາດເຂົ້າເຖິງໄດ້</translation></message>
++    <message>
++        <source>An unsupported function was requested</source>
++        <translation>ມີການຮ້ອງຂໍຟັງຊັນທີ່ບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>The hostname provided does not match the one received from the peer</source>
++        <translation>ຊື່ເຈົ້າພາບທີ່ສະໜອງບໍ່ກົງກັບຊື່ທີ່ໄດ້ຮັບຈາກຄູ່ຄ້ານ</translation></message>
++    <message>
++        <source>No common protocol exists between the client and the server</source>
++        <translation>ບໍ່ມີໂປຣໂຕຄໍລ໌ທີ່ຮູ້ຈັກກັນລະຫວ່າງລູກຄ້າແລະເຊີບເວີ</translation></message>
++    <message>
++        <source>Unexpected or badly-formatted message received</source>
++        <translation>ຂໍ້ຄວາມທີ່ບໍ່ຄາດຄິດ ຫຼື ມີຮູບແບບບໍ່ຖືກຕ້ອງໄດ້ຮັບ</translation></message>
++    <message>
++        <source>The data could not be encrypted</source>
++        <translation>ຂໍ້ມູນບໍ່ສາມາດເຂົ້າລະຫັດໄດ້</translation></message>
++    <message>
++        <source>No cipher suites in common</source>
++        <translation>ບໍ່ມີ cipher suites ທີ່ຄ້າຍຄືກັນ</translation></message>
++    <message>
++        <source>The credentials were not recognized / Invalid argument</source>
++        <translation>ຂໍ້ມູນການຢືນຢັນບໍ່ຖືກຮັບຮູ້ / ອາກິວເມັນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The message was tampered with, damaged or out of sequence.</source>
++        <translation>ຂໍ້ຄວາມຖືກປະຕິບັດການປ່ຽນແປງ, ເສຍຫາຍ ຫຼື ອອກຈາກລຳດັບ.</translation></message>
++    <message>
++        <source>A message was received out of sequence.</source>
++        <translation>ຂໍ້ຄວາມໄດ້ຮັບມາໃນລຳດັບທີ່ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Unknown error occurred: %1</source>
++        <translation>ມີຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກເກີດຂຶ້ນ: %1</translation></message>
++    <message>
++        <source>Invalid protocol chosen</source>
++        <translation>ໂປຣໂຕຄອນທີ່ເລືອກບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The certificate provided cannot be used for a client.</source>
++        <translation>ໃບຢັ້ງຢືນທີ່ສະໜອງໃຫ້ບໍ່ສາມາດນຳໃຊ້ສຳລັບລູກຄ້າໄດ້.</translation></message>
++    <message>
++        <source>The certificate provided cannot be used for a server.</source>
++        <translation>ໃບຢັ້ງຢືນທີ່ສະໜອງໃຫ້ບໍ່ສາມາດນຳໃຊ້ສຳລັບເຊີບເວີໄດ້.</translation></message>
++    <message>
++        <source>Server did not accept any certificate we could present.</source>
++        <translation>ເຊີບເວີບໍ່ໄດ້ຍອມຮັບໃບຢັ້ງຢືນໃດໆທີ່ພວກເຮົາສາມາດນຳສະເໜີໄດ້.</translation></message>
++    <message>
++        <source>Algorithm mismatch</source>
++        <translation>ຂໍ້ຜິດພາດຂອງຂັ້ນຕອນການຄິດໄລ່</translation></message>
++    <message>
++        <source>Handshake failed: %1</source>
++        <translation>ຈັບມືລົ້ມເຫຼວ: %1</translation></message>
++    <message>
++        <source>Failed to query the TLS context: %1</source>
++        <translation>ບໍ່ສາມາດສອບຖາມບໍລິບົດ TLS: %1</translation></message>
++    <message>
++        <source>Did not get the required attributes for the connection.</source>
++        <translation>ບໍ່ໄດ້ຮັບຄຸນລັກສະນະທີ່ຕ້ອງການສຳລັບການເຊື່ອມຕໍ່.</translation></message>
++    <message>
++        <source>Unwanted protocol was negotiated</source>
++        <translation>ພິທີການທີ່ບໍ່ຕ້ອງການໄດ້ຖືກເຈລະຈາ</translation></message>
++    <message>
++        <source>Renegotiation was unsuccessful: %1</source>
++        <translation>ການເຊື່ອມຕໍ່ຄືນໃໝ່ບໍ່ສຳເລັດ: %1</translation></message>
++    <message>
++        <source>Schannel failed to encrypt data: %1</source>
++        <translation>Schannel ບໍ່ສາມາດເຂົ້າລະຫັດຂໍ້ມູນໄດ້: %1</translation></message>
++    <message>
++        <source>Cannot provide a certificate with no key</source>
++        <translation>ບໍ່ສາມາດອອກໃບຢັ້ງຢືນໂດຍບໍ່ມີກະແຈ</translation></message>
++</context>
++<context>
++    <name>QStandardPaths</name>
++    <message>
++        <source>Desktop</source>
++        <translation>Desktop</translation></message>
++    <message>
++        <source>Documents</source>
++        <translation>ເອກະສານ</translation></message>
++    <message>
++        <source>Fonts</source>
++        <translation>ຟອນ</translation></message>
++    <message>
++        <source>Applications</source>
++        <translation>ແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>Music</source>
++        <translation>ດົນຕີ</translation></message>
++    <message>
++        <source>Movies</source>
++        <translation>ຮູບເງົາ</translation></message>
++    <message>
++        <source>Pictures</source>
++        <translation>ຮູບພາບ</translation></message>
++    <message>
++        <source>Temporary Directory</source>
++        <translation>ໂຟນເດີຊົ່ວຄາວ</translation></message>
++    <message>
++        <source>Home</source>
++        <translation>ໜ້າຫຼັກ</translation></message>
++    <message>
++        <source>Cache</source>
++        <translation>ຄັງຂໍ້ມູນຊົ່ວຄາວ</translation></message>
++    <message>
++        <source>Shared Data</source>
++        <translation>ຂໍ້ມູນທີ່ແບ່ງປັນ</translation></message>
++    <message>
++        <source>Runtime</source>
++        <translation>ເວລາປະຕິບັດງານ</translation></message>
++    <message>
++        <source>Configuration</source>
++        <translation>ການຕັ້ງຄ່າ</translation></message>
++    <message>
++        <source>Shared Configuration</source>
++        <translation>ການຕັ້ງຄ່າຮ່ວມກັນ</translation></message>
++    <message>
++        <source>Shared Cache</source>
++        <translation>ແຄັດຊ໌ທີ່ແບ່ງປັນກັນ</translation></message>
++    <message>
++        <source>Download</source>
++        <translation>ດາວໂຫຼດ</translation></message>
++    <message>
++        <source>Application Data</source>
++        <translation>ຂໍ້ມູນແອັບພລິເຄຊັນ</translation></message>
++    <message>
++        <source>Application Configuration</source>
++        <translation>ການຕັ້ງຄ່າແອັບພລິເຄຊັນ</translation></message>
++</context>
++<context>
++    <name>QStateMachine</name>
++    <message>
++        <source>Missing initial state in compound state '%1'</source>
++        <translation>ຂາດສະຖານະເບື້ອງຕົ້ນໃນສະຖານະປະສົມ '%1'</translation></message>
++    <message>
++        <source>Missing default state in history state '%1'</source>
++        <translation>ຂາດສະຖານະພື້ນຖານໃນສະຖານະປະຫວັດ '%1'</translation></message>
++    <message>
++        <source>No common ancestor for targets and source of transition from state '%1'</source>
++        <translation>ບໍ່ມີບັນພະບຸລຸດຮ່ວມກັນສຳລັບເປົ້າໝາຍ ແລະ ແຫຼ່ງຂໍ້ມູນຂອງການປ່ຽນແປງຈາກສະພາບ '%1'</translation></message>
++    <message>
++        <source>Child mode of state machine '%1' is not 'ExclusiveStates'.</source>
++        <translation>ໂໝດລູກຂອງເຄື່ອງຈັກສະຖານະ '%1' ບໍ່ແມ່ນ 'ExclusiveStates'.</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QSystemSemaphore</name>
++    <message>
++        <source>%1: permission denied</source>
++        <translation>%1: ບໍ່ອະນຸຍາດ</translation></message>
++    <message>
++        <source>%1: already exists</source>
++        <translation>%1: ມີຢູ່ແລ້ວ</translation></message>
++    <message>
++        <source>%1: does not exist</source>
++        <translation>%1: ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>%1: out of resources</source>
++        <translation>%1: ຂາດແຫຼ່ງຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>%1: unknown error %2</source>
++        <translation>%1: ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ %2</translation></message>
++</context>
++<context>
++    <name>QTDSDriver</name>
++    <message>
++        <source>Unable to open connection</source>
++        <translation>ບໍ່ສາມາດເປີດການເຊື່ອມຕໍ່ໄດ້</translation></message>
++    <message>
++        <source>Unable to use database</source>
++        <translation>ບໍ່ສາມາດໃຊ້ຖານຂໍ້ມູນໄດ້</translation></message>
++</context>
++<context>
++    <name>QTabBar</name>
++    <message>
++        <source>Scroll Left</source>
++        <translation>ເລື່ອນໄປຊ້າຍ</translation></message>
++    <message>
++        <source>Scroll Right</source>
++        <translation>ເລື່ອນໄປທາງຂວາ</translation></message>
++</context>
++<context>
++    <name>QTcpServer</name>
++    <message>
++        <source>Operation on socket is not supported</source>
++        <translation>ການດຳເນີນການກ່ຽວກັບ socket ບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation></message>
++</context>
++<context>
++    <name>QTgaFile</name>
++    <message>
++        <source>Could not read image data</source>
++        <translation>ບໍ່ສາມາດອ່ານຂໍ້ມູນຮູບພາບໄດ້</translation></message>
++    <message>
++        <source>Sequential device (eg socket) for image read not supported</source>
++        <translation>ອຸປະກອນຕາມລຳດັບ (ເຊັ່ນ: ຊັອກເກັດ) ສຳລັບການອ່ານຮູບພາບບໍ່ຖືກຮອງຮັບ</translation></message>
++    <message>
++        <source>Seek file/device for image read failed</source>
++        <translation>ຊອກຫາໄຟລ໌/ອຸປະກອນສໍາລັບການອ່ານຮູບພາບລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Image header read failed</source>
++        <translation>ອ່ານຫົວຂໍ້ຮູບພາບລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Image type not supported</source>
++        <translation>ປະເພດຮູບພາບບໍ່ຖືກຮັບຮອງ</translation></message>
++    <message>
++        <source>Image depth not valid</source>
++        <translation>ຄວາມເລິກຂອງຮູບພາບບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Image size exceeds limit</source>
++        <translation>ຂະໜາດຮູບພາບເກີນຂອບເຂດທີ່ກຳນົດ</translation></message>
++    <message>
++        <source>Could not seek to image read footer</source>
++        <translation>ບໍ່ສາມາດຊອກຫາຮູບພາບເພື່ອອ່ານສ່ວນທ້າຍ</translation></message>
++    <message>
++        <source>Could not read footer</source>
++        <translation>ບໍ່ສາມາດອ່ານສ່ວນທ້າຍເຈ້ຍໄດ້</translation></message>
++    <message>
++        <source>Image type (non-TrueVision 2.0) not supported</source>
++        <translation>ປະເພດຮູບພາບ (ທີ່ບໍ່ແມ່ນ TrueVision 2.0) ບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>Could not reset to read data</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າໃຫມ່ເພື່ອອ່ານຂໍ້ມູນໄດ້</translation></message>
++</context>
++<context>
++    <name>QUdpSocket</name>
++    <message>
++        <source>Unable to send a datagram</source>
++        <translation>ບໍ່ສາມາດສົ່ງຂໍ້ມູນດາຕາກຣາມໄດ້</translation></message>
++    <message>
++        <source>No datagram available for reading</source>
++        <translation>ບໍ່ມີຂໍ້ມູນດາຕາກຣາມພ້ອມສຳລັບການອ່ານ</translation></message>
++</context>
++<context>
++    <name>QUndoGroup</name>
++    <message>
++        <source>Undo %1</source>
++        <translation>ກັບຄືນ %1</translation></message>
++    <message>
++        <source>Undo</source>
++        <comment>Default text for undo action</comment>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Redo %1</source>
++        <translation>ເຮັດຄືນ %1</translation></message>
++    <message>
++        <source>Redo</source>
++        <comment>Default text for redo action</comment>
++        <translation>ເຮັດຄືນ</translation></message>
++</context>
++<context>
++    <name>QUndoModel</name>
++    <message>
++        <source>&lt;empty&gt;</source>
++        <translation>&lt;empty&gt;</translation></message>
++</context>
++<context>
++    <name>QUndoStack</name>
++    <message>
++        <source>Undo %1</source>
++        <translation>ກັບຄືນ %1</translation></message>
++    <message>
++        <source>Undo</source>
++        <comment>Default text for undo action</comment>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Redo %1</source>
++        <translation>ເຮັດຄືນ %1</translation></message>
++    <message>
++        <source>Redo</source>
++        <comment>Default text for redo action</comment>
++        <translation>ເຮັດຄືນ</translation></message>
++</context>
++<context>
++    <name>QUnicodeControlCharacterMenu</name>
++    <message>
++        <source>LRM Left-to-right mark</source>
++        <translation>LRM ສັນຍານຊ້າຍຫາຂວາ</translation></message>
++    <message>
++        <source>RLM Right-to-left mark</source>
++        <translation>RLM ເຄື່ອງໝາຍຈາກຂວາຫາຊ້າຍ</translation></message>
++    <message>
++        <source>ZWJ Zero width joiner</source>
++        <translation>ZWJ ຕົວເຊື່ອມຕໍ່ທີ່ບໍ່ມີຄວາມກວ້າງ</translation></message>
++    <message>
++        <source>ZWNJ Zero width non-joiner</source>
++        <translation>ZWNJ ຕົວອັກສອນທີ່ບໍ່ຕໍ່ກັນທີ່ບໍ່ມີຄວາມກວ້າງ</translation></message>
++    <message>
++        <source>ZWSP Zero width space</source>
++        <translation>ZWSP ຊ່ອງຫວ່າງທີ່ບໍ່ມີຄວາມກວ້າງ</translation></message>
++    <message>
++        <source>LRE Start of left-to-right embedding</source>
++        <translation>LRE ເລີ່ມຕົ້ນຂອງການຝັງຈອມຊ້າຍຫາຂວາ</translation></message>
++    <message>
++        <source>RLE Start of right-to-left embedding</source>
++        <translation>RLE ການເລີ່ມຕົ້ນຂອງການຝັງຂວາຫາຊ້າຍ</translation></message>
++    <message>
++        <source>LRO Start of left-to-right override</source>
++        <translation>LRO ເລີ່ມຕົ້ນການບັງຄັບໃຊ້ຊ້າຍຫາຂວາ</translation></message>
++    <message>
++        <source>RLO Start of right-to-left override</source>
++        <translation>RLO ການເລີ່ມຕົ້ນຂອງການບັງຄັບຊ້າຍຫາຂວາ</translation></message>
++    <message>
++        <source>PDF Pop directional formatting</source>
++        <translation>PDF Pop ການຈັດຮູບແບບທິດທາງ</translation></message>
++    <message>
++        <source>LRI Left-to-right isolate</source>
++        <translation>LRI ຊ້າຍຫາຂວາແຍກຕົວ</translation></message>
++    <message>
++        <source>RLI Right-to-left isolate</source>
++        <translation>RLI ຈາກຂວາໄປຫາຊ້າຍທີ່ແຍກຕ່າງຫາກ</translation></message>
++    <message>
++        <source>FSI First strong isolate</source>
++        <translation>FSI ການແຍກຕົວທີ່ເຂັ້ມແຂງຄັ້ງທຳອິດ</translation></message>
++    <message>
++        <source>PDI Pop directional isolate</source>
++        <translation>PDI ປັບທິດທາງແຍກຕົວ</translation></message>
++    <message>
++        <source>Insert Unicode control character</source>
++        <translation>ໃສ່ຕົວອັກສອນຄວບຄຸມ Unicode</translation></message>
++</context>
++<context>
++    <name>QWhatsThisAction</name>
++    <message>
++        <source>What's This?</source>
++        <translation>ນີ້ແມ່ນຫຍັງ?</translation></message>
++</context>
++<context>
++    <name>QWidget</name>
++    <message>
++        <source>*</source>
++        <translation>*</translation></message>
++</context>
++<context>
++    <name>QWidgetTextControl</name>
++    <message>
++        <source>&amp;Undo</source>
++        <translation>&amp;ກັບຄືນ</translation></message>
++    <message>
++        <source>&amp;Redo</source>
++        <translation>&amp;ດໍາເນີນການຄືນໃໝ່</translation></message>
++    <message>
++        <source>Cu&amp;t</source>
++        <translation>ຕັດ</translation></message>
++    <message>
++        <source>&amp;Copy</source>
++        <translation>&amp;ສຳເນົາ</translation></message>
++    <message>
++        <source>Copy &amp;Link Location</source>
++        <translation>ສຳເນົາ &amp;ຕຳແໜ່ງລິ້ງ</translation></message>
++    <message>
++        <source>&amp;Paste</source>
++        <translation>&amp;ວາງ</translation></message>
++    <message>
++        <source>Delete</source>
++        <translation>ລຶບ</translation></message>
++    <message>
++        <source>Select All</source>
++        <translation>ເລືອກທັງໝົດ</translation></message>
++</context>
++<context>
++    <name>QWindowsDirect2DIntegration</name>
++    <message>
++        <source>Qt cannot load the direct2d platform plugin because the Direct2D version on this system is too old. The minimum system requirement for this platform plugin is Windows 7 SP1 with Platform Update.
++
++The minimum Direct2D version required is %1. The Direct2D version on this system is %2.</source>
++        <translation>Qt ບໍ່ສາມາດໂຫຼດປັກອິນແພລດຟອມ direct2d ໄດ້ເພາະວ່າລູ້ນ Direct2D ໃນລະບົບນີ້ເກົ່າເກີນໄປ. ຂໍ້ກຳນົດລະບົບຕ່ຳສຸດສຳລັບປັກອິນແພລດຟອມນີ້ແມ່ນ Windows 7 SP1 ພ້ອມກັບການອັບເດດແພລດຟອມ.
++
++ລູ້ນ Direct2D ຕ່ຳສຸດທີ່ຕ້ອງການແມ່ນ %1. ລູ້ນ Direct2D ໃນລະບົບນີ້ແມ່ນ %2.</translation></message>
++    <message>
++        <source>Cannot load direct2d platform plugin</source>
++        <translation>ບໍ່ສາມາດໂຫຼດປັກອິນເວີດເຄື່ອງມືທາງກົງ 2d</translation></message>
++</context>
++<context>
++    <name>QWizard</name>
++    <message>
++        <source>Go Back</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>&lt; &amp;Back</source>
++        <translation>&lt; ກັບຄືນ</translation></message>
++    <message>
++        <source>Continue</source>
++        <translation>ສືບຕໍ່</translation></message>
++    <message>
++        <source>&amp;Next</source>
++        <translation>&amp;ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>&amp;Next &gt;</source>
++        <translation>&amp;ຕໍ່ໄປ &amp;gt;</translation></message>
++    <message>
++        <source>Commit</source>
++        <translation>ຄໍາສັ່ງ</translation></message>
++    <message>
++        <source>Done</source>
++        <translation>ສຳເລັດແລ້ວ</translation></message>
++    <message>
++        <source>&amp;Finish</source>
++        <translation>&amp;ສຳເລັດ</translation></message>
++    <message>
++        <source>Cancel</source>
++        <translation>ຍົກເລີກ</translation></message>
++    <message>
++        <source>Help</source>
++        <translation>ຊ່ວຍເຫຼືອ</translation></message>
++    <message>
++        <source>&amp;Help</source>
++        <translation>&amp;ຊ່ວຍເຫຼືອ</translation></message>
++</context>
++<context>
++    <name>QXml</name>
++    <message>
++        <source>no error occurred</source>
++        <translation>ບໍ່ມີຂໍ້ຜິດພາດເກີດຂຶ້ນ</translation></message>
++    <message>
++        <source>error triggered by consumer</source>
++        <translation>ຜິດພາດທີ່ກະຕຸ້ນໂດຍຜູ້ບໍລິໂພກ</translation></message>
++    <message>
++        <source>unexpected end of file</source>
++        <translation>ບໍ່ຄາດຄິດວ່າຈະສິ້ນສຸດໄຟລ໌</translation></message>
++    <message>
++        <source>more than one document type definition</source>
++        <translation>ຫຼາຍກວ່າຫນຶ່ງຄໍານິຍາມປະເພດເອກະສານ</translation></message>
++    <message>
++        <source>error occurred while parsing element</source>
++        <translation>ຂໍ້ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ວິເຄາະອົງປະກອບ</translation></message>
++    <message>
++        <source>tag mismatch</source>
++        <translation>ແທັກບໍ່ກົງກັນ</translation></message>
++    <message>
++        <source>error occurred while parsing content</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ວິເຄາະເນື້ອຫາ</translation></message>
++    <message>
++        <source>unexpected character</source>
++        <translation>ຕົວອັກສອນທີ່ບໍ່ຄາດຄິດ</translation></message>
++    <message>
++        <source>invalid name for processing instruction</source>
++        <translation>ຊື່ບໍ່ຖືກຕ້ອງສໍາລັບຄໍາແນະນໍາການປະມວນຜົນ</translation></message>
++    <message>
++        <source>version expected while reading the XML declaration</source>
++        <translation>ລູກຄ່າທີ່ຄາດຫວັງໃນຂະນະທີ່ກຳລັງອ່ານການປະກາດ XML</translation></message>
++    <message>
++        <source>wrong value for standalone declaration</source>
++        <translation>ຄ່າຜິດພາດສໍາລັບການປະກາດດ່ຽວ</translation></message>
++    <message>
++        <source>encoding declaration or standalone declaration expected while reading the XML declaration</source>
++        <translation>ການປະກາດການເຂົ້າລະຫັດ ຫຼື ການປະກາດດ່ຽວຄາດຫວັງໃນຂະນະທີ່ກໍາລັງອ່ານການປະກາດ XML</translation></message>
++    <message>
++        <source>standalone declaration expected while reading the XML declaration</source>
++        <translation>ຄາດຫວັງວ່າຈະມີການປະກາດຕົວຕົນເອງໃນຂະນະທີ່ກໍາລັງອ່ານການປະກາດ XML</translation></message>
++    <message>
++        <source>error occurred while parsing document type definition</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ວິເຄາະຄໍານິຍາມປະເພດເອກະສານ</translation></message>
++    <message>
++        <source>letter is expected</source>
++        <translation>ຈົດໝາຍຖືກຄາດຫວັງ</translation></message>
++    <message>
++        <source>error occurred while parsing comment</source>
++        <translation>ຂໍ້ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ວິເຄາະຄວາມຄິດເຫັນ</translation></message>
++    <message>
++        <source>error occurred while parsing reference</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນຂະນະທີ່ຈັດວາງການອ້າງອີງ</translation></message>
++    <message>
++        <source>internal general entity reference not allowed in DTD</source>
++        <translation>ການອ້າງອີງເອນທິຕີພາຍໃນທົ່ວໄປບໍ່ອະນຸຍາດໃນ DTD</translation></message>
++    <message>
++        <source>external parsed general entity reference not allowed in attribute value</source>
++        <translation>ການອ້າງອີງເອກະສານທົ່ວໄປທີ່ຖືກວິເຄາະພາຍນອກບໍ່ອະນຸຍາດໃນຄ່າຄຸນລັກສະນະ</translation></message>
++    <message>
++        <source>external parsed general entity reference not allowed in DTD</source>
++        <translation>ການອ້າງອີງເອກະສານທົ່ວໄປທີ່ຖືກວິເຄາະພາຍນອກບໍ່ອະນຸຍາດໃນ DTD</translation></message>
++    <message>
++        <source>unparsed entity reference in wrong context</source>
++        <translation>ການອ້າງອີງຕົວເລກທີ່ບໍ່ໄດ້ວິເຄາະໃນບໍລິບົດທີ່ຜິດ</translation></message>
++    <message>
++        <source>recursive entities</source>
++        <translation>ສິ່ງທີ່ກຳນົດຄືນເອງ</translation></message>
++    <message>
++        <source>error in the text declaration of an external entity</source>
++        <translation>ຜິດພາດໃນການປະກາດຂໍ້ຄວາມຂອງເອນທີຕີພາຍນອກ</translation></message>
++</context>
++<context>
++    <name>QXmlStream</name>
++    <message>
++        <source>Extra content at end of document.</source>
++        <translation>ເນື້ອຫາເພີ່ມເຕີມທີ່ທ້າຍຂອງເອກະສານ.</translation></message>
++    <message>
++        <source>Invalid entity value.</source>
++        <translation>ຄ່າຂອງອົງປະກອບບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Invalid XML character.</source>
++        <translation>XML ຕົວອັກສອນບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Sequence ']]&gt;' not allowed in content.</source>
++        <translation>ລຳດັບ ']]&gt;' ບໍ່ອະນຸຍາດໃນເນື້ອຫາ.</translation></message>
++    <message>
++        <source>Encountered incorrectly encoded content.</source>
++        <translation>ພົບເຫັນເນື້ອຫາທີ່ຖືກກໍານົດລະຫັດບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Namespace prefix '%1' not declared</source>
++        <translation>ຊື່ຫນ້າຂອງ namespace '%1' ບໍ່ໄດ້ຖືກປະກາດ</translation></message>
++    <message>
++        <source>Illegal namespace declaration.</source>
++        <translation>ການປະກາດ namespace ທີ່ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Attribute '%1' redefined.</source>
++        <translation>ຄຸນລັກສະນະ '%1' ຖືກກຳນົດໃໝ່.</translation></message>
++    <message>
++        <source>Unexpected character '%1' in public id literal.</source>
++        <translation>ຕົວອັກສອນທີ່ບໍ່ຄາດຄິດ '%1' ໃນຄຳສັບສາທາລະນະ.</translation></message>
++    <message>
++        <source>Invalid XML version string.</source>
++        <translation>ສະຕຣິງລູກຄ່າ XML ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Unsupported XML version.</source>
++        <translation>XML ສະບັບທີ່ບໍ່ຮອງຮັບ.</translation></message>
++    <message>
++        <source>The standalone pseudo attribute must appear after the encoding.</source>
++        <translation>ຄຸນລັກສະນະ pseudo ທີ່ຢູ່ດ້ວຍຕົວເອງຕ້ອງປາກົດຫຼັງຈາກການເຂົ້າລະຫັດ.</translation></message>
++    <message>
++        <source>%1 is an invalid encoding name.</source>
++        <translation>%1 ແມ່ນຊື່ການເຂົ້າລະຫັດທີ່ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Encoding %1 is unsupported</source>
++        <translation>ການເຂົ້າລະຫັດ %1 ບໍ່ຖືກຮອງຮັບ</translation></message>
++    <message>
++        <source>Standalone accepts only yes or no.</source>
++        <translation>ສະຖານະດຽວຍອມຮັບແຕ່ ແມ່ນ ຫຼື ບໍ່ແມ່ນ ເທົ່ານັ້ນ.</translation></message>
++    <message>
++        <source>Invalid attribute in XML declaration.</source>
++        <translation>ຄຸນລັກສະນະບໍ່ຖືກຕ້ອງໃນການປະກາດ XML.</translation></message>
++    <message>
++        <source>Premature end of document.</source>
++        <translation>ເອກະສານສິ້ນສຸດກ່ອນເວລາ.</translation></message>
++    <message>
++        <source>Invalid document.</source>
++        <translation>ເອກະສານບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>'%1'</source>
++        <comment>expected</comment>
++        <extracomment>'&lt;first option&gt;'</extracomment>
++        <translation>'%1'</translation></message>
++    <message>
++        <source>%1 or '%2'</source>
++        <comment>expected</comment>
++        <extracomment>&lt;first option&gt;, '&lt;second option&gt;'</extracomment>
++        <translation>%1 ຫຼື '%2'</translation></message>
++    <message>
++        <source>%1, '%2'</source>
++        <comment>expected</comment>
++        <extracomment>&lt;options so far&gt;, '&lt;next option&gt;'</extracomment>
++        <translation>%1, '%2'</translation></message>
++    <message>
++        <source>%1, or '%2'</source>
++        <comment>expected</comment>
++        <extracomment>&lt;options so far&gt;, or '&lt;final option&gt;'</extracomment>
++        <translation>%1, ຫຼື '%2'</translation></message>
++    <message>
++        <source>Expected %1, but got '%2'.</source>
++        <translation>ຄາດຫວັງ %1, ແຕ່ໄດ້ຮັບ '%2'.</translation></message>
++    <message>
++        <source>Unexpected '%1'.</source>
++        <translation>ບໍ່ຄາດຄິດ '%1'.</translation></message>
++    <message>
++        <source>Expected character data.</source>
++        <translation>ຄາດຫວັງຂໍ້ມູນຕົວອັກສອນ.</translation></message>
++    <message>
++        <source>Self-referencing entity detected.</source>
++        <translation>ກຳລັງກວດພົບຕົວເອງທີ່ອ້າງອີງຕົວເອງ.</translation></message>
++    <message>
++        <source>Entity expands to more characters than the entity expansion limit.</source>
++        <translation>ເອນຕິຕີຂະຫຍາຍເປັນຕົວອັກສອນຫຼາຍກວ່າຂອບເຂດການຂະຫຍາຍເອນຕິຕີ.</translation></message>
++    <message>
++        <source>Start tag expected.</source>
++        <translation>ຕ້ອງການແທັກເລີ່ມຕົ້ນ.</translation></message>
++    <message>
++        <source>NDATA in parameter entity declaration.</source>
++        <translation>NDATA ໃນການປະກາດຕົວແປພາຣາມິເຕີ.</translation></message>
++    <message>
++        <source>XML declaration not at start of document.</source>
++        <translation>ການປະກາດ XML ບໍ່ໄດ້ຢູ່ໃນຕົ້ນເອກະສານ.</translation></message>
++    <message>
++        <source>%1 is an invalid processing instruction name.</source>
++        <translation>%1 ແມ່ນຊື່ຄໍາສັ່ງປະມວນຜົນທີ່ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Invalid processing instruction name.</source>
++        <translation>ຊື່ຄໍາສັ່ງປະມວນຜົນບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>%1 is an invalid PUBLIC identifier.</source>
++        <translation>%1 ແມ່ນຕົວຊີ້ບອກ PUBLIC ທີ່ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Invalid XML name.</source>
++        <translation>ຊື່ XML ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Opening and ending tag mismatch.</source>
++        <translation>ເປີດ ແລະ ປິດປ້າຍບໍ່ກົງກັນ.</translation></message>
++    <message>
++        <source>Entity '%1' not declared.</source>
++        <translation>ເອນຕິຕີ '%1' ບໍ່ໄດ້ຖືກປະກາດ.</translation></message>
++    <message>
++        <source>Reference to unparsed entity '%1'.</source>
++        <translation>ອ້າງອີງເຖິງຕົວແທນທີ່ບໍ່ໄດ້ວິເຄາະ '%1'.</translation></message>
++    <message>
++        <source>Reference to external entity '%1' in attribute value.</source>
++        <translation>ການອ້າງອີງເຖິງເອນຕິຕີພາຍນອກ '%1' ໃນຄ່າຄຸນລັກສະນະ.</translation></message>
++    <message>
++        <source>Invalid character reference.</source>
++        <translation>ການອ້າງອີງຕົວອັກສອນບໍ່ຖືກຕ້ອງ.</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qtconnectivity_lo.ts b/translations/qtconnectivity_lo.ts
+new file mode 100644
+index 0000000..726e8c5
+--- /dev/null
++++ b/translations/qtconnectivity_lo.ts
+@@ -0,0 +1,1117 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>QBluetoothDeviceDiscoveryAgent</name>
++    <message>
++        <source>Device is powered off</source>
++        <translation>ອຸປະກອນຖືກປິດພະລັງງານ</translation></message>
++    <message>
++        <source>Cannot find valid Bluetooth adapter.</source>
++        <translation>ບໍ່ສາມາດຊອກຫາ Bluetooth adapter ທີ່ຖືກຕ້ອງໄດ້.</translation></message>
++    <message>
++        <source>Input Output Error</source>
++        <translation>ການປ້ອນຂໍ້ມູນ ຜົນຜະລິດ ຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>Bluetooth LE is not supported</source>
++        <translation>Bluetooth LE ບໍ່ຖືກສະຫນັບສະຫນູນ</translation></message>
++    <message>
++        <source>Unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Cannot start device inquiry</source>
++        <translation>ບໍ່ສາມາດເລີ່ມການສອບຖາມອຸປະກອນ</translation></message>
++    <message>
++        <source>Cannot start low energy device inquiry</source>
++        <translation>ບໍ່ສາມາດເລີ່ມການສອບຖາມອຸປະກອນພະລັງງານຕ່ຳ</translation></message>
++    <message>
++        <source>Discovery cannot be stopped</source>
++        <translation>ການຄົ້ນພົບບໍ່ສາມາດຢຸດໄດ້</translation></message>
++    <message>
++        <source>Invalid Bluetooth adapter address</source>
++        <translation>ທີ່ຢູ່ Bluetooth adapter ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>One or more device discovery methods are not supported on this platform</source>
++        <translation>ຫນຶ່ງຫຼືຫຼາຍວິທີການຄົ້ນພົບອຸປະກອນບໍ່ຖືກສະຫນັບສະຫນູນໃນແພລດຟອມນີ້</translation></message>
++    <message>
++        <source>Device does not support Bluetooth</source>
++        <translation>ອຸປະກອນບໍ່ຮອງຮັບ Bluetooth</translation></message>
++    <message>
++        <source>Passed address is not a local device.</source>
++        <translation>ທີ່ຢູ່ທີ່ຜ່ານມາບໍ່ແມ່ນອຸປະກອນທ້ອງຖິ່ນ.</translation></message>
++    <message>
++        <source>Missing Location permission. Search is not possible.</source>
++        <translation>ຂາດອະນຸຍາດສະຖານທີ່. ການຊອກຫາບໍ່ສາມາດເຮັດໄດ້.</translation></message>
++    <message>
++        <source>Location service turned off. Search is not possible.</source>
++        <translation>ບໍລິການຕຳແໜ່ງຖືກປິດ. ການຄົ້ນຫາບໍ່ສາມາດເຮັດໄດ້.</translation></message>
++    <message>
++        <source>Classic Discovery cannot be started</source>
++        <translation>ການຄົ້ນພົບແບບຄລາສສິກບໍ່ສາມາດເລີ່ມຕົ້ນໄດ້</translation></message>
++    <message>
++        <source>Low Energy Discovery not supported</source>
++        <translation>ການຄົ້ນພົບພະລັງງານຕ່ຳບໍ່ຖືກຮອງຮັບ</translation></message>
++    <message>
++        <source>Bluetooth adapter error</source>
++        <translation>ຂໍ້ຜິດພາດຂອງອັດັບເຕີ Bluetooth</translation></message>
++    <message>
++        <source>Device discovery not supported on this platform</source>
++        <translation>ການຄົ້ນຫາອຸປະກອນບໍ່ຖືກສະຫນັບສະຫນູນໃນແພັດຟອມນີ້</translation></message>
++    <message>
++        <source>Cannot access adapter during service discovery</source>
++        <translation>ບໍ່ສາມາດເຂົ້າເຖິງອັດຕັບເຕີໃນລະຫວ່າງການຄົ້ນພົບບໍລິການ</translation></message>
++</context>
++<context>
++    <name>QBluetoothServiceDiscoveryAgent</name>
++    <message>
++        <source>Local device is powered off</source>
++        <translation>ອຸປະກອນທ້ອງຖິ່ນຖືກປິດໄຟຟ້າ</translation></message>
++    <message>
++        <source>Minimal service discovery failed</source>
++        <translation>ການຄົ້ນຫາບໍລິການຂັ້ນຕ່ຳລົ້ມເຫຼວ</translation></message>
++    <message>
++        <source>Invalid Bluetooth adapter address</source>
++        <translation>ທີ່ຢູ່ Bluetooth adapter ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Platform does not support Bluetooth</source>
++        <translation>ເວທີບໍ່ຮອງຮັບ Bluetooth</translation></message>
++    <message>
++        <source>Android API below v15 does not support SDP discovery</source>
++        <translation>Android API ຕໍ່າກວ່າ v15 ບໍ່ຮອງຮັບການຄົ້ນພົບ SDP</translation></message>
++    <message>
++        <source>Cannot create Android BluetoothDevice</source>
++        <translation>ບໍ່ສາມາດສ້າງ Android BluetoothDevice</translation></message>
++    <message>
++        <source>Cannot obtain service uuids</source>
++        <translation>ບໍ່ສາມາດໄດ້ຮັບ service uuids</translation></message>
++    <message>
++        <source>Serial Port Profile</source>
++        <translation>ໂປຣໄຟລ໌ພອດລຳດັບ</translation></message>
++    <message>
++        <source>Device is powered off</source>
++        <translation>ອຸປະກອນຖືກປິດພະລັງງານ</translation></message>
++    <message>
++        <source>Unable to find appointed local adapter</source>
++        <translation>ບໍ່ສາມາດຊອກຫາແອດແປຕ້ອງທ້ອງຖິ່ນທີ່ກຳນົດໄວ້ໄດ້</translation></message>
++    <message>
++        <source>Cannot find local Bluetooth adapter</source>
++        <translation>ບໍ່ສາມາດຊອກຫາ Bluetooth adapter ທ້ອງຖິ່ນໄດ້</translation></message>
++    <message>
++        <source>Unable to find sdpscanner</source>
++        <translation>ບໍ່ສາມາດຊອກຫາ sdpscanner</translation></message>
++    <message>
++        <source>Unable to perform SDP scan</source>
++        <translation>ບໍ່ສາມາດສະແກນ SDP ໄດ້</translation></message>
++    <message>
++        <source>Custom Service</source>
++        <translation>ບໍລິການທີ່ປັບແຕ່ງ</translation></message>
++    <message>
++        <source>Unable to access device</source>
++        <translation>ບໍ່ສາມາດເຂົ້າເຖິງອຸປະກອນໄດ້</translation></message>
++    <message>
++        <source>Service Discovery</source>
++        <translation>ການຄົ້ນພົບບໍລິການ</translation></message>
++    <message>
++        <source>Browse Group Descriptor</source>
++        <translation>ກວດສອບກຸ່ມທີ່ອະທິບາຍ</translation></message>
++    <message>
++        <source>Public Browse Group</source>
++        <translation>ກຸ່ມທ່ອງເວັບສາທາລະນະ</translation></message>
++    <message>
++        <source>LAN Access Profile</source>
++        <translation>ໂປຣໄຟລ໌ການເຂົ້າເຖິງ LAN</translation></message>
++    <message>
++        <source>Dial-Up Networking</source>
++        <translation>ເຄືອຂ່າຍການໂທລະສັບຂຶ້ນ</translation></message>
++    <message>
++        <source>Synchronization</source>
++        <translation>ປັບສົມທົບ</translation></message>
++    <message>
++        <source>Object Push</source>
++        <translation>ການຍູ້ວັດຖຸ</translation></message>
++    <message>
++        <source>File Transfer</source>
++        <translation>ການໂອນໄຟລ໌</translation></message>
++    <message>
++        <source>Synchronization Command</source>
++        <translation>ຄຳສັ່ງປະສານສົມທົບ</translation></message>
++    <message>
++        <source>Headset</source>
++        <translation>ຫູຟັງ</translation></message>
++    <message>
++        <source>Audio Source</source>
++        <translation>ແຫຼ່ງສຽງ</translation></message>
++    <message>
++        <source>Audio Sink</source>
++        <translation>ສຽງສິ່ງຕົ້ນທາງ</translation></message>
++    <message>
++        <source>Audio/Video Remote Control Target</source>
++        <translation>ເປົ້າໝາຍການຄວບຄຸມທາງໄກສຽງ/ວິດີໂອ</translation></message>
++    <message>
++        <source>Advanced Audio Distribution</source>
++        <translation>ການແຈກຢາຍສຽງຂັ້ນສູງ</translation></message>
++    <message>
++        <source>Audio/Video Remote Control</source>
++        <translation>ການຄວບຄຸມສຽງ/ວິດີໂອທາງໄກ</translation></message>
++    <message>
++        <source>Audio/Video Remote Control Controller</source>
++        <translation>ຕົວຄວບຄຸມຄວບຄຸມທາງໄກສຽງ/ວິດີໂອ</translation></message>
++    <message>
++        <source>Headset AG</source>
++        <translation>ຫູຟັງ AG</translation></message>
++    <message>
++        <source>Personal Area Networking (PANU)</source>
++        <translation>ເຄືອຂ່າຍພື້ນທີ່ສ່ວນຕົວ (PANU)</translation></message>
++    <message>
++        <source>Personal Area Networking (NAP)</source>
++        <translation>ເຄືອຂ່າຍພື້ນທີ່ສ່ວນຕົວ (NAP)</translation></message>
++    <message>
++        <source>Personal Area Networking (GN)</source>
++        <translation>ເຄືອຂ່າຍພື້ນທີ່ສ່ວນຕົວ (GN)</translation></message>
++    <message>
++        <source>Basic Direct Printing (BPP)</source>
++        <translation>ພິມໂດຍກົງພື້ນຖານ (BPP)</translation></message>
++    <message>
++        <source>Basic Reference Printing (BPP)</source>
++        <translation>ພິມອ້າງອີງພື້ນຖານ (BPP)</translation></message>
++    <message>
++        <source>Basic Imaging Profile</source>
++        <translation>ໂປຣໄຟລພາບພື້ນຖານ</translation></message>
++    <message>
++        <source>Basic Imaging Responder</source>
++        <translation>ຜູ້ຕອບສະຫນອງການສ້າງຮູບພາບພື້ນຖານ</translation></message>
++    <message>
++        <source>Basic Imaging Archive</source>
++        <translation>ຫໍສະໝຸດຮູບພາບພື້ນຖານ</translation></message>
++    <message>
++        <source>Basic Imaging Ref Objects</source>
++        <translation>ວັດຖຸອ້າງອີງພາບພື້ນຖານ</translation></message>
++    <message>
++        <source>Hands-Free</source>
++        <translation>ບໍ່ຕ້ອງໃຊ້ມື</translation></message>
++    <message>
++        <source>Hands-Free AG</source>
++        <translation>ການຄວບຄຸມອັດຕະໂນມັດໂດຍບໍ່ຕ້ອງໃຊ້ມື</translation></message>
++    <message>
++        <source>Basic Printing RefObject Service</source>
++        <translation>ການພິມພື້ນຖານ RefObject Service</translation></message>
++    <message>
++        <source>Basic Printing Reflected UI</source>
++        <translation>ການພິມພື້ນຖານ ສະແດງຜົນການໃຊ້ງານຜູ້ໃຊ້</translation></message>
++    <message>
++        <source>Basic Printing</source>
++        <translation>ພິມພື້ນຖານ</translation></message>
++    <message>
++        <source>Basic Printing Status</source>
++        <translation>ສະຖານະການພິມພື້ນຖານ</translation></message>
++    <message>
++        <source>Human Interface Device</source>
++        <translation>ອຸປະກອນສໍາພັດກັບມະນຸດ</translation></message>
++    <message>
++        <source>Hardcopy Cable Replacement</source>
++        <translation>ການປ່ຽນແທນສາຍເຄເບິນຮາດຄອບີ</translation></message>
++    <message>
++        <source>Hardcopy Cable Replacement Print</source>
++        <translation>ພິມສາຍແທນທີ່ພິມອອກມາ</translation></message>
++    <message>
++        <source>Hardcopy Cable Replacement Scan</source>
++        <translation>ສະແກນທົດແທນເຄເບິລພິມອອກເປັນຮາດຄອບີ</translation></message>
++    <message>
++        <source>SIM Access Server</source>
++        <translation>ເຊີບເວີການເຂົ້າເຖິງ SIM</translation></message>
++    <message>
++        <source>Phonebook Access PCE</source>
++        <translation>ການເຂົ້າເຖິງປຶ້ມໂທລະສັບ PCE</translation></message>
++    <message>
++        <source>Phonebook Access PSE</source>
++        <translation>ການເຂົ້າເຖິງປຶ້ມໂທລະສັບ PSE</translation></message>
++    <message>
++        <source>Phonebook Access</source>
++        <translation>ການເຂົ້າເຖິງປຶ້ມໂທລະສັບ</translation></message>
++    <message>
++        <source>Headset HS</source>
++        <translation>ຫູຟັງ HS</translation></message>
++    <message>
++        <source>Message Access Server</source>
++        <translation>ເຊີບເວີການເຂົ້າເຖິງຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Message Notification Server</source>
++        <translation>ເຊີບເວີແຈ້ງເຕືອນຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Message Access</source>
++        <translation>ການເຂົ້າເຖິງຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Global Navigation Satellite System</source>
++        <translation>ລະບົບດາວທຽມນຳທາງໂລກ</translation></message>
++    <message>
++        <source>Global Navigation Satellite System Server</source>
++        <translation>ເຊີບເວີລະບົບດາວທຽມນຳທາງໂລກ</translation></message>
++    <message>
++        <source>3D Synchronization Display</source>
++        <translation>ການສະແດງການປະສານງານ 3D</translation></message>
++    <message>
++        <source>3D Synchronization Glasses</source>
++        <translation>ແວ່ນຕາສຳຮອງ 3D</translation></message>
++    <message>
++        <source>3D Synchronization</source>
++        <translation>ການປັບສອງ 3D</translation></message>
++    <message>
++        <source>Multi-Profile Specification (Profile)</source>
++        <translation>ກຳນົດຂໍ້ມູນຫຼາຍໂປຣໄຟລ໌ (ໂປຣໄຟລ໌)</translation></message>
++    <message>
++        <source>Multi-Profile Specification</source>
++        <translation>ການກຳນົດຂໍ້ມູນຫຼາຍໂປຣໄຟລ໌</translation></message>
++    <message>
++        <source>Device Identification</source>
++        <translation>ການລະບຸອຸປະກອນ</translation></message>
++    <message>
++        <source>Generic Networking</source>
++        <translation>ເຄືອຂ່າຍທົ່ວໄປ</translation></message>
++    <message>
++        <source>Generic File Transfer</source>
++        <translation>ການໂອນໄຟລ໌ທົ່ວໄປ</translation></message>
++    <message>
++        <source>Generic Audio</source>
++        <translation>ສຽງທົ່ວໄປ</translation></message>
++    <message>
++        <source>Generic Telephony</source>
++        <translation>ໂທລະສັບທົ່ວໄປ</translation></message>
++    <message>
++        <source>Video Source</source>
++        <translation>ແຫຼ່ງວິດີໂອ</translation></message>
++    <message>
++        <source>Video Sink</source>
++        <translation>ກະທູ້ວິດີໂອ</translation></message>
++    <message>
++        <source>Video Distribution</source>
++        <translation>ການແຈກຢາຍວິດີໂອ</translation></message>
++    <message>
++        <source>Health Device</source>
++        <translation>ອຸປະກອນສຸຂະພາບ</translation></message>
++    <message>
++        <source>Health Device Source</source>
++        <translation>ແຫຼ່ງທີ່ມາຂອງອຸປະກອນສຸຂະພາບ</translation></message>
++    <message>
++        <source>Health Device Sink</source>
++        <translation>ອຸປະກອນສຸຂະພາບສິ້ງ</translation></message>
++    <message>
++        <source>Generic Access</source>
++        <translation>ການເຂົ້າເຖິງທົ່ວໄປ</translation></message>
++    <message>
++        <source>Generic Attribute</source>
++        <translation>ຄຸນລັກສະນະທົ່ວໄປ</translation></message>
++    <message>
++        <source>Immediate Alert</source>
++        <translation>ການແຈ້ງເຕືອນທັນທີ</translation></message>
++    <message>
++        <source>Link Loss</source>
++        <translation>ການສູນເສຍການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Tx Power</source>
++        <translation>ພະລັງງານ Tx</translation></message>
++    <message>
++        <source>Current Time Service</source>
++        <translation>ບໍລິການເວລາປັດຈຸບັນ</translation></message>
++    <message>
++        <source>Reference Time Update Service</source>
++        <translation>ບໍລິການອັບເດດເວລາອ້າງອີງ</translation></message>
++    <message>
++        <source>Next DST Change Service</source>
++        <translation>ການປ່ຽນແປງ DST ຕໍ່ໄປ</translation></message>
++    <message>
++        <source>Glucose</source>
++        <translation>ກລູໂຄສ</translation></message>
++    <message>
++        <source>Health Thermometer</source>
++        <translation>ເຄື່ອງວັດອຸນຫະພູມສຸຂະພາບ</translation></message>
++    <message>
++        <source>Device Information</source>
++        <translation>ຂໍ້ມູນອຸປະກອນ</translation></message>
++    <message>
++        <source>Heart Rate</source>
++        <translation>ອັດຕາການເຕັ້ນຂອງຫົວໃຈ</translation></message>
++    <message>
++        <source>Phone Alert Status Service</source>
++        <translation>ບໍລິການສະຖານະການແຈ້ງເຕືອນທາງໂທລະສັບ</translation></message>
++    <message>
++        <source>Battery Service</source>
++        <translation>ບໍລິການແບດເຕີຣີ</translation></message>
++    <message>
++        <source>Blood Pressure</source>
++        <translation>ຄວາມດັນເລືອດ</translation></message>
++    <message>
++        <source>Alert Notification Service</source>
++        <translation>ບໍລິການແຈ້ງເຕືອນ</translation></message>
++    <message>
++        <source>Scan Parameters</source>
++        <translation>ພາຣາມີເຕີສະແກນ</translation></message>
++    <message>
++        <source>Running Speed and Cadence</source>
++        <translation>ຄວາມໄວແລະຄວາມໄວໃນການແລ່ນ</translation></message>
++    <message>
++        <source>Cycling Speed and Cadence</source>
++        <translation>ຄວາມໄວແລະຄວາມຖີ່ຂອງການຂີ່ລົດຖີບ</translation></message>
++    <message>
++        <source>Cycling Power</source>
++        <translation>ພະລັງງານຂອງການຂີ່ລົດຖີບ</translation></message>
++    <message>
++        <source>Location and Navigation</source>
++        <translation>ສະຖານທີ່ ແລະ ການນຳທາງ</translation></message>
++    <message>
++        <source>Environmental Sensing</source>
++        <translation>ການສຳຫຼວດສະພາບແວດລ້ອມ</translation></message>
++    <message>
++        <source>Body Composition</source>
++        <translation>ອົງປະກອບຂອງຮ່າງກາຍ</translation></message>
++    <message>
++        <source>User Data</source>
++        <translation>ຂໍ້ມູນຜູ້ໃຊ້</translation></message>
++    <message>
++        <source>Weight Scale</source>
++        <translation>ຕູ້ຊັ່ງນໍ້າໜັກ</translation></message>
++    <message>
++        <source>Bond Management</source>
++        <extracomment>Connection management (Bluetooth)</extracomment>
++        <translation>ການຈັດການພັນທະບັດ</translation></message>
++    <message>
++        <source>Continuous Glucose Monitoring</source>
++        <translation>ການຕິດຕາມລະດັບນໍ້າຕານໃນເລືອດຢ່າງຕໍ່ເນື່ອງ</translation></message>
++    <message>
++        <source>Service Discovery Protocol</source>
++        <translation>ພິເສດການຄົ້ນພົບບໍລິການ</translation></message>
++    <message>
++        <source>User Datagram Protocol</source>
++        <translation>ພິຊະຍາໂປຣໂຕຄອນສົ່ງຂໍ້ມູນຜູ້ໃຊ້</translation></message>
++    <message>
++        <source>Radio Frequency Communication</source>
++        <translation>ການສື່ສານຄື້ນວິທະຍຸຄວາມຖີ່</translation></message>
++    <message>
++        <source>Transmission Control Protocol</source>
++        <translation>ພິຊິດການຄວບຄຸມການສົ່ງຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Telephony Control Specification - Binary</source>
++        <translation>ຂໍ້ກໍານົດການຄວບຄຸມໂທລະສັບ - ໄບນາຣີ</translation></message>
++    <message>
++        <source>Telephony Control Specification - AT</source>
++        <translation>ຂໍ້ກໍານົດການຄວບຄຸມໂທລະສັບ - AT</translation></message>
++    <message>
++        <source>Attribute Protocol</source>
++        <translation>ພິເສດຂອງໂປຣໂຕຄອນ</translation></message>
++    <message>
++        <source>Object Exchange Protocol</source>
++        <translation>ພິທີການແລກປ່ຽນວັດຖຸ</translation></message>
++    <message>
++        <source>Internet Protocol</source>
++        <translation>ອິນເຕີເນັດໂປຣໂຕຄໍ</translation></message>
++    <message>
++        <source>File Transfer Protocol</source>
++        <translation>ພິທີການໂອນໄຟລ໌</translation></message>
++    <message>
++        <source>Hypertext Transfer Protocol</source>
++        <translation>Hypertext Transfer Protocol</translation></message>
++    <message>
++        <source>Wireless Short Packet Protocol</source>
++        <translation>ໂປຣໂຕຄອນຂໍ້ມູນສັ້ນແບບບໍ່ສາຍ</translation></message>
++    <message>
++        <source>Bluetooth Network Encapsulation Protocol</source>
++        <translation>ອະນຸສັນຍາການຫຸ້ມຫໍ່ເຄືອຂ່າຍ Bluetooth</translation></message>
++    <message>
++        <source>Extended Service Discovery Protocol</source>
++        <translation>ພັອຕໂຄລການຄົ້ນພົບບໍລິການທີ່ຂະຫຍາຍອອກ</translation></message>
++    <message>
++        <source>Human Interface Device Protocol</source>
++        <translation>ພິທັກຄໍລ໌ອິນເຕີເຟສຂອງອຸປະກອນມະນຸດ</translation></message>
++    <message>
++        <source>Hardcopy Control Channel</source>
++        <translation>ຊ່ອງທາງຄວບຄຸມສຳເນົາຮາດຄອບີ</translation></message>
++    <message>
++        <source>Hardcopy Data Channel</source>
++        <translation>ຊ່ອງທາງຂໍ້ມູນຮາດຄອບີ</translation></message>
++    <message>
++        <source>Hardcopy Notification</source>
++        <translation>ການແຈ້ງເຕືອນພິມອອກເປັນຮາດຄອບີ</translation></message>
++    <message>
++        <source>Audio/Video Control Transport Protocol</source>
++        <translation>ພິດສະຄິບການຂົນສົ່ງການຄວບຄຸມສຽງ/ວິດີໂອ</translation></message>
++    <message>
++        <source>Audio/Video Distribution Transport Protocol</source>
++        <translation>ພິກັດການຂົນສົ່ງການແຈກຢາຍສຽງ/ວິດີໂອ</translation></message>
++    <message>
++        <source>Common ISDN Access Protocol</source>
++        <translation>ພິທີການເຂົ້າເຖິງ ISDN ທົ່ວໄປ</translation></message>
++    <message>
++        <source>UdiCPlain</source>
++        <translation>ອູດິຊພລາຍ</translation></message>
++    <message>
++        <source>Multi-Channel Adaptation Protocol - Control</source>
++        <translation>ພິທີການປັບຕົວຫຼາຍຊ່ອງທາງ - ການຄວບຄຸມ</translation></message>
++    <message>
++        <source>Multi-Channel Adaptation Protocol - Data</source>
++        <translation>ພິທີການປັບຕົວຫຼາຍຊ່ອງທາງ - ຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Layer 2 Control Protocol</source>
++        <translation>ໂປຣໂຕຄອນຄວບຄຸມຊັ້ນ 2</translation></message>
++    <message>
++        <source>GAP Device Name</source>
++        <extracomment>GAP: Generic Access Profile (Bluetooth)</extracomment>
++        <translation>ຊື່ອຸປະກອນ GAP</translation></message>
++    <message>
++        <source>GAP Appearance</source>
++        <extracomment>GAP: Generic Access Profile (Bluetooth)</extracomment>
++        <translation>ຮູບລັກສະນະ GAP</translation></message>
++    <message>
++        <source>GAP Peripheral Privacy Flag</source>
++        <extracomment>GAP: Generic Access Profile (Bluetooth)</extracomment>
++        <translation>ທຸງຄວາມເປັນສ່ວນຕົວຂອງ GAP Peripheral</translation></message>
++    <message>
++        <source>GAP Reconnection Address</source>
++        <extracomment>GAP: Generic Access Profile (Bluetooth)</extracomment>
++        <translation>ທີ່ຢູ່ການເຊື່ອມຕໍ່ຄືນ GAP</translation></message>
++    <message>
++        <source>GAP Peripheral Preferred Connection Parameters</source>
++        <translation>GAP ອຸປະກອນພາຍນອກ ພາຣາມີເຕີການເຊື່ອມຕໍ່ທີ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>GATT Service Changed</source>
++        <extracomment>GATT: _G_eneric _Att_ribute Profile (Bluetooth)</extracomment>
++        <translation>ການປ່ຽນແປງບໍລິການ GATT</translation></message>
++    <message>
++        <source>Alert Level</source>
++        <translation>ລະດັບການເຕືອນ</translation></message>
++    <message>
++        <source>TX Power</source>
++        <translation>TX Power</translation></message>
++    <message>
++        <source>Date Time</source>
++        <translation>ວັນທີ ເວລາ</translation></message>
++    <message>
++        <source>Day Of Week</source>
++        <translation>ວັນຂອງອາທິດ</translation></message>
++    <message>
++        <source>Day Date Time</source>
++        <translation>ວັນ ວັນທີ ເວລາ</translation></message>
++    <message>
++        <source>Exact Time 256</source>
++        <translation>ເວລາທີ່ແນ່ນອນ 256</translation></message>
++    <message>
++        <source>DST Offset</source>
++        <translation>ການຊົດເຊີຍເວລາອອມແສງ (DST)</translation></message>
++    <message>
++        <source>Time Zone</source>
++        <translation>ເຂດເວລາ</translation></message>
++    <message>
++        <source>Local Time Information</source>
++        <translation>ຂໍ້ມູນເວລາທ້ອງຖິ່ນ</translation></message>
++    <message>
++        <source>Time With DST</source>
++        <translation>ເວລາພ້ອມກັບ DST</translation></message>
++    <message>
++        <source>Time Accuracy</source>
++        <translation>ຄວາມຖືກຕ້ອງຂອງເວລາ</translation></message>
++    <message>
++        <source>Time Source</source>
++        <translation>ແຫຼ່ງເວລາ</translation></message>
++    <message>
++        <source>Reference Time Information</source>
++        <translation>ຂໍ້ມູນເວລາອ້າງອີງ</translation></message>
++    <message>
++        <source>Time Update Control Point</source>
++        <translation>ຈຸດຄວບຄຸມການອັບເດດເວລາ</translation></message>
++    <message>
++        <source>Time Update State</source>
++        <translation>ສະຖານະການອັບເດດເວລາ</translation></message>
++    <message>
++        <source>Glucose Measurement</source>
++        <translation>ການວັດແທກລະດັບນໍ້າຕານໃນເລືອດ</translation></message>
++    <message>
++        <source>Battery Level</source>
++        <translation>ລະດັບແບດເຕີຣີ</translation></message>
++    <message>
++        <source>Temperature Measurement</source>
++        <translation>ການວັດແທກອຸນຫະພູມ</translation></message>
++    <message>
++        <source>Temperature Type</source>
++        <translation>ປະເພດອຸນຫະພູມ</translation></message>
++    <message>
++        <source>Intermediate Temperature</source>
++        <translation>ອຸນຫະພູມລະດັບກາງ</translation></message>
++    <message>
++        <source>Measurement Interval</source>
++        <translation>ຊ່ວງເວລາວັດແທກ</translation></message>
++    <message>
++        <source>Boot Keyboard Input Report</source>
++        <translation>ລາຍງານການປ້ອນຂໍ້ມູນຄີບອດ Boot</translation></message>
++    <message>
++        <source>System ID</source>
++        <translation>ລະບົບ ID</translation></message>
++    <message>
++        <source>Model Number String</source>
++        <translation>ສະຕະວັດຂອງໝາຍເລກຮູບແບບ</translation></message>
++    <message>
++        <source>Serial Number String</source>
++        <translation>ສະຕະວັດທີຕົວເລກລຳດັບ</translation></message>
++    <message>
++        <source>Firmware Revision String</source>
++        <translation>ສະຕຣິງການປັບປຸງເວີຊັນເຟມແວ</translation></message>
++    <message>
++        <source>Hardware Revision String</source>
++        <translation>ສະຕຣິງການປັບປຸງຮາດແວ</translation></message>
++    <message>
++        <source>Software Revision String</source>
++        <translation>ສະຕຣິງການປັບປຸງຊອບແວ</translation></message>
++    <message>
++        <source>Manufacturer Name String</source>
++        <translation>ຊື່ຜູ້ຜະລິດ</translation></message>
++    <message>
++        <source>IEEE 11073 20601 Regulatory Certification Data List</source>
++        <translation>IEEE 11073 20601 ຂໍ້ມູນການຢັ້ງຢືນກົດລະບຽບ</translation></message>
++    <message>
++        <source>Current Time</source>
++        <translation>ເວລາປັດຈຸບັນ</translation></message>
++    <message>
++        <source>Scan Refresh</source>
++        <translation>ສະແກນຟື້ນຟີວ</translation></message>
++    <message>
++        <source>Boot Keyboard Output Report</source>
++        <translation>ລາຍງານຜົນຜະລິດຄີບອດ Boot</translation></message>
++    <message>
++        <source>Boot Mouse Input Report</source>
++        <translation>ລາຍງານການປ້ອນຂໍ້ມູນຂອງເມົາ Boot</translation></message>
++    <message>
++        <source>Glucose Measurement Context</source>
++        <translation>ບໍລິບັດການວັດແທກກຸ່ມນ້ຳຕານໃນເລືອດ</translation></message>
++    <message>
++        <source>Blood Pressure Measurement</source>
++        <translation>ການວັດແທກຄວາມດັນເລືອດ</translation></message>
++    <message>
++        <source>Intermediate Cuff Pressure</source>
++        <translation>ຄວາມດັນຂອງສາຍຮັດແຂນລະດັບກາງ</translation></message>
++    <message>
++        <source>Heart Rate Measurement</source>
++        <translation>ການວັດແທກອັດຕາການເຕັ້ນຂອງຫົວໃຈ</translation></message>
++    <message>
++        <source>Body Sensor Location</source>
++        <translation>ສະຖານທີ່ຕິດຕັ້ງເຊັນເຊີຮ່າງກາຍ</translation></message>
++    <message>
++        <source>Heart Rate Control Point</source>
++        <translation>ຈຸດຄວບຄຸມອັດຕາການເຕັ້ນຂອງຫົວໃຈ</translation></message>
++    <message>
++        <source>Alert Status</source>
++        <translation>ສະຖານະການແຈ້ງເຕືອນ</translation></message>
++    <message>
++        <source>Ringer Control Point</source>
++        <translation>ຈຸດຄວບຄຸມສຽງສັນຍານ</translation></message>
++    <message>
++        <source>Ringer Setting</source>
++        <translation>ການຕັ້ງຄ່າສຽງສັນຍານ</translation></message>
++    <message>
++        <source>Alert Category ID Bit Mask</source>
++        <translation>ປ່ຽນເປັນພາສາລາວ: ໝາຍເລກບິດຂອງໝວດໝູ່ການແຈ້ງເຕືອນ</translation></message>
++    <message>
++        <source>Alert Category ID</source>
++        <translation>ລະຫັດປະເພດການແຈ້ງເຕືອນ</translation></message>
++    <message>
++        <source>Alert Notification Control Point</source>
++        <translation>ຈຸດຄວບຄຸມການແຈ້ງເຕືອນ</translation></message>
++    <message>
++        <source>Unread Alert Status</source>
++        <translation>ສະຖານະການແຈ້ງເຕືອນທີ່ຍັງບໍ່ໄດ້ອ່ານ</translation></message>
++    <message>
++        <source>New Alert</source>
++        <translation>ການແຈ້ງເຕືອນໃໝ່</translation></message>
++    <message>
++        <source>Supported New Alert Category</source>
++        <translation>ສະໜັບສະໜູນໝວດໝູ່ການແຈ້ງເຕືອນໃໝ່</translation></message>
++    <message>
++        <source>Supported Unread Alert Category</source>
++        <translation>ປະເພດການແຈ້ງເຕືອນທີ່ຍັງບໍ່ໄດ້ອ່ານທີ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>Blood Pressure Feature</source>
++        <translation>ຄຸນສົມບັດຄວາມດັນເລືອດ</translation></message>
++    <message>
++        <source>HID Information</source>
++        <extracomment>HID: Human Interface Device Profile (Bluetooth)</extracomment>
++        <translation>ຂໍ້ມູນ HID</translation></message>
++    <message>
++        <source>Report Map</source>
++        <translation>ລາຍງານແຜນທີ່</translation></message>
++    <message>
++        <source>HID Control Point</source>
++        <extracomment>HID: Human Interface Device Profile (Bluetooth)</extracomment>
++        <translation>ຈຸດຄວບຄຸມ HID</translation></message>
++    <message>
++        <source>Report</source>
++        <translation>ລາຍງານ</translation></message>
++    <message>
++        <source>Protocol Mode</source>
++        <translation>ໂຫມດພິຣອະໂຄລ</translation></message>
++    <message>
++        <source>Scan Interval Window</source>
++        <translation>ປ່ອງຢ້ຽມໄລຍະການສະແກນ</translation></message>
++    <message>
++        <source>PnP ID</source>
++        <translation>PnP ID</translation></message>
++    <message>
++        <source>Glucose Feature</source>
++        <translation>ຄຸນສົມບັດຂອງກລູໂຄສ</translation></message>
++    <message>
++        <source>Record Access Control Point</source>
++        <extracomment>Glucose Sensor patient record database.</extracomment>
++        <translation>ຈຸດຄວບຄຸມການເຂົ້າເຖິງບັນທຶກ</translation></message>
++    <message>
++        <source>RSC Measurement</source>
++        <extracomment>RSC: Running Speed and Cadence</extracomment>
++        <translation>ການວັດແທກ RSC</translation></message>
++    <message>
++        <source>RSC Feature</source>
++        <extracomment>RSC: Running Speed and Cadence</extracomment>
++        <translation>ຄຸນສົມບັດ RSC</translation></message>
++    <message>
++        <source>SC Control Point</source>
++        <translation>SC ຈຸດຄວບຄຸມ</translation></message>
++    <message>
++        <source>CSC Measurement</source>
++        <extracomment>CSC: Cycling Speed and Cadence</extracomment>
++        <translation>ການວັດແທກ CSC</translation></message>
++    <message>
++        <source>CSC Feature</source>
++        <extracomment>CSC: Cycling Speed and Cadence</extracomment>
++        <translation>ຄຸນສົມບັດ CSC</translation></message>
++    <message>
++        <source>Sensor Location</source>
++        <translation>ສະຖານທີ່ຂອງເຊັນເຊີ</translation></message>
++    <message>
++        <source>Cycling Power Measurement</source>
++        <translation>ການວັດແທກພະລັງງານການຂີ່ລົດຖີບ</translation></message>
++    <message>
++        <source>Cycling Power Vector</source>
++        <translation>ກຳລັງຂັບເຄື່ອນຂອງການຂີ່ລົດຖີບ</translation></message>
++    <message>
++        <source>Cycling Power Feature</source>
++        <translation>ຄຸນສົມບັດພະລັງງານຂອງການຂີ່ລົດຖີບ</translation></message>
++    <message>
++        <source>Cycling Power Control Point</source>
++        <translation>ຈຸດຄວບຄຸມພະລັງງານຂອງການຂີ່ລົດຖີບ</translation></message>
++    <message>
++        <source>Location And Speed</source>
++        <translation>ສະຖານທີ່ ແລະ ຄວາມໄວ</translation></message>
++    <message>
++        <source>Navigation</source>
++        <translation>ນຳທາງ</translation></message>
++    <message>
++        <source>Position Quality</source>
++        <translation>ຄຸນນະພາບຕໍາແໜ່ງ</translation></message>
++    <message>
++        <source>LN Feature</source>
++        <translation>ຄຸນສົມບັດ LN</translation></message>
++    <message>
++        <source>LN Control Point</source>
++        <translation>ຈຸດຄວບຄຸມ LN</translation></message>
++    <message>
++        <source>Magnetic Declination</source>
++        <extracomment>Angle between geographic and magnetic north</extracomment>
++        <translation>ການຫຼຸດລົງຂອງແມ່ເຫຼັກ</translation></message>
++    <message>
++        <source>Elevation</source>
++        <extracomment>Above/below sea level</extracomment>
++        <translation>ລະດັບຄວາມສູງ</translation></message>
++    <message>
++        <source>Pressure</source>
++        <translation>ຄວາມກົດດັນ</translation></message>
++    <message>
++        <source>Temperature</source>
++        <translation>ອຸນຫະພູມ</translation></message>
++    <message>
++        <source>Humidity</source>
++        <translation>ຄວາມຊຸ່ມຊື່ນ</translation></message>
++    <message>
++        <source>True Wind Speed</source>
++        <extracomment>Wind speed while standing</extracomment>
++        <translation>ຄວາມໄວລົມທີ່ແທ້ຈິງ</translation></message>
++    <message>
++        <source>True Wind Direction</source>
++        <translation>ທິດທາງລົມທີ່ແທ້ຈິງ</translation></message>
++    <message>
++        <source>Apparent Wind Speed</source>
++        <extracomment>Wind speed while observer is moving</extracomment>
++        <translation>ຄວາມໄວລົມທີ່ປາກົດ</translation></message>
++    <message>
++        <source>Apparent Wind Direction</source>
++        <translation>ທິດທາງລົມທີ່ປາກົດ</translation></message>
++    <message>
++        <source>Gust Factor</source>
++        <extracomment>Factor by which wind gust is stronger than average wind</extracomment>
++        <translation>ປັດໄຈລົມພັດ</translation></message>
++    <message>
++        <source>Pollen Concentration</source>
++        <translation>ຄວາມເຂັ້ມຂຸ້ນຂອງເກສອນ</translation></message>
++    <message>
++        <source>UV Index</source>
++        <translation>ດັດຊີອຸທິດສະຫວ່າງອຸລຕະລາເມວ</translation></message>
++    <message>
++        <source>Irradiance</source>
++        <translation>ການສະຫວ່າງສະຫວ່າງ</translation></message>
++    <message>
++        <source>Rainfall</source>
++        <translation>ຝົນຕົກ</translation></message>
++    <message>
++        <source>Wind Chill</source>
++        <translation>ລົມຫນາວ</translation></message>
++    <message>
++        <source>Heat Index</source>
++        <translation>ດັດຊະນີຄວາມຮ້ອນ</translation></message>
++    <message>
++        <source>Dew Point</source>
++        <translation>ຈຸດນ້ຳຄ້າງ</translation></message>
++    <message>
++        <source>Descriptor Value Changed</source>
++        <extracomment>Environmental sensing related</extracomment>
++        <translation>ຄ່າຂອງຕົວບັນຍາຍຖືກປ່ຽນແປງ</translation></message>
++    <message>
++        <source>Aerobic Heart Rate Lower Limit</source>
++        <translation>ຂອບເຂດອັດຕາການເຕັ້ນຂອງຫົວໃຈທີ່ຕ່ຳສຸດສຳລັບການອອກກຳລັງກາຍແບບແອໂຣບິກ</translation></message>
++    <message>
++        <source>Aerobic Heart Rate Upper Limit</source>
++        <translation>ຂອບເຂດເທິງຂອງອັດຕາການເຕັ້ນຂອງຫົວໃຈໃນການອອກກຳລັງກາຍແບບເອໂອຣອບິກ</translation></message>
++    <message>
++        <source>Aerobic Threshold</source>
++        <translation>ຂອບເຂດການຫາຍໃຈແບບອາໂຣບິກ</translation></message>
++    <message>
++        <source>Age</source>
++        <extracomment>Age of person</extracomment>
++        <translation>ອາຍຸ</translation></message>
++    <message>
++        <source>Anaerobic Heart Rate Lower Limit</source>
++        <translation>ຂອບເຂດຕ່ຳສຸດຂອງອັດຕາການເຕັ້ນຂອງຫົວໃຈແບບບໍ່ມີອົກຊີເຈນ</translation></message>
++    <message>
++        <source>Anaerobic Heart Rate Upper Limit</source>
++        <translation>ຂອບເຂດອັດຕາການເຕັ້ນຂອງຫົວໃຈທີ່ບໍ່ມີອົກຊີເຈນ</translation></message>
++    <message>
++        <source>Anaerobic Threshold</source>
++        <translation>ຂອບເຂດທີ່ບໍ່ມີອົກຊີເຈນ</translation></message>
++    <message>
++        <source>Date Of Birth</source>
++        <translation>ວັນເດືອນປີເກີດ</translation></message>
++    <message>
++        <source>Date Of Threshold Assessment</source>
++        <translation>ວັນທີຂອງການປະເມີນຂອບເຂດ</translation></message>
++    <message>
++        <source>Email Address</source>
++        <translation>ທີ່ຢູ່ອີເມວ</translation></message>
++    <message>
++        <source>Fat Burn Heart Rate Lower Limit</source>
++        <translation>ຂອບເຂດລຸ່ມຂອງອັດຕາການເຜົາຜານໄຂມັນ</translation></message>
++    <message>
++        <source>Fat Burn Heart Rate Upper Limit</source>
++        <translation>ຂອບເຂດເທິງຂອງອັດຕາການເຜົາຜານໄຂມັນ</translation></message>
++    <message>
++        <source>First Name</source>
++        <translation>ຊື່</translation></message>
++    <message>
++        <source>5-Zone Heart Rate Limits</source>
++        <translation>5-ເຂດຈຳກັດອັດຕາການເຕັ້ນຂອງຫົວໃຈ</translation></message>
++    <message>
++        <source>Gender</source>
++        <translation>ເພດ</translation></message>
++    <message>
++        <source>Heart Rate Maximum</source>
++        <translation>ອັດຕາການເຕັ້ນຂອງຫົວໃຈສູງສຸດ</translation></message>
++    <message>
++        <source>Height</source>
++        <extracomment>Height of a person</extracomment>
++        <translation>ຄວາມສູງ</translation></message>
++    <message>
++        <source>Hip Circumference</source>
++        <translation>ລວດຮອບສະໂພກ</translation></message>
++    <message>
++        <source>Last Name</source>
++        <translation>ນາມສະກຸນ</translation></message>
++    <message>
++        <source>Maximum Recommended Heart Rate</source>
++        <translation>ອັດຕາການເຕັ້ນຂອງຫົວໃຈທີ່ແນະນຳສູງສຸດ</translation></message>
++    <message>
++        <source>Resting Heart Rate</source>
++        <translation>ອັດຕາການເຕັ້ນຂອງຫົວໃຈໃນລະຫວ່າງພັກຜ່ອນ</translation></message>
++    <message>
++        <source>Sport Type For Aerobic/Anaerobic Thresholds</source>
++        <translation>ປະເພດກິລາສຳລັບຂອບເຂດອາກາດ/ອາກາດທີ່ບໍ່ມີອາກາດ</translation></message>
++    <message>
++        <source>3-Zone Heart Rate Limits</source>
++        <translation>3-ເຂດຂອບເຂດອັດຕາການເຕັ້ນຂອງຫົວໃຈ</translation></message>
++    <message>
++        <source>2-Zone Heart Rate Limits</source>
++        <translation>2-ເຂດຈຳກັດອັດຕາການເຕັ້ນຂອງຫົວໃຈ</translation></message>
++    <message>
++        <source>Oxygen Uptake</source>
++        <translation>ການດູດຊຶມອົກຊີເຈນ</translation></message>
++    <message>
++        <source>Waist Circumference</source>
++        <translation>ລວດຮອບແອວ</translation></message>
++    <message>
++        <source>Weight</source>
++        <translation>ນໍ້າໜັກ</translation></message>
++    <message>
++        <source>Database Change Increment</source>
++        <extracomment>Environmental sensing related</extracomment>
++        <translation>ການປ່ຽນແປງຖານຂໍ້ມູນເພີ່ມຂຶ້ນ</translation></message>
++    <message>
++        <source>User Index</source>
++        <translation>ດັດຊະນີຜູ້ໃຊ້</translation></message>
++    <message>
++        <source>Body Composition Feature</source>
++        <translation>ຄຸນສົມບັດຂອງອົງການປະກອບສ່ວນຂອງຮ່າງກາຍ</translation></message>
++    <message>
++        <source>Body Composition Measurement</source>
++        <translation>ການວັດແທກອົງປະກອບຂອງຮ່າງກາຍ</translation></message>
++    <message>
++        <source>Weight Measurement</source>
++        <translation>ການວັດແທກນ້ຳໜັກ</translation></message>
++    <message>
++        <source>User Control Point</source>
++        <translation>ຈຸດຄວບຄຸມຜູ້ໃຊ້</translation></message>
++    <message>
++        <source>Magnetic Flux Density 2D</source>
++        <translation>ຄວາມໜາແໜ້ນຂອງຟລັກແມ່ເຫຼັກ 2D</translation></message>
++    <message>
++        <source>Magnetic Flux Density 3D</source>
++        <translation>ຄວາມໜາແໜ້ນຂອງສາຍແມ່ເຫຼັກ 3D</translation></message>
++    <message>
++        <source>Language</source>
++        <translation>ພາສາ</translation></message>
++    <message>
++        <source>Barometric Pressure Trend</source>
++        <translation>ແນວໂນ້ມຄວາມກົດດັນບາຣໍເມັດຣິກ</translation></message>
++    <message>
++        <source>Characteristic Extended Properties</source>
++        <translation>ຄຸນລັກສະນະຂອງຄຸນສົມບັດທີ່ຂະຫຍາຍ</translation></message>
++    <message>
++        <source>Characteristic User Description</source>
++        <translation>ລັກສະນະຂອງຜູ້ໃຊ້</translation></message>
++    <message>
++        <source>Client Characteristic Configuration</source>
++        <translation>ການຕັ້ງຄ່າລັກສະນະຂອງລູກຄ້າ</translation></message>
++    <message>
++        <source>Server Characteristic Configuration</source>
++        <translation>ການຕັ້ງຄ່າຄຸນລັກສະນະຂອງເຊີບເວີ</translation></message>
++    <message>
++        <source>Characteristic Presentation Format</source>
++        <translation>ຮູບແບບການນຳສະເໜີລັກສະນະ</translation></message>
++    <message>
++        <source>Characteristic Aggregate Format</source>
++        <translation>ຮູບແບບລວມລັກສະນະ</translation></message>
++    <message>
++        <source>Valid Range</source>
++        <translation>ຂອບເຂດທີ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>External Report Reference</source>
++        <translation>ການອ້າງອີງລາຍງານພາຍນອກ</translation></message>
++    <message>
++        <source>Report Reference</source>
++        <translation>ລາຍງານອ້າງອີງ</translation></message>
++    <message>
++        <source>Environmental Sensing Configuration</source>
++        <translation>ການຕັ້ງຄ່າການສຳຫຼວດສະພາບແວດລ້ອມ</translation></message>
++    <message>
++        <source>Environmental Sensing Measurement</source>
++        <translation>ການວັດແທກການຮັບຮູ້ສະພາບແວດລ້ອມ</translation></message>
++    <message>
++        <source>Environmental Sensing Trigger Setting</source>
++        <translation>ການຕັ້ງຄ່າຕົວກະຕຸ້ນການສຳຫຼວດສະພາບແວດລ້ອມ</translation></message>
++    <message>
++        <source>Unknown Service</source>
++        <translation>ບໍລິການທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QBluetoothSocket</name>
++    <message>
++        <source>Network Error</source>
++        <translation>ຂໍ້ຜິດພາດເຄືອຂ່າຍ</translation></message>
++    <message>
++        <source>Cannot write while not connected</source>
++        <translation>ບໍ່ສາມາດຂຽນໄດ້ໃນຂະນະທີ່ບໍ່ໄດ້ເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Trying to connect while connection is in progress</source>
++        <translation>ພະຍາຍາມເຊື່ອມຕໍ່ຂະນະທີ່ການເຊື່ອມຕໍ່ກຳລັງດຳເນີນຢູ່</translation></message>
++    <message>
++        <source>Service cannot be found</source>
++        <translation>ບໍ່ສາມາດຊອກຫາບໍລິການໄດ້</translation></message>
++    <message>
++        <source>Invalid data/data size</source>
++        <translation>ຂໍ້ມູນບໍ່ຖືກຕ້ອງ/ຂະໜາດຂໍ້ມູນ</translation></message>
++    <message>
++        <source>Cannot read while not connected</source>
++        <translation>ບໍ່ສາມາດອ່ານໄດ້ໃນຂະນະທີ່ບໍ່ໄດ້ເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Cannot connect to %1</source>
++        <comment>%1 = uuid</comment>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບ %1</translation></message>
++    <message>
++        <source>Device does not support Bluetooth</source>
++        <translation>ອຸປະກອນບໍ່ຮອງຮັບ Bluetooth</translation></message>
++    <message>
++        <source>Device is powered off</source>
++        <translation>ອຸປະກອນຖືກປິດໄຟຟ້າ</translation></message>
++    <message>
++        <source>Cannot access address %1</source>
++        <comment>%1 = Bt address e.g. 11:22:33:44:55:66</comment>
++        <translation>ບໍ່ສາມາດເຂົ້າເຖິງທີ່ຢູ່ %1</translation></message>
++    <message>
++        <source>Cannot connect to %1 on %2</source>
++        <comment>%1 = uuid, %2 = Bt address</comment>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບ %1 ໃນ %2</translation></message>
++    <message>
++        <source>Socket type not supported</source>
++        <translation>ປະເພດຂອງຊັອກເກັດບໍ່ຖືກຮອງຮັບ</translation></message>
++    <message>
++        <source>Obtaining streams for service failed</source>
++        <translation>ການເກັບກຳສະຕຣີມສຳລັບບໍລິການລົ້ມເຫຼວ</translation></message>
++    <message>
++        <source>Input stream thread cannot be started</source>
++        <translation>ກະທູ້ຂາເຂົ້າຂໍ້ມູນບໍ່ສາມາດເລີ່ມຕົ້ນໄດ້</translation></message>
++    <message>
++        <source>Connection to service failed</source>
++        <translation>ການເຊື່ອມຕໍ່ກັບບໍລິການລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Error during write on socket.</source>
++        <translation>ຜິດພາດໃນລະຫວ່າງການຂຽນຂໍ້ມູນລົງໃນຊັອກເກັດ.</translation></message>
++    <message>
++        <source>Network error during read</source>
++        <translation>ຂໍ້ຜິດພາດເຄືອຂ່າຍໃນລະຫວ່າງການອ່ານ</translation></message>
++    <message>
++        <source>Unknown socket error</source>
++        <translation>ຂໍ້ຜິດພາດຂອງຊັອກເກັດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Cannot set connection security level</source>
++        <translation>ບໍ່ສາມາດຕັ້ງລະດັບຄວາມປອດໄພການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Network Error: %1</source>
++        <translation>ຂໍ້ຜິດພາດເຄືອຂ່າຍ: %1</translation></message>
++    <message>
++        <source>Cannot export profile on DBus</source>
++        <translation>ບໍ່ສາມາດສົ່ງອອກໂປຣໄຟລ໌ໃນ DBus</translation></message>
++    <message>
++        <source>Cannot register profile on DBus</source>
++        <translation>ບໍ່ສາມາດລົງທະບຽນໂປຣໄຟລ໌ໃນ DBus ໄດ້</translation></message>
++    <message>
++        <source>Cannot find remote device</source>
++        <translation>ບໍ່ສາມາດຊອກຫາອຸປະກອນທາງໄກ</translation></message>
++    <message>
++        <source>Cannot connect to remote profile</source>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບໂປຣໄຟລ໌ທາງໄກ</translation></message>
++    <message>
++        <source>Missing serviceUuid or Serial Port service class uuid</source>
++        <translation>ຂາດ serviceUuid ຫຼື Serial Port service class uuid</translation></message>
++    <message>
++        <source>Invalid Bluetooth address passed to connectToService()</source>
++        <translation>ທີ່ຢູ່ Bluetooth ບໍ່ຖືກຕ້ອງ ຖືກສົ່ງໄປຍັງ connectToService()</translation></message>
++    <message>
++        <source>Network error</source>
++        <translation>ຂໍ້ຜິດພາດເຄືອຂ່າຍ</translation></message>
++    <message>
++        <source>Remote host closed connection</source>
++        <translation>ໂຮສຕຣາງໄກປິດການເຊື່ອມຕໍ່</translation></message>
++    <message>
++        <source>Connection timed out</source>
++        <translation>ການເຊື່ອມຕໍ່ໝົດເວລາ</translation></message>
++    <message>
++        <source>Host not reachable</source>
++        <translation>ໂຮສບໍ່ສາມາດເຂົ້າເຖິງໄດ້</translation></message>
++    <message>
++        <source>Host refused connection</source>
++        <translation>ເຊີບເວີປະຕິເສດການເຊື່ອມຕໍ່</translation></message>
++</context>
++<context>
++    <name>QBluetoothSocketPrivateAndroid</name>
++    <message>
++        <source>Connecting to port is not supported</source>
++        <translation>ການເຊື່ອມຕໍ່ກັບພອດບໍ່ຖືກສະຫນັບສະຫນູນ</translation></message>
++</context>
++<context>
++    <name>QBluetoothSocketPrivateBluezDBus</name>
++    <message>
++        <source>Connecting to port is not supported via Bluez DBus</source>
++        <translation>ການເຊື່ອມຕໍ່ກັບພອດບໍ່ຖືກສະຫນັບສະຫນູນຜ່ານ Bluez DBus</translation></message>
++</context>
++<context>
++    <name>QBluetoothTransferReply</name>
++    <message>
++        <source>Invalid target address</source>
++        <translation>ທີ່ຢູ່ເປົ້າໝາຍບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Push session cannot be started</source>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນເຊສຊັນການດັນໄດ້</translation></message>
++    <message>
++        <source>Push session cannot connect</source>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບຊຸດການກົດ</translation></message>
++    <message>
++        <source>Source file does not exist</source>
++        <translation>ໄຟລ໌ຕົ້ນສະບັບບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>QIODevice cannot be read. Make sure it is open for reading.</source>
++        <translation>QIODevice ບໍ່ສາມາດອ່ານໄດ້. ໃຫ້ແນ່ໃຈວ່າມັນເປີດສຳລັບການອ່ານ.</translation></message>
++    <message>
++        <source>Push session failed</source>
++        <translation>ການຍູ້ເຊຊັນລົ້ມເຫລວ</translation></message>
++    <message>
++        <source>Invalid input device (null)</source>
++        <translation>ອຸປະກອນປ້ອນຂໍ້ມູນບໍ່ຖືກຕ້ອງ (null)</translation></message>
++    <message>
++        <source>Operation canceled</source>
++        <translation>ການດຳເນີນງານຖືກຍົກເລີກ</translation></message>
++    <message>
++        <source>Transfer already started</source>
++        <translation>ໂອນແລ້ວ</translation></message>
++    <message>
++        <source>Push service not found</source>
++        <translation>ບໍ່ພົບບໍລິການການສົ່ງຂໍ້ມູນ</translation></message>
++</context>
++<context>
++    <name>QBluetoothTransferReplyBluez</name>
++    <message>
++        <source>Unknown Error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Could not open file for sending</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ສຳລັບການສົ່ງໄດ້</translation></message>
++    <message>
++        <source>The transfer was canceled</source>
++        <translation>ການໂອນເງິນຖືກຍົກເລີກ</translation></message>
++    <message>
++        <source>Operation canceled</source>
++        <translation>ການດຳເນີນງານຖືກຍົກເລີກ</translation></message>
++</context>
++<context>
++    <name>QLowEnergyController</name>
++    <message>
++        <source>Remote device cannot be found</source>
++        <translation>ອຸປະກອນທາງໄກບໍ່ສາມາດພົບເຫັນ</translation></message>
++    <message>
++        <source>Cannot find local adapter</source>
++        <translation>ບໍ່ສາມາດຊອກຫາ adapter ທ້ອງຖິ່ນໄດ້</translation></message>
++    <message>
++        <source>Error occurred during connection I/O</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນລະຫວ່າງການເຊື່ອມຕໍ່ I/O</translation></message>
++    <message>
++        <source>Unknown Error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Advertisement data is larger than 31 bytes</source>
++        <translation>ຂໍ້ມູນໂຄສະນາໃຫຍ່ກວ່າ 31 ໄບຕ໌</translation></message>
++    <message>
++        <source>Advertisement feature not supported on the platform</source>
++        <translation>ຄຸນສົມບັດການໂຄສະນາບໍ່ຖືກສະໜັບສະໜູນໃນແພລດຟອມ</translation></message>
++    <message>
++        <source>Error occurred trying to start advertising</source>
++        <translation>ຜິດພາດເກີດຂຶ້ນໃນການພະຍາຍາມເລີ່ມຕົ້ນການໂຄສະນາ</translation></message>
++    <message>
++        <source>Failed due to too many advertisers</source>
++        <translation>ລົ້ມເຫລວເນື່ອງຈາກມີນັກໂຄສະນາຫຼາຍເກີນໄປ</translation></message>
++    <message>
++        <source>Unknown advertisement error</source>
++        <translation>ຂໍ້ຜິດພາດການໂຄສະນາທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>Error occurred trying to connect to remote device.</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນການພະຍາຍາມເຊື່ອມຕໍ່ກັບອຸປະກອນທາງໄກ.</translation></message>
++    <message>
++        <source>Remote device closed the connection</source>
++        <translation>ອຸປະກອນທາງໄກໄດ້ປິດການເຊື່ອມຕໍ່</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qtdeclarative_lo.ts b/translations/qtdeclarative_lo.ts
+new file mode 100644
+index 0000000..3f3e0dd
+--- /dev/null
++++ b/translations/qtdeclarative_lo.ts
+@@ -0,0 +1,2003 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>AbstractButtonSection</name>
++    <message>
++        <source>AbstractButton</source>
++        <translation>ປຸ່ມສະຫຼຸບຍ່ອຍ</translation></message>
++    <message>
++        <source>Text</source>
++        <translation>ຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>The text displayed on the button.</source>
++        <translation>ຂໍ້ຄວາມທີ່ສະແດງຢູ່ເທິງປຸ່ມ.</translation></message>
++    <message>
++        <source>Display</source>
++        <translation>ສະແດງ</translation></message>
++    <message>
++        <source>Determines how the icon and text are displayed within the button.</source>
++        <translation>ກຳນົດວິທີທີ່ໄອຄອນ ແລະ ຂໍ້ຄວາມຖືກສະແດງພາຍໃນປຸ່ມ.</translation></message>
++    <message>
++        <source>Checkable</source>
++        <translation>ກວດສອບໄດ້</translation></message>
++    <message>
++        <source>Whether the button is checkable.</source>
++        <translation>ປຸ່ມສາມາດກວດສອບໄດ້ຫຼືບໍ່.</translation></message>
++    <message>
++        <source>Checked</source>
++        <translation>ກວດສອບແລ້ວ</translation></message>
++    <message>
++        <source>Whether the button is checked.</source>
++        <translation>ປຸ່ມຖືກເລືອກຫຼືບໍ່.</translation></message>
++    <message>
++        <source>Exclusive</source>
++        <translation>ສະເພາະ</translation></message>
++    <message>
++        <source>Whether the button is exclusive.</source>
++        <translation>ປຸ່ມນີ້ເປັນປຸ່ມທີ່ສະເພາະບໍ?</translation></message>
++    <message>
++        <source>Repeat</source>
++        <translation>ເຮັດຊ້ຳ</translation></message>
++    <message>
++        <source>Whether the button repeats while pressed and held down.</source>
++        <translation>ປຸ່ມຈະຄືນຄືນເມື່ອກົດແລະຖືຄ້າງຢູ່ບໍ?</translation></message>
++</context>
++<context>
++    <name>BusyIndicatorSpecifics</name>
++    <message>
++        <source>BusyIndicator</source>
++        <translation>ຕົວຊີ້ບອກຄວາມຄືບຫນ້າ</translation></message>
++    <message>
++        <source>Running</source>
++        <translation>ກຳລັງແລ່ນ</translation></message>
++    <message>
++        <source>Whether the busy indicator is currently indicating activity.</source>
++        <translation>ຕົວຊີ້ບອກຄວາມຫຍຸ້ງຍາກປະຈຸບັນກຳລັງຊີ້ບອກການເຄື່ອນໄຫວຫຼືບໍ່.</translation></message>
++</context>
++<context>
++    <name>ButtonSection</name>
++    <message>
++        <source>Button</source>
++        <translation>ປຸ່ມ</translation></message>
++    <message>
++        <source>AutoRepeat</source>
++        <translation>ອັດຕະໂນມັດເຮັດຊ້ຳ</translation></message>
++    <message>
++        <source>Whether the button repeats pressed(), released() and clicked() signals while the button is pressed and held down.</source>
++        <translation>ບຸກຄີກົດຊໍ້າເຄື່ອງໝາຍສັນຍານທີ່ຖືກກົດ(), ປ່ອຍ() ແລະ ກົດ() ໃນຂະນະທີ່ບຸກຄີຖືກກົດແລະຖືຄົງໄວ້.</translation></message>
++    <message>
++        <source>Flat</source>
++        <translation>ພື້ນທີ່</translation></message>
++    <message>
++        <source>Whether the button is flat.</source>
++        <translation>ປຸ່ມແມ່ນຮາບພຽງຫຼືບໍ່.</translation></message>
++    <message>
++        <source>Highlighted</source>
++        <translation>ເນັ້ນໃສ່</translation></message>
++    <message>
++        <source>Whether the button is highlighted.</source>
++        <translation>ປຸ່ມຖືກເນັ້ນຫຼືບໍ່.</translation></message>
++</context>
++<context>
++    <name>CheckBoxSpecifics</name>
++    <message>
++        <source>CheckBox</source>
++        <translation>ກວດສອບກ່ອງ</translation></message>
++</context>
++<context>
++    <name>CheckDelegateSpecifics</name>
++    <message>
++        <source>CheckDelegate</source>
++        <translation>ກວດສອບຜູ້ແທນ</translation></message>
++</context>
++<context>
++    <name>CheckSection</name>
++    <message>
++        <source>Check State</source>
++        <translation>ກວດສອບສະຖານະ</translation></message>
++    <message>
++        <source>The current check state.</source>
++        <translation>ສະຖານະການກວດສອບປະຈຸບັນ.</translation></message>
++    <message>
++        <source>Tri-state</source>
++        <translation>ສາມລັດ</translation></message>
++    <message>
++        <source>Whether the checkbox has three states.</source>
++        <translation>ບໍ່ວ່າກ່ອງໝາຍຖືກມີສາມສະຖານະ.</translation></message>
++</context>
++<context>
++    <name>ComboBoxSpecifics</name>
++    <message>
++        <source>ComboBox</source>
++        <translation>ກ່ອມໂບກັດ</translation></message>
++    <message>
++        <source>Text Role</source>
++        <translation>ບົດຂໍ້ຄວາມ ບົດບາດ</translation></message>
++    <message>
++        <source>The model role used for displaying text.</source>
++        <translation>ບົດບາດຂອງແບບຈຳລອງທີ່ໃຊ້ເພື່ອສະແດງຂໍ້ຄວາມ.</translation></message>
++    <message>
++        <source>Current</source>
++        <translation>ປະຈຸບັນ</translation></message>
++    <message>
++        <source>The index of the current item.</source>
++        <translation>ດັດຊະນີຂອງລາຍການປະຈຸບັນ.</translation></message>
++    <message>
++        <source>Editable</source>
++        <translation>ແກ້ໄຂໄດ້</translation></message>
++    <message>
++        <source>Whether the combo box is editable.</source>
++        <translation>ບໍ່ວ່າກ່ອງລາຍການສາມາດແກ້ໄຂໄດ້ຫຼືບໍ່.</translation></message>
++    <message>
++        <source>Flat</source>
++        <translation>ພື້ນທີ່ຮາບພຽງ</translation></message>
++    <message>
++        <source>Whether the combo box button is flat.</source>
++        <translation>ບຸກຄັງຄອມໂບບັອກແມ່ນຮາບພຽງຫຼືບໍ່.</translation></message>
++    <message>
++        <source>DisplayText</source>
++        <translation>ສະແດງຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Holds the text that is displayed on the combo box button.</source>
++        <translation>ຮັກສາຂໍ້ຄວາມທີ່ສະແດງຢູ່ເທິງປຸ່ມກ່ອງລາຍການ.</translation></message>
++</context>
++<context>
++    <name>ContainerSection</name>
++    <message>
++        <source>Container</source>
++        <translation>ກະຕ່າ</translation></message>
++    <message>
++        <source>Current</source>
++        <translation>ປັດຈຸບັນ</translation></message>
++    <message>
++        <source>The index of the current item.</source>
++        <translation>ດັດຊະນີຂອງລາຍການປະຈຸບັນ.</translation></message>
++</context>
++<context>
++    <name>ControlSection</name>
++    <message>
++        <source>Control</source>
++        <translation>ຄວບຄຸມ</translation></message>
++    <message>
++        <source>Enabled</source>
++        <translation>ເປີດໃຊ້ງານ</translation></message>
++    <message>
++        <source>Whether the control is enabled.</source>
++        <translation>ການຄວບຄຸມແມ່ນເປີດໃຊ້ງານຫຼືບໍ່.</translation></message>
++    <message>
++        <source>Focus Policy</source>
++        <translation>ນະໂຍບາຍການສຸມໃສ່</translation></message>
++    <message>
++        <source>Focus policy of the control.</source>
++        <translation>ນະໂຍບາຍການສຸມໃສ່ຂອງການຄວບຄຸມ.</translation></message>
++    <message>
++        <source>Hover</source>
++        <translation>ລ່ອງເມົາ</translation></message>
++    <message>
++        <source>Whether control accepts hover evets.</source>
++        <translation>ການຄວບຄຸມຍອມຮັບເຫດການ hover ຫຼືບໍ່.</translation></message>
++    <message>
++        <source>Spacing</source>
++        <translation>ຊ່ອງຫວ່າງ</translation></message>
++    <message>
++        <source>Spacing between internal elements of the control.</source>
++        <translation>ຊ່ອງຫວ່າງລະຫວ່າງອົງປະກອບພາຍໃນຂອງການຄວບຄຸມ.</translation></message>
++    <message>
++        <source>Wheel</source>
++        <translation>ກົງລໍ້</translation></message>
++    <message>
++        <source>Whether control accepts wheel evets.</source>
++        <translation>ບັນຈຸການຄວບຄຸມຍອດລໍ້ຫຼິ້ນຫຼືບໍ່.</translation></message>
++</context>
++<context>
++    <name>DelayButtonSpecifics</name>
++    <message>
++        <source>DelayButton</source>
++        <translation>ປຸ່ມຊັກຊ້າ</translation></message>
++    <message>
++        <source>Delay</source>
++        <translation>ຊັກຊ້າ</translation></message>
++    <message>
++        <source>The delay in milliseconds.</source>
++        <translation>ການລັດເຊວໃນມິນລິວິນາທີ.</translation></message>
++</context>
++<context>
++    <name>DialSpecifics</name>
++    <message>
++        <source>Dial</source>
++        <translation>ໂທ</translation></message>
++    <message>
++        <source>Value</source>
++        <translation>ມູນຄ່າ</translation></message>
++    <message>
++        <source>The current value of the dial.</source>
++        <translation>ຄ່າປັດຈຸບັນຂອງເດີຍ.</translation></message>
++    <message>
++        <source>From</source>
++        <translation>ຈາກ</translation></message>
++    <message>
++        <source>The starting value of the dial range.</source>
++        <translation>ຄ່າເລີ່ມຕົ້ນຂອງຊ່ວງເລກປັບ.</translation></message>
++    <message>
++        <source>To</source>
++        <translation>ເພື່ອ</translation></message>
++    <message>
++        <source>The ending value of the dial range.</source>
++        <translation>ຄ່າສຸດທ້າຍຂອງຂອບເຂດເລື່ອນ.</translation></message>
++    <message>
++        <source>Step Size</source>
++        <translation>ຂະໜາດຂັ້ນຕອນ</translation></message>
++    <message>
++        <source>The step size of the dial.</source>
++        <translation>ຂະໜາດຂັ້ນຂອງເດີຍ.</translation></message>
++    <message>
++        <source>Snap Mode</source>
++        <translation>ໂໝດ Snap</translation></message>
++    <message>
++        <source>The snap mode of the dial.</source>
++        <translation>ໂໝດສະແນບຂອງເດີຍ.</translation></message>
++    <message>
++        <source>Live</source>
++        <translation>ສົດ</translation></message>
++    <message>
++        <source>Whether the dial provides live value updates.</source>
++        <translation>ບໍ່ວ່າການໂທຈະສະໜອງການອັບເດດຄ່າຕົວເລກແບບສົດສະເໝີ.</translation></message>
++    <message>
++        <source>Input Mode</source>
++        <translation>ໂໝດປ້ອນຂໍ້ມູນ</translation></message>
++    <message>
++        <source>How the dial tracks movement.</source>
++        <translation>ວິທີທີ່ໝາຍເລກຕິດຕາມການເຄື່ອນໄຫວ.</translation></message>
++</context>
++<context>
++    <name>GroupBoxSpecifics</name>
++    <message>
++        <source>GroupBox</source>
++        <translation>ກຸ່ມບັອກ</translation></message>
++    <message>
++        <source>Title</source>
++        <translation>ຫົວຂໍ້</translation></message>
++    <message>
++        <source>The title of the group box.</source>
++        <translation>ຫົວຂໍ້ຂອງກຸ່ມກ່ອງ.</translation></message>
++</context>
++<context>
++    <name>ItemDelegateSection</name>
++    <message>
++        <source>ItemDelegate</source>
++        <translation>ຕົວແທນລາຍການ</translation></message>
++    <message>
++        <source>Highlighted</source>
++        <translation>ເນັ້ນໃສ່</translation></message>
++    <message>
++        <source>Whether the delegate is highlighted.</source>
++        <translation>ບໍ່ວ່າຜູ້ແທນຈະຖືກເນັ້ນໃຫ້ເຫັນ.</translation></message>
++</context>
++<context>
++    <name>LabelSpecifics</name>
++    <message>
++        <source>Text Color</source>
++        <translation>ສີຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Style Color</source>
++        <translation>ຮູບແບບສີ</translation></message>
++</context>
++<context>
++    <name>PaddingSection</name>
++    <message>
++        <source>Padding</source>
++        <translation>ການຕື່ມພື້ນທີ່</translation></message>
++    <message>
++        <source>Top</source>
++        <translation>ດ້ານເທິງ</translation></message>
++    <message>
++        <source>Padding between the content and the top edge of the control.</source>
++        <translation>ຊ່ອງຫວ່າງລະຫວ່າງເນື້ອໃນແລະຂອບເທິງຂອງຄວບຄຸມ.</translation></message>
++    <message>
++        <source>Left</source>
++        <translation>ຊ້າຍ</translation></message>
++    <message>
++        <source>Padding between the content and the left edge of the control.</source>
++        <translation>ຊ່ອງຫວ່າງລະຫວ່າງເນື້ອໃນແລະຂອບຊ້າຍຂອງຄວບຄຸມ.</translation></message>
++    <message>
++        <source>Right</source>
++        <translation>ຂວາ</translation></message>
++    <message>
++        <source>Padding between the content and the right edge of the control.</source>
++        <translation>ຊ່ອງຫວ່າງລະຫວ່າງເນື້ອຫາກັບຂອບຂວາຂອງຄວບຄຸມ.</translation></message>
++    <message>
++        <source>Bottom</source>
++        <translation>ລຸ່ມ</translation></message>
++    <message>
++        <source>Padding between the content and the bottom edge of the control.</source>
++        <translation>ຊ່ອງຫວ່າງລະຫວ່າງເນື້ອໃນແລະຂອບລຸ່ມຂອງຄວບຄຸມ.</translation></message>
++</context>
++<context>
++    <name>PageIndicatorSpecifics</name>
++    <message>
++        <source>PageIndicator</source>
++        <translation>ຕົວຊີ້ບອກໜ້າ</translation></message>
++    <message>
++        <source>Count</source>
++        <translation>ນັບ</translation></message>
++    <message>
++        <source>The number of pages.</source>
++        <translation>ຈຳນວນຫນ້າ.</translation></message>
++    <message>
++        <source>Current</source>
++        <translation>ປະຈຸບັນ</translation></message>
++    <message>
++        <source>The index of the current page.</source>
++        <translation>ດັດຊະນີຂອງໜ້າປັດຈຸບັນ.</translation></message>
++</context>
++<context>
++    <name>PageSpecifics</name>
++    <message>
++        <source>Page</source>
++        <translation>ໜ້າ</translation></message>
++    <message>
++        <source>Title</source>
++        <translation>ຫົວຂໍ້</translation></message>
++    <message>
++        <source>Title of the page.</source>
++        <translation>ຫົວຂໍ້ຂອງໜ້າ.</translation></message>
++    <message>
++        <source>Content Width</source>
++        <translation>ຄວາມກວ້າງຂອງເນື້ອຫາ</translation></message>
++    <message>
++        <source>Content height used for calculating the total implicit width.</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາທີ່ໃຊ້ໃນການຄິດໄລ່ຄວາມກວ້າງທັງໝົດທີ່ບໍ່ຊັດເຈນ.</translation></message>
++    <message>
++        <source>Content Height</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາ</translation></message>
++    <message>
++        <source>Content height used for calculating the total implicit height.</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາທີ່ໃຊ້ໃນການຄິດໄລ່ຄວາມສູງທັງໝົດທີ່ບໍ່ໄດ້ກຳນົດໄວ້.</translation></message>
++</context>
++<context>
++    <name>PaneSection</name>
++    <message>
++        <source>Pane</source>
++        <translation>ກະດານ</translation></message>
++    <message>
++        <source>Content Width</source>
++        <translation>ຄວາມກວ້າງຂອງເນື້ອຫາ</translation></message>
++    <message>
++        <source>Content height used for calculating the total implicit width.</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາທີ່ໃຊ້ໃນການຄິດໄລ່ຄວາມກວ້າງທັງໝົດທີ່ບໍ່ໄດ້ກໍານົດໄວ້.</translation></message>
++    <message>
++        <source>Content Height</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາ</translation></message>
++    <message>
++        <source>Content height used for calculating the total implicit height.</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາທີ່ໃຊ້ໃນການຄິດໄລ່ຄວາມສູງທັງໝົດທີ່ບໍ່ໄດ້ກຳນົດໄວ້.</translation></message>
++</context>
++<context>
++    <name>ProgressBarSpecifics</name>
++    <message>
++        <source>ProgressBar</source>
++        <translation>ແຖບຄວາມຄືບໜ້າ</translation></message>
++    <message>
++        <source>Indeterminate</source>
++        <translation>ບໍ່ສາມາດກຳນົດໄດ້</translation></message>
++    <message>
++        <source>Whether the progress is indeterminate.</source>
++        <translation>ຄວາມຄືບໜ້າແມ່ນບໍ່ສາມາດກຳນົດໄດ້ຫຼືບໍ່.</translation></message>
++    <message>
++        <source>Value</source>
++        <translation>ມູນຄ່າ</translation></message>
++    <message>
++        <source>The current value of the progress.</source>
++        <translation>ມູນຄ່າປະຈຸບັນຂອງຄວາມຄືບໜ້າ.</translation></message>
++    <message>
++        <source>From</source>
++        <translation>ຈາກ</translation></message>
++    <message>
++        <source>The starting value for the progress.</source>
++        <translation>ຄ່າເລີ່ມຕົ້ນສໍາລັບຄວາມຄືບໜ້າ.</translation></message>
++    <message>
++        <source>To</source>
++        <translation>ເພື່ອ</translation></message>
++    <message>
++        <source>The ending value for the progress.</source>
++        <translation>ຄ່າສິ້ນສຸດສຳລັບຄວາມຄືບໜ້າ.</translation></message>
++</context>
++<context>
++    <name>QQuickPlatformDialog</name>
++    <message>
++        <source>Dialog is an abstract base class</source>
++        <translation>ກ່ອງຂໍ້ຄວາມແມ່ນຫ້ອງຮຽນພື້ນຖານທີ່ບໍ່ມີຕົວຕົນ</translation></message>
++    <message>
++        <source>Cannot create an instance of StandardButton</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງຂອງ StandardButton ໄດ້</translation></message>
++</context>
++<context>
++    <name>QtQuickControls2ImagineStylePlugin</name>
++    <message>
++        <source>Imagine is an attached property</source>
++        <translation>Imagine ເປັນຄຸນສົມບັດທີ່ຕິດພັນ</translation></message>
++</context>
++<context>
++    <name>QtQuickControls2MaterialStylePlugin</name>
++    <message>
++        <source>Material is an attached property</source>
++        <translation>ວັດສະດຸເປັນຄຸນສົມບັດທີ່ຕິດພັນ</translation></message>
++</context>
++<context>
++    <name>QtQuickControls2UniversalStylePlugin</name>
++    <message>
++        <source>Universal is an attached property</source>
++        <translation>Universal ແມ່ນຄຸນສົມບັດທີ່ຕິດພັນ</translation></message>
++</context>
++<context>
++    <name>RangeSliderSpecifics</name>
++    <message>
++        <source>RangeSlider</source>
++        <translation>ສະໄລເດີເຄື່ອງມືຊ່ວງ</translation></message>
++    <message>
++        <source>First Value</source>
++        <translation>ຄ່າທຳອິດ</translation></message>
++    <message>
++        <source>The value of the first range slider handle.</source>
++        <translation>ຄ່າຂອງຕົວຈັບເຄື່ອງມືຊ່ວງທຳອິດ.</translation></message>
++    <message>
++        <source>Second Value</source>
++        <translation>ຄ່າທີສອງ</translation></message>
++    <message>
++        <source>The value of the second range slider handle.</source>
++        <translation>ຄ່າຂອງຕົວຈັບສະໄລເດີເປີນທີ່ສອງ.</translation></message>
++    <message>
++        <source>From</source>
++        <translation>ຈາກ</translation></message>
++    <message>
++        <source>The starting value of the range slider range.</source>
++        <translation>ຄ່າເລີ່ມຕົ້ນຂອງຊ່ວງຂອງຕົວເລື່ອນຊ່ວງ.</translation></message>
++    <message>
++        <source>To</source>
++        <translation>ເພື່ອ</translation></message>
++    <message>
++        <source>The ending value of the range slider range.</source>
++        <translation>ຄ່າສຸດທ້າຍຂອງເຄື່ອງໝາຍລະດັບເຄື່ອງໝາຍລະດັບ.</translation></message>
++    <message>
++        <source>Step Size</source>
++        <translation>ຂະໜາດຂັ້ນຕອນ</translation></message>
++    <message>
++        <source>The step size of the range slider.</source>
++        <translation>ຂະໜາດຂັ້ນຂອງເຄື່ອງມືລ່ຽວໄລຍະຫ່າງ.</translation></message>
++    <message>
++        <source>Snap Mode</source>
++        <translation>ໂໝດ Snap</translation></message>
++    <message>
++        <source>The snap mode of the range slider.</source>
++        <translation>ໂໝດສະແນບຂອງເຄື່ອງເລື່ອນໄລຍະຫ່າງ.</translation></message>
++    <message>
++        <source>Orientation</source>
++        <translation>ທິດທາງ</translation></message>
++    <message>
++        <source>The orientation of the range slider.</source>
++        <translation>ທິດທາງຂອງເຄື່ອງມືລຽນເລື່ອນຊ່ວງ.</translation></message>
++    <message>
++        <source>Live</source>
++        <translation>ສົດ</translation></message>
++    <message>
++        <source>Whether the range slider provides live value updates.</source>
++        <translation>ບໍ່ວ່າເຄື່ອງມືສະໄລເດີຊ່ວງຈະສະຫນອງການອັບເດດຄ່າຕົວເລກແບບສົດ.</translation></message>
++</context>
++<context>
++    <name>RoundButtonSpecifics</name>
++    <message>
++        <source>RoundButton</source>
++        <translation>ປຸ່ມກົມ</translation></message>
++    <message>
++        <source>Radius</source>
++        <translation>ລັດສະໝີ</translation></message>
++    <message>
++        <source>Radius of the button.</source>
++        <translation>ລັດສະໝີຂອງປຸ່ມ.</translation></message>
++</context>
++<context>
++    <name>ScrollViewSpecifics</name>
++    <message>
++        <source>ScrollView</source>
++        <translation>ScrollView</translation></message>
++    <message>
++        <source>Content Width</source>
++        <translation>ຄວາມກວ້າງຂອງເນື້ອຫາ</translation></message>
++    <message>
++        <source>Content height used for calculating the total implicit width.</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາທີ່ໃຊ້ໃນການຄິດໄລ່ຄວາມກວ້າງທັງໝົດທີ່ບໍ່ຊັດເຈນ.</translation></message>
++    <message>
++        <source>Content Height</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາ</translation></message>
++    <message>
++        <source>Content height used for calculating the total implicit height.</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາທີ່ໃຊ້ໃນການຄິດໄລ່ຄວາມສູງທັງໝົດທີ່ບໍ່ຊັດເຈນ.</translation></message>
++</context>
++<context>
++    <name>SliderSpecifics</name>
++    <message>
++        <source>Slider</source>
++        <translation>ສະໄລເດີ</translation></message>
++    <message>
++        <source>Value</source>
++        <translation>ມູນຄ່າ</translation></message>
++    <message>
++        <source>The current value of the slider.</source>
++        <translation>ຄ່າປັດຈຸບັນຂອງສະລາຍເດີ.</translation></message>
++    <message>
++        <source>From</source>
++        <translation>ຈາກ</translation></message>
++    <message>
++        <source>The starting value of the slider range.</source>
++        <translation>ຄ່າເລີ່ມຕົ້ນຂອງຊ່ວງສະໄລເດີ.</translation></message>
++    <message>
++        <source>To</source>
++        <translation>ເພື່ອ</translation></message>
++    <message>
++        <source>The ending value of the slider range.</source>
++        <translation>ຄ່າສຸດທ້າຍຂອງຊ່ວງສະໄລເດີ.</translation></message>
++    <message>
++        <source>Step Size</source>
++        <translation>ຂະໜາດຂັ້ນຕອນ</translation></message>
++    <message>
++        <source>The step size of the slider.</source>
++        <translation>ຂະໜາດຂັ້ນຂອງສະໄລເດີ.</translation></message>
++    <message>
++        <source>Snap Mode</source>
++        <translation>ໂໝດ Snap</translation></message>
++    <message>
++        <source>The snap mode of the slider.</source>
++        <translation>ໂໝດສະແນບຂອງສະລາຍເດີ.</translation></message>
++    <message>
++        <source>Orientation</source>
++        <translation>ທິດທາງ</translation></message>
++    <message>
++        <source>The orientation of the slider.</source>
++        <translation>ທິດທາງຂອງສະລາຍເດີ.</translation></message>
++    <message>
++        <source>Live</source>
++        <translation>ສົດ</translation></message>
++    <message>
++        <source>Whether the slider provides live value updates.</source>
++        <translation>ບໍ່ວ່າສະລາຍເດີຈະສະໜອງການອັບເດດຄ່າຕະຫຼອດເວລາຫຼືບໍ່.</translation></message>
++</context>
++<context>
++    <name>SpinBoxSpecifics</name>
++    <message>
++        <source>SpinBox</source>
++        <translation>SpinBox</translation></message>
++    <message>
++        <source>Value</source>
++        <translation>ມູນຄ່າ</translation></message>
++    <message>
++        <source>The current value of the spinbox.</source>
++        <translation>ຄ່າປັດຈຸບັນຂອງກ່ອງສະປິນ.</translation></message>
++    <message>
++        <source>From</source>
++        <translation>ຈາກ</translation></message>
++    <message>
++        <source>The starting value of the spinbox range.</source>
++        <translation>ຄ່າເລີ່ມຕົ້ນຂອງຊ່ວງສະປິນບັອກ.</translation></message>
++    <message>
++        <source>To</source>
++        <translation>ເພື່ອ</translation></message>
++    <message>
++        <source>The ending value of the spinbox range.</source>
++        <translation>ຄ່າສຸດທ້າຍຂອງຊ່ວງສະປິນບັອກ.</translation></message>
++    <message>
++        <source>Step Size</source>
++        <translation>ຂະໜາດຂັ້ນຕອນ</translation></message>
++    <message>
++        <source>The step size of the spinbox.</source>
++        <translation>ຂະໜາດຂັ້ນຕອນຂອງກ່ອງສະປິນ.</translation></message>
++    <message>
++        <source>Editable</source>
++        <translation>ສາມາດແກ້ໄຂໄດ້</translation></message>
++    <message>
++        <source>Whether the spinbox is editable.</source>
++        <translation>ສະພິນບັອກສາມາດແກ້ໄຂໄດ້ຫຼືບໍ່.</translation></message>
++</context>
++<context>
++    <name>SwipeViewSpecifics</name>
++    <message>
++        <source>SwipeView</source>
++        <translation>ສະໄວບມຸມມອງ</translation></message>
++    <message>
++        <source>Interactive</source>
++        <translation>ມີສ່ວນຮ່ວມ</translation></message>
++    <message>
++        <source>Whether the view is interactive.</source>
++        <translation>ບໍ່ວ່າມຸມມອງແມ່ນມີການຕິດຕໍ່ສົນທະນາຫຼືບໍ່.</translation></message>
++    <message>
++        <source>Orientation</source>
++        <translation>ທິດທາງ</translation></message>
++    <message>
++        <source>Orientation of the view.</source>
++        <translation>ທິດທາງຂອງມຸມມອງ.</translation></message>
++</context>
++<context>
++    <name>TabBarSpecifics</name>
++    <message>
++        <source>TabBar</source>
++        <translation>ແຖບແຖບ</translation></message>
++    <message>
++        <source>Position</source>
++        <translation>ຕຳແໜ່ງ</translation></message>
++    <message>
++        <source>Position of the tabbar.</source>
++        <translation>ຕຳແໜ່ງຂອງແຖບແຖບ.</translation></message>
++    <message>
++        <source>Content Width</source>
++        <translation>ຄວາມກວ້າງຂອງເນື້ອຫາ</translation></message>
++    <message>
++        <source>Content height used for calculating the total implicit width.</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາທີ່ໃຊ້ໃນການຄິດໄລ່ຄວາມກວ້າງທັງໝົດທີ່ບໍ່ຊັດເຈນ.</translation></message>
++    <message>
++        <source>Content Height</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາ</translation></message>
++    <message>
++        <source>Content height used for calculating the total implicit height.</source>
++        <translation>ຄວາມສູງຂອງເນື້ອຫາທີ່ໃຊ້ໃນການຄິດໄລ່ຄວາມສູງທັງໝົດທີ່ບໍ່ຊັດເຈນ.</translation></message>
++</context>
++<context>
++    <name>TextAreaSpecifics</name>
++    <message>
++        <source>TextArea</source>
++        <translation>ພື້ນທີ່ຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Placeholder</source>
++        <translation>ຕຳແໜ່ງວ່າງ</translation></message>
++    <message>
++        <source>Placeholder text displayed when the editor is empty.</source>
++        <translation>ຂໍ້ຄວາມຕົວຢ່າງທີ່ສະແດງເມື່ອບັນຊີລາຍຊື່ຫວ່າງເປົ່າ.</translation></message>
++</context>
++<context>
++    <name>TextFieldSpecifics</name>
++    <message>
++        <source>TextField</source>
++        <translation>ຟິວດຂໍ້ຄວາມ</translation></message>
++    <message>
++        <source>Placeholder</source>
++        <translation>ຕຳແໜ່ງວ່າງ</translation></message>
++    <message>
++        <source>Placeholder text displayed when the editor is empty.</source>
++        <translation>ຂໍ້ຄວາມຕົວຢ່າງທີ່ສະແດງເມື່ອບັນຊີລາຍຊື່ຫວ່າງເປົ່າ.</translation></message>
++</context>
++<context>
++    <name>ToolBarSpecifics</name>
++    <message>
++        <source>ToolBar</source>
++        <translation>ແຖບເຄື່ອງມື</translation></message>
++    <message>
++        <source>Position</source>
++        <translation>ຕຳແໜ່ງ</translation></message>
++    <message>
++        <source>Position of the toolbar.</source>
++        <translation>ຕຳແໜ່ງຂອງແຖບເຄື່ອງມື.</translation></message>
++</context>
++<context>
++    <name>ToolSeparatorSpecifics</name>
++    <message>
++        <source>ToolSeparator</source>
++        <translation>ເຄື່ອງມືແຍກ</translation></message>
++    <message>
++        <source>Orientation</source>
++        <translation>ທິດທາງ</translation></message>
++    <message>
++        <source>The orientation of the separator.</source>
++        <translation>ທິດທາງຂອງຕົວແຍກ.</translation></message>
++</context>
++<context>
++    <name>TumblerSpecifics</name>
++    <message>
++        <source>Tumbler</source>
++        <translation>ຖັງນ້ຳ</translation></message>
++    <message>
++        <source>Visible Count</source>
++        <translation>ຈຳນວນທີ່ເຫັນໄດ້</translation></message>
++    <message>
++        <source>The count of visible items.</source>
++        <translation>ຈຳນວນຂອງລາຍການທີ່ເຫັນໄດ້.</translation></message>
++    <message>
++        <source>Current</source>
++        <translation>ປັດຈຸບັນ</translation></message>
++    <message>
++        <source>The index of the current item.</source>
++        <translation>ດັດຊະນີຂອງລາຍການປະຈຸບັນ.</translation></message>
++    <message>
++        <source>Wrap</source>
++        <translation>ຫໍ່</translation></message>
++    <message>
++        <source>Whether the tumbler wrap.</source>
++        <translation>ບໍ່ວ່າການຫໍ່ຖ້ວຍນ້ຳ.</translation></message>
++</context>
++<context>
++    <name>Object</name>
++    <message>
++        <source>Duplicate scoped enum name</source>
++        <translation>ຊື່ຂອງ enum ທີ່ມີຂອບເຂດຊໍ້າ</translation></message>
++    <message>
++        <source>Duplicate signal name</source>
++        <translation>ຊື່ສັນຍານຊໍ້າ</translation></message>
++    <message>
++        <source>Duplicate property name</source>
++        <translation>ຊື່ຄຸນສົມບັດຊໍ້າ</translation></message>
++    <message>
++        <source>Property names cannot begin with an upper case letter</source>
++        <translation>ຊື່ຂອງຄຸນສົມບັດບໍ່ສາມາດເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນໃຫຍ່</translation></message>
++    <message>
++        <source>Duplicate default property</source>
++        <translation>ສຳເນົາ ຄຸນສົມບັດເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Duplicate alias name</source>
++        <translation>ຊື່ຊ້ອນທີ່ຊ້ອນກັນ</translation></message>
++    <message>
++        <source>Alias names cannot begin with an upper case letter</source>
++        <translation>ຊື່ຫຍໍ້ບໍ່ສາມາດເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນໃຫຍ່</translation></message>
++    <message>
++        <source>Property value set multiple times</source>
++        <translation>ຄ່າຂອງຊັບສິນຖືກຕັ້ງຄ່າຫຼາຍຄັ້ງ</translation></message>
++</context>
++<context>
++    <name>QInputMethod</name>
++    <message>
++        <source>InputMethod is an abstract class</source>
++        <translation>InputMethod ແມ່ນຫ້ອງຮຽນທີ່ບໍ່ມີຕົວຕົນ</translation></message>
++</context>
++<context>
++    <name>QQmlAbstractDelegateComponent</name>
++    <message>
++        <source>Cannot create instance of abstract class AbstractDelegateComponent.</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງຂອງຄລາດ abstract AbstractDelegateComponent ໄດ້.</translation></message>
++</context>
++<context>
++    <name>QQmlAnonymousComponentResolver</name>
++    <message>
++        <source>Component objects cannot declare new functions.</source>
++        <translation>ວັດຖຸອົງປະກອບບໍ່ສາມາດປະກາດຟັງຊັນໃໝ່ໄດ້.</translation></message>
++    <message>
++        <source>Component objects cannot declare new properties.</source>
++        <translation>ວັດຖຸອົງປະກອບບໍ່ສາມາດປະກາດຄຸນສົມບັດໃໝ່ໄດ້.</translation></message>
++    <message>
++        <source>Component objects cannot declare new signals.</source>
++        <translation>ວັດຖຸອົງປະກອບບໍ່ສາມາດປະກາດສັນຍານໃໝ່ໄດ້.</translation></message>
++    <message>
++        <source>Cannot create empty component specification</source>
++        <translation>ບໍ່ສາມາດສ້າງຂໍ້ກໍານົດອົງປະກອບທີ່ຫວ່າງເປົ່າ</translation></message>
++    <message>
++        <source>Component elements may not contain properties other than id</source>
++        <translation>ອົງປະກອບຂອງສ່ວນປະກອບອາດຈະບໍ່ມີຄຸນສົມບັດອື່ນໆນອກເໜືອຈາກ id</translation></message>
++    <message>
++        <source>Invalid component body specification</source>
++        <translation>ການກຳນົດຂໍ້ມູນສ່ວນປະກອບບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>id is not unique</source>
++        <translation>ລະຫັດບໍ່ແມ່ນເອກະລັກ</translation></message>
++    <message>
++        <source>Circular alias reference detected</source>
++        <translation>ກຳລັງກວດພົບການອ້າງອີງຊື່ຫຍໍ້ແບບວົງກົມ</translation></message>
++    <message>
++        <source>Invalid alias reference. Unable to find id "%1"</source>
++        <translation>ການອ້າງອີງຊື່ຫຍໍ້ບໍ່ຖືກຕ້ອງ. ບໍ່ສາມາດຊອກຫາ id "%1" ໄດ້</translation></message>
++    <message>
++        <source>Invalid alias target location: %1</source>
++        <translation>ສະຖານທີ່ເປົ້າໝາຍນາມສົມມຸດບໍ່ຖືກຕ້ອງ: %1</translation></message>
++</context>
++<context>
++    <name>QQmlCodeGenerator</name>
++    <message>
++        <source>Duplicate method name</source>
++        <translation>ຊື່ວິທີການຊໍ້າ</translation></message>
++    <message>
++        <source>Method names cannot begin with an upper case letter</source>
++        <translation>ຊື່ຂອງວິທີການບໍ່ສາມາດເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນພິມໃຫຍ່</translation></message>
++    <message>
++        <source>Illegal method name</source>
++        <translation>ຊື່ວິທີການທີ່ຜິດກົດໝາຍ</translation></message>
++    <message>
++        <source>Property value set multiple times</source>
++        <translation>ຄ່າຂອງຊັບສິນຖືກກຳນົດຫຼາຍຄັ້ງ</translation></message>
++    <message>
++        <source>Expected type name</source>
++        <translation>ຄາດຫວັງຊື່ປະເພດ</translation></message>
++    <message>
++        <source>Scoped enum names must begin with an upper case letter</source>
++        <translation>ຊື່ enum ທີ່ຖືກກຳນົດຂອບເຂດຕ້ອງເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນໂຕໃຫຍ່</translation></message>
++    <message>
++        <source>Enum names must begin with an upper case letter</source>
++        <translation>ຊື່ຂອງ Enum ຕ້ອງເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນພິມໃຫຍ່</translation></message>
++    <message>
++        <source>Enum value must be an integer</source>
++        <translation>ຄ່າຂອງ Enum ຕ້ອງເປັນຈຳນວນເຕັມ</translation></message>
++    <message>
++        <source>Enum value out of range</source>
++        <translation>ຄ່າຂອງ Enum ອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>Signal names cannot begin with an upper case letter</source>
++        <translation>ຊື່ສັນຍານບໍ່ສາມາດເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນໃຫຍ່</translation></message>
++    <message>
++        <source>Illegal signal name</source>
++        <translation>ຊື່ສັນຍານທີ່ຜິດກົດໝາຍ</translation></message>
++    <message>
++        <source>Illegal property name</source>
++        <translation>ຊື່ຂອງຊັບສິນທີ່ຜິດກົດໝາຍ</translation></message>
++    <message>
++        <source>Invalid component id specification</source>
++        <translation>ການກຳນົດລະຫັດອົງປະກອບບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>No property alias location</source>
++        <translation>ບໍ່ມີສະຖານທີ່ຊື່ຫຍໍ້ຂອງຊັບສິນ</translation></message>
++    <message>
++        <source>Invalid alias reference. An alias reference must be specified as &lt;id&gt;, &lt;id&gt;.&lt;property&gt; or &lt;id&gt;.&lt;value property&gt;.&lt;property&gt;</source>
++        <translation>ການອ້າງອີງຊື່ປະຫຍັດບໍ່ຖືກຕ້ອງ. ການອ້າງອີງຊື່ປະຫຍັດຕ້ອງຖືກກຳນົດເປັນ &lt;id&gt;, &lt;id&gt;.&lt;property&gt; ຫຼື &lt;id&gt;.&lt;value property&gt;.&lt;property&gt;</translation></message>
++    <message>
++        <source>Invalid alias location</source>
++        <translation>ຕຳແໜ່ງຊື່ຫຍໍ້ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid empty ID</source>
++        <translation>ລະຫັດ ID ທີ່ບໍ່ຖືກຕ້ອງ ເປົ່າຫວ່າງ</translation></message>
++    <message>
++        <source>IDs cannot start with an uppercase letter</source>
++        <translation>ລະຫັດບໍ່ສາມາດເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນໃຫຍ່</translation></message>
++    <message>
++        <source>IDs must start with a letter or underscore</source>
++        <translation>ລະຫັດຕ້ອງເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນ ຫຼື ຂີດລຸ່ມ</translation></message>
++    <message>
++        <source>IDs must contain only letters, numbers, and underscores</source>
++        <translation>ລະຫັດຕ້ອງປະກອບດ້ວຍຕົວອັກສອນ, ຕົວເລກ, ແລະຂີດກ້ອງເທົ່ານັ້ນ</translation></message>
++    <message>
++        <source>ID illegally masks global JavaScript property</source>
++        <translation>ID ຜິດກົດໝາຍໃນການປິດບັງຄຸນສົມບັດ JavaScript ທົ່ວໂລກ</translation></message>
++    <message>
++        <source>Invalid use of id property</source>
++        <translation>ການນຳໃຊ້ຄຸນສົມບັດ id ບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QQmlComponent</name>
++    <message>
++        <source>Invalid empty URL</source>
++        <translation>URL ທີ່ຫວ່າງເປົ່າບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>createObject: value is not an object</source>
++        <translation>ສ້າງວັດຖຸ: ຄ່າບໍ່ແມ່ນວັດຖຸ</translation></message>
++    <message>
++        <source>Object or context destroyed during incubation</source>
++        <translation>ວັດຖຸ ຫຼື ບໍລິບົດ ຖືກທຳລາຍໃນລະຫວ່າງການຟັກຕົວ</translation></message>
++</context>
++<context>
++    <name>QQmlConnections</name>
++    <message>
++        <source>Cannot assign to non-existent property "%1"</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າໃຫ້ກັບຄຸນສົມບັດທີ່ບໍ່ມີຢູ່ "%1"</translation></message>
++    <message>
++        <source>Connections: nested objects not allowed</source>
++        <translation>ການເຊື່ອມຕໍ່: ບໍ່ອະນຸຍາດໃຫ້ມີວັດຖຸທີ່ຊ້ອນກັນ</translation></message>
++    <message>
++        <source>Connections: syntax error</source>
++        <translation>ການເຊື່ອມຕໍ່: ຂໍ້ຜິດພາດໃນການຂຽນຄຳສັ່ງ</translation></message>
++    <message>
++        <source>Connections: script expected</source>
++        <translation>ການເຊື່ອມຕໍ່: ສະຄິບທີ່ຄາດຫວັງ</translation></message>
++</context>
++<context>
++    <name>QQmlDebugServerImpl</name>
++    <message>
++        <source>QML Debugger: Invalid argument "%1" detected. Ignoring the same.</source>
++        <translation>QML Debugger: ອາກິວເມັນບໍ່ຖືກຕ້ອງ "%1" ຖືກກວດພົບ. ກຳລັງບໍ່ສົນໃຈອາກິວເມັນນີ້.</translation></message>
++    <message>
++        <source>QML Debugger: Ignoring "-qmljsdebugger=%1".</source>
++        <translation>QML Debugger: ບໍ່ສົນໃຈ "-qmljsdebugger=%1".</translation></message>
++    <message>
++        <source>The format is "-qmljsdebugger=[file:&lt;file&gt;|port:&lt;port_from&gt;][,&lt;port_to&gt;][,host:&lt;ip address&gt;][,block][,services:&lt;service&gt;][,&lt;service&gt;]*"</source>
++        <translation>ຮູບແບບແມ່ນ "-qmljsdebugger=[file:&lt;file&gt;|port:&lt;port_from&gt;][,&lt;port_to&gt;][,host:&lt;ip address&gt;][,block][,services:&lt;service&gt;][,&lt;service&gt;]*"</translation></message>
++    <message>
++        <source>"file:" can be used to specify the name of a file the debugger will try to connect to using a QLocalSocket. If "file:" is given any "host:" and"port:" arguments will be ignored.</source>
++        <translation>"file:" ສາມາດນຳໃຊ້ເພື່ອກຳນົດຊື່ຂອງໄຟລ໌ທີ່ debugger ຈະພະຍາຍາມເຊື່ອມຕໍ່ໂດຍໃຊ້ QLocalSocket. ຖ້າ "file:" ຖືກກຳນົດ ອາກິວເມັນ "host:" ແລະ "port:" ໃດໆຈະຖືກບໍ່ສົນໃຈ.</translation></message>
++    <message>
++        <source>"host:" and "port:" can be used to specify an address and a single port or a range of ports the debugger will try to bind to with a QTcpServer.</source>
++        <translation>"host:" ແລະ "port:" ສາມາດໃຊ້ເພື່ອກຳນົດທີ່ຢູ່ ແລະ ພອດດຽວ ຫຼື ຊ່ວງຂອງພອດທີ່ debugger ຈະພະຍາຍາມຜູກມັດກັບ QTcpServer.</translation></message>
++    <message>
++        <source>"block" makes the debugger and some services wait for clients to be connected and ready before the first QML engine starts.</source>
++        <translation>"block" ເຮັດໃຫ້ debugger ແລະບໍລິການບາງຢ່າງລໍຖ້າລູກຄ້າເຊື່ອມຕໍ່ ແລະພ້ອມກ່ອນທີ່ເຄື່ອງຈັກ QML ທຳອິດຈະເລີ່ມຕົ້ນ.</translation></message>
++    <message>
++        <source>"services:" can be used to specify which debug services the debugger should load. Some debug services interact badly with others. The V4 debugger should not be loaded when using the QML profiler as it will force any V4 engines to use the JavaScript interpreter rather than the JIT. The following debug services are available by default:</source>
++        <translation>"ບໍລິການ:" ສາມາດນຳໃຊ້ເພື່ອກຳນົດວ່າບໍລິການ debug ໃດທີ່ debugger ຄວນຈະໂຫຼດ. ບາງບໍລິການ debug ມີປະຕິກິລິຍາທີ່ບໍ່ດີກັບບໍລິການອື່ນໆ. Debugger V4 ບໍ່ຄວນຖືກໂຫຼດເມື່ອໃຊ້ QML profiler ເພາະວ່າມັນຈະບັງຄັບໃຫ້ engine V4 ໃດໆໃຊ້ interpreter JavaScript ແທນທີ່ຈະໃຊ້ JIT. ບໍລິການ debug ຕໍ່ໄປນີ້ມີຢູ່ໂດຍຄ່າເລີ່ມຕົ້ນ:</translation></message>
++    <message>
++        <source>The QML debugger</source>
++        <translation>ຕົວດີບັກ QML</translation></message>
++    <message>
++        <source>The V4 debugger</source>
++        <translation>ຕົວດີບັກ V4</translation></message>
++    <message>
++        <source>The QML inspector</source>
++        <translation>ຜູ້ກວດສອບ QML</translation></message>
++    <message>
++        <source>The QML profiler</source>
++        <translation>ຜູ້ວິເຄາະ QML</translation></message>
++    <message>
++        <source>Allows the client to delay the starting and stopping of
++		  QML engines until other services are ready. QtCreator
++		  uses this service with the QML profiler in order to
++		  profile multiple QML engines at the same time.</source>
++        <translation>ອະນຸຍາດໃຫ້ລູກຄ້າຊັກຊ້າການເລີ່ມຕົ້ນ ແລະ ຢຸດ QML engines ຈົນກະທັ່ງບໍລິການອື່ນໆພ້ອມ. QtCreator
++		  ໃຊ້ບໍລິການນີ້ກັບ QML profiler ເພື່ອຈັດສະແດງຂໍ້ມູນຫຼາຍ QML engines ໃນເວລາດຽວກັນ.</translation></message>
++    <message>
++        <source>Sends qDebug() and similar messages over the QML debug
++		  connection. QtCreator uses this for showing debug
++		  messages in the debugger console.</source>
++        <translation>ສົ່ງຂໍ້ຄວາມ qDebug() ແລະຂໍ້ຄວາມທີ່ຄ້າຍຄືກັນຜ່ານການເຊື່ອມຕໍ່ debug QML. QtCreator ໃຊ້ສິ່ງນີ້ເພື່ອສະແດງຂໍ້ຄວາມ debug ໃນ console ຂອງ debugger.</translation></message>
++    <message>
++        <source>Other services offered by qmltooling plugins that implement QQmlDebugServiceFactory and which can be found in the standard plugin paths will also be available and can be specified. If no "services" argument is given, all services found this way, including the default ones, are loaded.</source>
++        <translation>ບໍລິການອື່ນໆທີ່ສະເໜີໂດຍປັກອິນ qmltooling ທີ່ຈັດຕັ້ງປະຕິບັດ QQmlDebugServiceFactory ແລະທີ່ສາມາດພົບເຫັນໃນເສັ້ນທາງປັກອິນມາດຕະຖານກໍ່ຈະມີຢູ່ ແລະສາມາດກຳນົດໄດ້. ຖ້າບໍ່ມີອາກິວເມັນ "services" ໃຫ້, ບໍລິການທັງໝົດທີ່ພົບເຫັນດ້ວຍວິທີນີ້, ລວມທັງບໍລິການເລີ່ມຕົ້ນ, ຈະຖືກໂຫຼດ.</translation></message>
++</context>
++<context>
++    <name>QQmlDelegateModel</name>
++    <message>
++        <source>The delegate of a DelegateModel cannot be changed within onUpdated.</source>
++        <translation>ຜູ້ຕາງຫນ້າຂອງ DelegateModel ບໍ່ສາມາດປ່ຽນແປງໄດ້ພາຍໃນ onUpdated.</translation></message>
++    <message>
++        <source>The maximum number of supported DelegateModelGroups is 8</source>
++        <translation>ຈຳນວນສູງສຸດທີ່ສະໜັບສະໜູນຂອງ DelegateModelGroups ແມ່ນ 8</translation></message>
++    <message>
++        <source>The group of a DelegateModel cannot be changed within onChanged</source>
++        <translation>ກຸ່ມຂອງ DelegateModel ບໍ່ສາມາດປ່ຽນແປງໄດ້ພາຍໃນ onChanged</translation></message>
++    <message>
++        <source>The delegates of a DelegateModel cannot be changed within onUpdated.</source>
++        <translation>ຜູ້ແທນຂອງ DelegateModel ບໍ່ສາມາດປ່ຽນແປງໄດ້ພາຍໃນ onUpdated.</translation></message>
++</context>
++<context>
++    <name>QQmlDelegateModelGroup</name>
++    <message>
++        <source>Group names must start with a lower case letter</source>
++        <translation>ຊື່ກຸ່ມຕ້ອງເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນພິມນ້ອຍ</translation></message>
++    <message>
++        <source>get: index out of range</source>
++        <translation>ໄດ້ຮັບ: ດັດຊະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>insert: index out of range</source>
++        <translation>ໃສ່: ດັດສະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>create: index out of range</source>
++        <translation>ສ້າງ: ດັດສະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>resolve: from index out of range</source>
++        <translation>ແກ້ໄຂ: ຈາກດັດຊະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>resolve: from index invalid</source>
++        <translation>ແກ້ໄຂ: ຈາກດັດຊະນີບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>resolve: to index out of range</source>
++        <translation>ແກ້ໄຂ: ເຖິງດັດສະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>resolve: to index invalid</source>
++        <translation>ແກ້ໄຂ: ເພື່ອດັດສະນີບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>resolve: from is not an unresolved item</source>
++        <translation>ແກ້ໄຂ: ຈາກ ບໍ່ແມ່ນລາຍການທີ່ຍັງບໍ່ໄດ້ແກ້ໄຂ</translation></message>
++    <message>
++        <source>resolve: to is not a model item</source>
++        <translation>ແກ້ໄຂ: ບໍ່ແມ່ນລາຍການແບບຈຳລອງ</translation></message>
++    <message>
++        <source>remove: invalid index</source>
++        <translation>ລຶບ: ດັດຊະນີບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>remove: index out of range</source>
++        <translation>ລຶບ: ດັດສະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>remove: invalid count</source>
++        <translation>ລຶບ: ຈຳນວນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>addGroups: index out of range</source>
++        <translation>ເພີ່ມກຸ່ມ: ດັດຊະນີອອກໄປນອກໄລຍະ</translation></message>
++    <message>
++        <source>addGroups: invalid count</source>
++        <translation>ເພີ່ມກຸ່ມ: ຈຳນວນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>removeGroups: index out of range</source>
++        <translation>removeGroups: ດັດຊະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>removeGroups: invalid count</source>
++        <translation>removeGroups: ຈຳນວນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>setGroups: index out of range</source>
++        <translation>setGroups: ດັດສະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>setGroups: invalid count</source>
++        <translation>ກຳນົດກຸ່ມ: ຈຳນວນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>move: invalid from index</source>
++        <translation>ຍ້າຍ: ດັດຊະນີຕົ້ນຕໍບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>move: invalid to index</source>
++        <translation>ຍ້າຍ: ບໍ່ຖືກຕ້ອງກັບດັດສະນີ</translation></message>
++    <message>
++        <source>move: invalid count</source>
++        <translation>ຍ້າຍ: ຈຳນວນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>move: from index out of range</source>
++        <translation>ຍ້າຍ: ຈາກດັດສະນີອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>move: to index out of range</source>
++        <translation>ຍ້າຍ: ໄປທີ່ດັດສະນີນອກເຂດ</translation></message>
++</context>
++<context>
++    <name>QQmlEngine</name>
++    <message>
++        <source>Locale cannot be instantiated.  Use Qt.locale()</source>
++        <translation>ພາສາບໍ່ສາມາດສ້າງຕົວຕົວຢ່າງໄດ້.  ໃຊ້ Qt.locale()</translation></message>
++    <message>
++        <source>There are still "%1" items in the process of being created at engine destruction.</source>
++        <translation>ຍັງມີ "%1" ລາຍການທີ່ກຳລັງຖືກສ້າງຢູ່ໃນຂະບວນການທຳລາຍເຄື່ອງຈັກ.</translation></message>
++    <message>
++        <source>executeSql called outside transaction()</source>
++        <translation>executeSql ຖືກເອີ້ນໃຊ້ນອກຈາກ transaction()</translation></message>
++    <message>
++        <source>Read-only Transaction</source>
++        <translation>ການເຮັດທຸລະກຳອ່ານເທົ່ານັ້ນ</translation></message>
++    <message>
++        <source>Version mismatch: expected %1, found %2</source>
++        <translation>ບໍ່ກົງກັນຂອງເວີຊັນ: ຄາດຫວັງ %1, ພົບ %2</translation></message>
++    <message>
++        <source>SQL transaction failed</source>
++        <translation>ການເຮັດທຸລະກຳ SQL ລົ້ມເຫຼວ</translation></message>
++    <message>
++        <source>transaction: missing callback</source>
++        <translation>ທຸລະກຳ: ການຮຽກກັບຄືນບໍ່ມີ</translation></message>
++    <message>
++        <source>SQL: can't create database, offline storage is disabled.</source>
++        <translation>SQL: ບໍ່ສາມາດສ້າງຖານຂໍ້ມູນ, ການເກັບຮັກສາແບບອອຟລາຍຖືກປິດໃຊ້ງານ.</translation></message>
++    <message>
++        <source>LocalStorage: can't create path %1</source>
++        <translation>LocalStorage: ບໍ່ສາມາດສ້າງເສັ້ນທາງ %1</translation></message>
++    <message>
++        <source>SQL: database version mismatch</source>
++        <translation>SQL: ຄວາມບໍ່ກົງກັນຂອງລຸ້ນຖານຂໍ້ມູນ</translation></message>
++</context>
++<context>
++    <name>QQmlEnumTypeResolver</name>
++    <message>
++        <source>Invalid property assignment: Enum value "%1" cannot start with a lowercase letter</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄ່າ Enum "%1" ບໍ່ສາມາດເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນພິມນ້ອຍ</translation></message>
++    <message>
++        <source>Invalid property assignment: "%1" is a read-only property</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: "%1" ແມ່ນຄຸນສົມບັດທີ່ອ່ານໄດ້ຢ່າງດຽວ</translation></message>
++</context>
++<context>
++    <name>QQmlImportDatabase</name>
++    <message>
++        <source>"%1" is ambiguous. Found in %2 and in %3</source>
++        <translation>"%1" ບໍ່ຊັດເຈນ. ພົບເຫັນໃນ %2 ແລະໃນ %3</translation></message>
++    <message>
++        <source>- %1 is not a namespace</source>
++        <translation>- %1 ບໍ່ແມ່ນ namespace</translation></message>
++    <message>
++        <source>- nested namespaces not allowed</source>
++        <translation>- ບໍ່ອະນຸຍາດໃຫ້ມີຊື່ເຂດທີ່ຊ້ອນກັນ</translation></message>
++    <message>
++        <source>local directory</source>
++        <translation>ໂຟນເດີທ້ອງຖິ່ນ</translation></message>
++    <message>
++        <source>is ambiguous. Found in %1 and in %2</source>
++        <translation>ມີຄວາມບໍ່ຊັດເຈນ. ພົບເຫັນໃນ %1 ແລະໃນ %2</translation></message>
++    <message>
++        <source>is ambiguous. Found in %1 in version %2.%3 and %4.%5</source>
++        <translation>ບໍ່ຊັດເຈນ. ພົບໃນ %1 ໃນເວີຊັນ %2.%3 ແລະ %4.%5</translation></message>
++    <message>
++        <source>is instantiated recursively</source>
++        <translation>ຖືກສ້າງຕັ້ງຂຶ້ນຢ່າງຊ້ອນຊ້ອນ</translation></message>
++    <message>
++        <source>is not a type</source>
++        <translation>ບໍ່ແມ່ນປະເພດ</translation></message>
++    <message>
++        <source>static plugin for module "%1" with name "%2" has no metadata URI</source>
++        <translation>static plugin ສຳລັບ module "%1" ທີ່ມີຊື່ "%2" ບໍ່ມີ metadata URI</translation></message>
++    <message>
++        <source>plugin cannot be loaded for module "%1": %2</source>
++        <translation>plugin ບໍ່ສາມາດໂຫຼດໄດ້ສໍາລັບ module "%1": %2</translation></message>
++    <message>
++        <source>module does not support the designer "%1"</source>
++        <translation>ໂມດູນບໍ່ສະໜັບສະໜູນຜູ້ອອກແບບ "%1"</translation></message>
++    <message>
++        <source>static plugin for module "%1" with name "%2" cannot be loaded: %3</source>
++        <translation>static plugin ສຳລັບ module "%1" ທີ່ມີຊື່ "%2" ບໍ່ສາມາດໂຫຼດໄດ້: %3</translation></message>
++    <message>
++        <source>could not resolve all plugins for module "%1"</source>
++        <translation>ບໍ່ສາມາດແກ້ໄຂປັກອິນທັງໝົດສຳລັບໂມດູນ "%1"</translation></message>
++    <message>
++        <source>module "%1" plugin "%2" not found</source>
++        <translation>ໂມດູນ "%1" ປລັກອິນ "%2" ບໍ່ພົບ</translation></message>
++    <message>
++        <source>"%1" version %2.%3 is defined more than once in module "%4"</source>
++        <translation>%1" ລູ້ນ %2.%3 ຖືກກຳນົດຫຼາຍກວ່າຫນຶ່ງຄັ້ງໃນໂມດູນ "%4</translation></message>
++    <message>
++        <source>module "%1" version %2.%3 is not installed</source>
++        <translation>ໂມດູນ "%1" ລຸ້ນ %2.%3 ບໍ່ໄດ້ຕິດຕັ້ງ</translation></message>
++    <message>
++        <source>module "%1" is not installed</source>
++        <translation>ໂມດູນ "%1" ບໍ່ໄດ້ຕິດຕັ້ງ</translation></message>
++    <message>
++        <source>"%1": no such directory</source>
++        <translation>"%1": ບໍ່ມີໄດເລັກທໍຣີນີ້</translation></message>
++    <message>
++        <source>import "%1" has no qmldir and no namespace</source>
++        <translation>ນຳເຂົ້າ "%1" ບໍ່ມີ qmldir ແລະ ບໍ່ມີ namespace</translation></message>
++    <message>
++        <source>Module loaded for URI '%1' does not implement QQmlTypesExtensionInterface</source>
++        <translation>ໂມດູນທີ່ໂຫຼດສຳລັບ URI '%1' ບໍ່ໄດ້ຈັດຕັ້ງຕົວ QQmlTypesExtensionInterface</translation></message>
++    <message>
++        <source>Module namespace '%1' does not match import URI '%2'</source>
++        <translation>ຊື່ເຂດຂອງໂມດູນ '%1' ບໍ່ກົງກັບ URI ນຳເຂົ້າ '%2'</translation></message>
++    <message>
++        <source>Namespace '%1' has already been used for type registration</source>
++        <translation>ຊ່ອງຊື່ '%1' ໄດ້ຖືກນຳໃຊ້ແລ້ວສຳລັບການລົງທະບຽນປະເພດ</translation></message>
++    <message>
++        <source>Module '%1' does not contain a module identifier directive - it cannot be protected from external registrations.</source>
++        <translation>ໂມດູນ '%1' ບໍ່ມີຄຳສັ່ງກຳນົດຕົວຊີ້ບອກໂມດູນ - ມັນບໍ່ສາມາດປົກປ້ອງຈາກການລົງທະບຽນພາຍນອກໄດ້.</translation></message>
++    <message>
++        <source>File name case mismatch for "%1"</source>
++        <translation>ຊື່ໄຟລ໌ບໍ່ກົງກັນກັບຕົວພິມໃຫຍ່-ນ້ອຍສໍາລັບ "%1"</translation></message>
++</context>
++<context>
++    <name>QQmlListModel</name>
++    <message>
++        <source>unable to enable dynamic roles as this model is not empty</source>
++        <translation>ບໍ່ສາມາດເປີດໃຊ້ບົດບາດທີ່ປ່ຽນແປງໄດ້ ເພາະວ່າຮູບແບບນີ້ບໍ່ເປັນຄ່າວ່າງ</translation></message>
++    <message>
++        <source>unable to enable static roles as this model is not empty</source>
++        <translation>ບໍ່ສາມາດເປີດໃຊ້ບົດບາດຄົງທີ່ໄດ້ ເພາະວ່າຮູບແບບນີ້ບໍ່ເປັນວ່າງ</translation></message>
++    <message>
++        <source>dynamic role setting must be made from the main thread, before any worker scripts are created</source>
++        <translation>ການຕັ້ງຄ່າບົດບາດແບບເຄື່ອນໄຫວຕ້ອງເຮັດຈາກຫົວຂໍ້ຫຼັກ, ກ່ອນທີ່ຈະສ້າງສະຄຣິບຂອງຜູ້ອອກແຮງງານໃດໆ</translation></message>
++    <message>
++        <source>remove: indices [%1 - %2] out of range [0 - %3]</source>
++        <translation>ລຶບ: ດັດຊະນີ [%1 - %2] ອອກຈາກຂອບເຂດ [0 - %3]</translation></message>
++    <message>
++        <source>remove: incorrect number of arguments</source>
++        <translation>ລຶບ: ຈຳນວນອາກິວເມັນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>insert: index %1 out of range</source>
++        <translation>ໃສ່: ດັດສະນີ %1 ອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>insert: value is not an object</source>
++        <translation>ໃສ່: ຄ່າບໍ່ແມ່ນວັດຖຸ</translation></message>
++    <message>
++        <source>move: out of range</source>
++        <translation>ຍ້າຍ: ອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>append: value is not an object</source>
++        <translation>ຕື່ມ: ຄ່າບໍ່ແມ່ນວັດຖຸ</translation></message>
++    <message>
++        <source>set: value is not an object</source>
++        <translation>ຕັ້ງຄ່າ: ຄ່າບໍ່ແມ່ນວັດຖຸ</translation></message>
++    <message>
++        <source>set: index %1 out of range</source>
++        <translation>ຕັ້ງຄ່າ: ດັດສະນີ %1 ອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>ListElement: cannot contain nested elements</source>
++        <translation>ListElement: ບໍ່ສາມາດປະກອບດ້ວຍອົງປະກອບທີ່ຊ້ອນກັນໄດ້</translation></message>
++    <message>
++        <source>ListElement: cannot use reserved "id" property</source>
++        <translation>ListElement: ບໍ່ສາມາດໃຊ້ຄຸນສົມບັດ "id" ທີ່ຈັດໄວ້</translation></message>
++    <message>
++        <source>ListElement: cannot use script for property value</source>
++        <translation>ListElement: ບໍ່ສາມາດໃຊ້ສະຄຣິບຕໍ່ຄ່າຂອງຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>ListModel: undefined property '%1'</source>
++        <translation>ListModel: ຄຸນສົມບັດ '%1' ບໍ່ຖືກກຳນົດ</translation></message>
++</context>
++<context>
++    <name>QQmlObjectCreator</name>
++    <message>
++        <source>Cannot assign value %1 to property %2</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າ %1 ໃຫ້ກັບຄຸນສົມບັດ %2</translation></message>
++    <message>
++        <source>Cannot set properties on %1 as it is null</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າຄຸນສົມບັດໃສ່ %1 ເພາະວ່າມັນເປັນ null</translation></message>
++    <message>
++        <source>Cannot assign an object to signal property %1</source>
++        <translation>ບໍ່ສາມາດກຳນົດວັດຖຸໃຫ້ກັບຄຸນສົມບັດສັນຍານ %1</translation></message>
++    <message>
++        <source>Cannot assign object type %1 with no default method</source>
++        <translation>ບໍ່ສາມາດກຳນົດປະເພດວັດຖຸ %1 ໂດຍບໍ່ມີວິທີເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Cannot connect mismatched signal/slot %1 %vs. %2</source>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ສັນຍານ/ຊ່ອງທີ່ບໍ່ກົງກັນ %1 %vs. %2</translation></message>
++    <message>
++        <source>Cannot assign object to interface property</source>
++        <translation>ບໍ່ສາມາດກຳນົດວັດຖຸໃຫ້ກັບຄຸນສົມບັດອິນເຕີເຟດໄດ້</translation></message>
++    <message>
++        <source>Cannot assign object to read only list</source>
++        <translation>ບໍ່ສາມາດກຳນົດວັດຖຸໃຫ້ກັບລາຍຊື່ທີ່ອ່ານໄດ້ຢ່າງດຽວ</translation></message>
++    <message>
++        <source>Cannot assign primitives to lists</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າພື້ນຖານໃຫ້ກັບລາຍການໄດ້</translation></message>
++    <message>
++        <source>Unable to create object of type %1</source>
++        <translation>ບໍ່ສາມາດສ້າງວັດຖຸປະເພດ %1 ໄດ້</translation></message>
++    <message>
++        <source>Composite Singleton Type %1 is not creatable</source>
++        <translation>ປະເພດ Composite Singleton %1 ບໍ່ສາມາດສ້າງໄດ້</translation></message>
++</context>
++<context>
++    <name>QQmlObjectModel</name>
++    <message>
++        <source>insert: index %1 out of range</source>
++        <translation>ໃສ່: ດັດສະນີ %1 ອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>move: out of range</source>
++        <translation>ຍ້າຍ: ອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>remove: indices [%1 - %2] out of range [0 - %3]</source>
++        <translation>ລຶບ: ດັດຊະນີ [%1 - %2] ອອກຈາກຂອບເຂດ [0 - %3]</translation></message>
++</context>
++<context>
++    <name>QQmlParser</name>
++    <message>
++        <source>Unexpected object definition</source>
++        <translation>ຄຳນິຍາມວັດຖຸທີ່ບໍ່ຄາດຄິດ</translation></message>
++    <message>
++        <source>Invalid import qualifier ID</source>
++        <translation>ລະຫັດຄຸນນະພາບການນຳເຂົ້າບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Reserved name "Qt" cannot be used as an qualifier</source>
++        <translation>ຊື່ທີ່ຈະເປັນສະຫງວນ "Qt" ບໍ່ສາມາດນຳໃຊ້ເປັນຄຳກຳນົດໄດ້</translation></message>
++    <message>
++        <source>Script import qualifiers must be unique.</source>
++        <translation>ຄຸນສົມບັດການນຳເຂົ້າສະຄຣິບຕ້ອງເປັນເອກະລັກ.</translation></message>
++    <message>
++        <source>Script import requires a qualifier</source>
++        <translation>ການນຳເຂົ້າສະຄຣິບຕ້ອງການຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>Library import requires a version</source>
++        <translation>ການນຳເຂົ້າຫໍສະໝຸດຕ້ອງການລຸ້ນ</translation></message>
++    <message>
++        <source>Pragma requires a valid qualifier</source>
++        <translation>Pragma ຕ້ອງການ qualifier ທີ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Expected parameter type</source>
++        <translation>ປະເພດພາລາມິເຕີທີ່ຄາດຫວັງ</translation></message>
++    <message>
++        <source>Invalid signal parameter type: </source>
++        <translation>ປະເພດພາຣາມີເຕີສັນຍານບໍ່ຖືກຕ້ອງ:</translation></message>
++    <message>
++        <source>Invalid property type modifier</source>
++        <translation>ປະເພດຕົວແກ້ໄຂຄຸນສົມບັດບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Unexpected property type modifier</source>
++        <translation>ປະເພດປັບແຕ່ງຄຸນສົມບັດທີ່ບໍ່ຄາດຄິດ</translation></message>
++    <message>
++        <source>Expected property type</source>
++        <translation>ຄາດຫວັງປະເພດຊັບສິນ</translation></message>
++    <message>
++        <source>JavaScript declaration outside Script element</source>
++        <translation>ການປະກາດ JavaScript ນອກຈາກອົງປະກອບ Script</translation></message>
++    <message>
++        <source>Illegal unicode escape sequence</source>
++        <translation>ລຳດັບການຫນີຈາກລະຫັດຢູນິໂຄດທີ່ຜິດກົດໝາຍ</translation></message>
++    <message>
++        <source>Unexpected token '.'</source>
++        <translation>ສັນຍານທີ່ບໍ່ຄາດຄິດ '.'</translation></message>
++    <message>
++        <source>Stray newline in string literal</source>
++        <translation>ບັນທຶກຂໍ້ຄວາມທີ່ມີບັນທຶກໃໝ່ທີ່ບໍ່ຖືກຕ້ອງໃນສະຕຣິງ</translation></message>
++    <message>
++        <source>End of file reached at escape sequence</source>
++        <translation>ສິ້ນສຸດໄຟລ໌ທີ່ບັນຈຸລະຫັດຫນີ</translation></message>
++    <message>
++        <source>Illegal hexadecimal escape sequence</source>
++        <translation>ລຳດັບການຫນີພິກສິດທິມະຫາສາດທີ່ຜິດກົດໝາຍ</translation></message>
++    <message>
++        <source>Octal escape sequences are not allowed</source>
++        <translation>ລຳດັບການຫນີ octal ບໍ່ອະນຸຍາດ</translation></message>
++    <message>
++        <source>Unclosed string at end of line</source>
++        <translation>ບໍ່ມີສະຕຣິງປິດທີ່ສຸດຂອງແຖວ</translation></message>
++    <message>
++        <source>At least one hexadecimal digit is required after '0%1'</source>
++        <translation>ຢ່າງໜ້ອຍຕ້ອງມີຕົວເລກຮັກຊາເດຊິມັນຢ່າງໜ້ອຍໜຶ່ງຕົວຫຼັງຈາກ '0%1'</translation></message>
++    <message>
++        <source>At least one octal digit is required after '0%1'</source>
++        <translation>ຢ່າງໜ້ອຍຫນຶ່ງຕົວເລກໂອກຕານຖືກຕ້ອງຫຼັງຈາກ '0%1'</translation></message>
++    <message>
++        <source>At least one binary digit is required after '0%1'</source>
++        <translation>ຢ່າງໜ້ອຍຕ້ອງມີຕົວເລກຖານສອງຢ່າງໜ້ອຍຫນຶ່ງຫຼັງຈາກ '0%1'</translation></message>
++    <message>
++        <source>Decimal numbers can't start with '0'</source>
++        <translation>ຕົວເລກທົດສະນິຍົມບໍ່ສາມາດເລີ່ມຕົ້ນດ້ວຍ '0'</translation></message>
++    <message>
++        <source>Illegal syntax for exponential number</source>
++        <translation>ການຂຽນໂຄດທີ່ບໍ່ຖືກຕ້ອງສໍາລັບຕົວເລກຊັກກໍາ</translation></message>
++    <message>
++        <source>Invalid regular expression flag '%0'</source>
++        <translation>ສະແດງອອກປົກກະຕິບໍ່ຖືກຕ້ອງ '%0'</translation></message>
++    <message>
++        <source>Unterminated regular expression backslash sequence</source>
++        <translation>ລຳດັບກັບຄືນຂອງການສະແດງອອກປົກກະຕິທີ່ບໍ່ສຳເລັດ</translation></message>
++    <message>
++        <source>Unterminated regular expression class</source>
++        <translation>ກຸ່ມການສະແດງອອກປົກກະຕິທີ່ບໍ່ສິ້ນສຸດ</translation></message>
++    <message>
++        <source>Unterminated regular expression literal</source>
++        <translation>ການສະແດງອອກປົກກະຕິທີ່ບໍ່ສິ້ນສຸດ</translation></message>
++    <message>
++        <source>Syntax error</source>
++        <translation>ຂໍ້ຜິດພາດໃນການຂຽນລະຫັດ</translation></message>
++    <message>
++        <source>Imported file must be a script</source>
++        <translation>ໄຟລ໌ນຳເຂົ້າຕ້ອງເປັນສະຄຣິບ</translation></message>
++    <message>
++        <source>Invalid module URI</source>
++        <translation>URI ໂມດູນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Module import requires a version</source>
++        <translation>ການນຳເຂົ້າໂມດູນຕ້ອງການລຸ້ນ</translation></message>
++    <message>
++        <source>File import requires a qualifier</source>
++        <translation>ການນຳເຂົ້າໄຟລ໌ຕ້ອງການຄວາມສາມາດ</translation></message>
++    <message>
++        <source>Module import requires a qualifier</source>
++        <translation>ການນຳເຂົ້າໂມດູນຕ້ອງການຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>Invalid import qualifier</source>
++        <translation>ຄຸນສົມບັດນຳເຂົ້າທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QQmlPartsModel</name>
++    <message>
++        <source>The group of a DelegateModel cannot be changed within onChanged</source>
++        <translation>ກຸ່ມຂອງ DelegateModel ບໍ່ສາມາດປ່ຽນແປງໄດ້ພາຍໃນ onChanged</translation></message>
++    <message>
++        <source>Delegate component must be Package type.</source>
++        <translation>ອົງປະກອບຜູ້ມອບສິດຕ້ອງເປັນປະເພດແພັກເກດ.</translation></message>
++</context>
++<context>
++    <name>QQmlPropertyCacheCreatorBase</name>
++    <message>
++        <source>Fully dynamic types cannot declare new properties.</source>
++        <translation>ປະເພດທີ່ເຄື່ອນໄຫວຢ່າງເຕັມທີ່ບໍ່ສາມາດປະກາດຄຸນສົມບັດໃໝ່ໄດ້.</translation></message>
++    <message>
++        <source>Fully dynamic types cannot declare new signals.</source>
++        <translation>ປະເພດແບບເຄື່ອນໄຫວທັງໝົດບໍ່ສາມາດປະກາດສັນຍານໃໝ່ໄດ້.</translation></message>
++    <message>
++        <source>Fully Dynamic types cannot declare new functions.</source>
++        <translation>ປະເພດທີ່ເປັນໄດນາມິກທັງໝົດບໍ່ສາມາດປະກາດຟັງຊັນໃໝ່ໄດ້.</translation></message>
++    <message>
++        <source>Non-existent attached object</source>
++        <translation>ວັດຖຸທີ່ຕິດພັນທີ່ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>Cannot override FINAL property</source>
++        <translation>ບໍ່ສາມາດທົດແທນຄຸນສົມບັດ FINAL ໄດ້</translation></message>
++    <message>
++        <source>Invalid signal parameter type: %1</source>
++        <translation>ປະເພດພາຣາມີເຕີສັນຍານບໍ່ຖືກຕ້ອງ: %1</translation></message>
++    <message>
++        <source>Duplicate signal name: invalid override of property change signal or superclass signal</source>
++        <translation>ຊື່ສັນຍານຊ້ຳກັນ: ການທົດແທນສັນຍານການປ່ຽນແປງຄຸນສົມບັດຫຼືສັນຍານຂອງຊັ້ນເທິງທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Duplicate method name: invalid override of property change signal or superclass signal</source>
++        <translation>ຊື່ວິທີທີ່ຊ້ຳກັນ: ການທົດແທນສັນຍານການປ່ຽນແປງຄຸນສົມບັດຫຼືສັນຍານຂອງຊັ້ນເທິງທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid property type</source>
++        <translation>ປະເພດຂອງຄຸນສົມບັດບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Cyclic alias</source>
++        <translation>ຊື່ຫຍໍ້ວົງຈອນ</translation></message>
++    <message>
++        <source>Invalid alias target</source>
++        <translation>ເປົ້າໝາຍຊື່ຫຍໍ້ບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QQmlPropertyValidator</name>
++    <message>
++        <source>Property assignment expected</source>
++        <translation>ຄາດຫວັງວ່າຈະມີການກຳນົດຄຸນສົມບັດ</translation></message>
++    <message>
++        <source>"%1.%2" is not available in %3 %4.%5.</source>
++        <translation>"%1.%2" ບໍ່ມີໃນ %3 %4.%5.</translation></message>
++    <message>
++        <source>"%1.%2" is not available due to component versioning.</source>
++        <translation>"%1.%2" ບໍ່ມີພ້ອມໃຫ້ໃຊ້ເນື່ອງຈາກການຈັດລະບຽບເວີຊັນຂອງອົງປະກອບ.</translation></message>
++    <message>
++        <source>Cannot assign a value directly to a grouped property</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າໂດຍກົງໃຫ້ກັບຄຸນສົມບັດທີ່ຖືກຈັດກຸ່ມ</translation></message>
++    <message>
++        <source>Invalid use of namespace</source>
++        <translation>ການນຳໃຊ້ namespace ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid attached object assignment</source>
++        <translation>ການກຳນົດວັດຖຸທີ່ຕິດພັນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Attached properties cannot be used here</source>
++        <translation>ຄຸນສົມບັດທີ່ຕິດຕັ້ງບໍ່ສາມາດໃຊ້ໄດ້ທີ່ນີ້</translation></message>
++    <message>
++        <source>Invalid property assignment: "%1" is a read-only property</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: "%1" ແມ່ນຄຸນສົມບັດທີ່ອ່ານໄດ້ຢ່າງດຽວ</translation></message>
++    <message>
++        <source>Cannot assign multiple values to a script property</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າຫຼາຍຄ່າໃຫ້ກັບຄຸນສົມບັດສະຄຣິບໄດ້</translation></message>
++    <message>
++        <source>Cannot assign multiple values to a singular property</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າຫຼາຍຄ່າໃຫ້ກັບຄຸນສົມບັດດຽວໄດ້</translation></message>
++    <message>
++        <source>Property has already been assigned a value</source>
++        <translation>ຄຸນສົມບັດໄດ້ຖືກກຳນົດຄ່າແລ້ວ</translation></message>
++    <message>
++        <source>Invalid grouped property access</source>
++        <translation>ການເຂົ້າເຖິງຄຸນສົມບັດທີ່ຈັດກຸ່ມບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Invalid grouped property access: Property "%1" with primitive type "%2".</source>
++        <translation>ການເຂົ້າເຖິງຄຸນສົມບັດທີ່ຈັດກຸ່ມບໍ່ຖືກຕ້ອງ: ຄຸນສົມບັດ "%1" ທີ່ມີປະເພດຂໍ້ມູນພື້ນຖານ "%2".</translation></message>
++    <message>
++        <source>Invalid grouped property access: Property "%1" with type "%2", which is not a value type</source>
++        <translation>ການເຂົ້າເຖິງຊັບສິນທີ່ຈັດກຸ່ມບໍ່ຖືກຕ້ອງ: ຊັບສິນ "%1" ທີ່ມີປະເພດ "%2", ເຊິ່ງບໍ່ແມ່ນປະເພດຄ່າ</translation></message>
++    <message>
++        <source>Cannot assign to non-existent default property</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າໃຫ້ກັບຄຸນສົມບັດເລີ່ມຕົ້ນທີ່ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>Cannot assign to non-existent property "%1"</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າໃຫ້ກັບຄຸນສົມບັດທີ່ບໍ່ມີຢູ່ "%1"</translation></message>
++    <message>
++        <source>Invalid use of id property with a value type</source>
++        <translation>ການນຳໃຊ້ຄຸນສົມບັດ id ທີ່ບໍ່ຖືກຕ້ອງພ້ອມກັບປະເພດຄ່າ</translation></message>
++    <message>
++        <source>Cannot assign primitives to lists</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າພື້ນຖານໃຫ້ກັບລາຍການ</translation></message>
++    <message>
++        <source>Invalid property assignment: unknown enumeration</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ບໍ່ຮູ້ຈັກການຈັດລຽງ</translation></message>
++    <message>
++        <source>Invalid property assignment: string expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການສະຕຣິງ</translation></message>
++    <message>
++        <source>Invalid property assignment: string or string list expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການສະຕຣິງ ຫຼື ລາຍການສະຕຣິງ</translation></message>
++    <message>
++        <source>Invalid property assignment: byte array expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະເປັນອາເຣບາຍ</translation></message>
++    <message>
++        <source>Invalid property assignment: url expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການ url</translation></message>
++    <message>
++        <source>Invalid property assignment: unsigned int expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງເປັນ unsigned int</translation></message>
++    <message>
++        <source>Invalid property assignment: int expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການ int</translation></message>
++    <message>
++        <source>Invalid property assignment: number expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການຕົວເລກ</translation></message>
++    <message>
++        <source>Invalid property assignment: color expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການສີ</translation></message>
++    <message>
++        <source>Invalid property assignment: date expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະເປັນວັນທີ</translation></message>
++    <message>
++        <source>Invalid property assignment: time expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງເວລາ</translation></message>
++    <message>
++        <source>Invalid property assignment: datetime expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະເປັນວັນທີເວລາ</translation></message>
++    <message>
++        <source>Invalid property assignment: point expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງຈຸດ</translation></message>
++    <message>
++        <source>Invalid property assignment: size expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຂະໜາດທີ່ຄາດຫວັງ</translation></message>
++    <message>
++        <source>Invalid property assignment: rect expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການ rect</translation></message>
++    <message>
++        <source>Invalid property assignment: boolean expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການຄ່າບູລີນ</translation></message>
++    <message>
++        <source>Invalid property assignment: 2D vector expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການເສັ້ນທາງ 2D</translation></message>
++    <message>
++        <source>Invalid property assignment: 3D vector expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການເສັ້ນທີ່ສາມມິຕິ</translation></message>
++    <message>
++        <source>Invalid property assignment: 4D vector expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການເສັ້ນທາງ 4D</translation></message>
++    <message>
++        <source>Invalid property assignment: quaternion expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະໄດ້ຮັບ quaternion</translation></message>
++    <message>
++        <source>Invalid property assignment: regular expression expected; use /pattern/ syntax</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຕ້ອງການການສະແດງອອກປົກກະຕິ; ໃຊ້ໂຄງສ້າງ /pattern/</translation></message>
++    <message>
++        <source>Invalid property assignment: number or array of numbers expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະເປັນຕົວເລກ ຫຼື ອາເຣຂອງຕົວເລກ</translation></message>
++    <message>
++        <source>Invalid property assignment: int or array of ints expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະເປັນ int ຫຼື array ຂອງ ints</translation></message>
++    <message>
++        <source>Invalid property assignment: bool or array of bools expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະເປັນ bool ຫຼື array ຂອງ bool</translation></message>
++    <message>
++        <source>Invalid property assignment: url or array of urls expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະເປັນ url ຫຼື array ຂອງ urls</translation></message>
++    <message>
++        <source>Invalid property assignment: string or array of strings expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າຈະເປັນສະຕຣິງ ຫຼື ອາເຣຂອງສະຕຣິງ</translation></message>
++    <message>
++        <source>Invalid property assignment: unsupported type "%1"</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ປະເພດ "%1" ບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>"%1" cannot operate on "%2"</source>
++        <translation>%1" ບໍ່ສາມາດດຳເນີນການໃນ "%2</translation></message>
++    <message>
++        <source>Cannot assign object to list property "%1"</source>
++        <translation>ບໍ່ສາມາດກຳນົດວັດຖຸໃຫ້ກັບຄຸນສົມບັດລາຍການ "%1"</translation></message>
++    <message>
++        <source>Can not assign value of type "%1" to property "%2", expecting "%3"</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າປະເພດ "%1" ໃຫ້ກັບຄຸນສົມບັດ "%2", ຄາດຫວັງ "%3"</translation></message>
++    <message>
++        <source>Can not assign value of type "%1" to property "%2", expecting an object</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າປະເພດ "%1" ໃຫ້ກັບຄຸນສົມບັດ "%2", ຄາດຫວັງວ່າຈະເປັນວັດຖຸ</translation></message>
++    <message>
++        <source>Invalid property assignment: script expected</source>
++        <translation>ການກຳນົດຄຸນສົມບັດບໍ່ຖືກຕ້ອງ: ຄາດຫວັງວ່າສະຄຣິບ</translation></message>
++    <message>
++        <source>Cannot assign object of type "%1" to property of type "%2" as the former is neither the same as the latter nor a sub-class of it.</source>
++        <translation>ບໍ່ສາມາດກຳນົດວັດຖຸປະເພດ "%1" ໃຫ້ກັບຄຸນສົມບັດປະເພດ "%2" ເພາະວ່າປະເພດທຳອິດບໍ່ແມ່ນປະເພດດຽວກັນກັບປະເພດທີສອງ ແລະ ກໍ່ບໍ່ແມ່ນຫ້ອງຮຽນຍ່ອຍຂອງມັນ.</translation></message>
++</context>
++<context>
++    <name>QQmlRewrite</name>
++    <message>
++        <source>Signal uses unnamed parameter followed by named parameter.</source>
++        <translation>Signal ໃຊ້ພາຣາມິເຕີທີ່ບໍ່ມີຊື່ຕາມດ້ວຍພາຣາມິເຕີທີ່ມີຊື່.</translation></message>
++    <message>
++        <source>Signal parameter "%1" hides global variable.</source>
++        <translation>ພາລາມິເຕີສັນຍານ "%1" ເຊື່ອງຕົວແປທົ່ວໂລກ.</translation></message>
++</context>
++<context>
++    <name>QQmlTypeData</name>
++    <message>
++        <source>Composite Singleton Type %1 is not creatable.</source>
++        <translation>ປະເພດ Composite Singleton %1 ບໍ່ສາມາດສ້າງໄດ້.</translation></message>
++    <message>
++        <source>Element is not creatable.</source>
++        <translation>ອົງປະກອບບໍ່ສາມາດສ້າງໄດ້.</translation></message>
++</context>
++<context>
++    <name>QQmlTypeLoader</name>
++    <message>
++        <source>Cannot update qmldir content for '%1'</source>
++        <translation>ບໍ່ສາມາດອັບເດດເນື້ອຫາຂອງ qmldir ສຳລັບ '%1'</translation></message>
++    <message>
++        <source>Script %1 unavailable</source>
++        <translation>ສະຄຣິບ %1 ບໍ່ມີ</translation></message>
++    <message>
++        <source>Type %1 unavailable</source>
++        <translation>ພິມ %1 ບໍ່ມີ</translation></message>
++    <message>
++        <source>No matching type found, pragma Singleton files cannot be used by QQmlComponent.</source>
++        <translation>ບໍ່ພົບປະເພດທີ່ກົງກັນ, ໄຟລ໌ Singleton ທີ່ມີ pragma ບໍ່ສາມາດນຳໃຊ້ໄດ້ໂດຍ QQmlComponent.</translation></message>
++    <message>
++        <source>pragma Singleton used with a non composite singleton type %1</source>
++        <translation>pragma Singleton ໃຊ້ກັບປະເພດ singleton ທີ່ບໍ່ແມ່ນ composite %1</translation></message>
++    <message>
++        <source>qmldir defines type as singleton, but no pragma Singleton found in type %1.</source>
++        <translation>qmldir ກໍານົດປະເພດເປັນ singleton, ແຕ່ບໍ່ພົບ pragma Singleton ໃນປະເພດ %1.</translation></message>
++    <message>
++        <source>File was compiled ahead of time with an incompatible version of Qt and the original file cannot be found. Please recompile</source>
++        <translation>ໄຟລ໌ຖືກຄຳນວນລ່ວງໜ້າດ້ວຍເວີຊັນ Qt ທີ່ບໍ່ສາມາດໃຊ້ຮ່ວມກັນໄດ້ ແລະ ບໍ່ສາມາດຊອກຫາໄຟລ໌ຕົ້ນສະບັບໄດ້. ກະລຸນາຄຳນວນໃໝ່</translation></message>
++    <message>
++        <source>No such file or directory</source>
++        <translation>ບໍ່ມີໄຟລ໌ ຫຼື ໂຟນເດີນັ້ນ</translation></message>
++    <message>
++        <source>File is empty</source>
++        <translation>ຟາຍຫວ່າງເປົ່າ</translation></message>
++    <message>
++        <source>module "%1" is not installed</source>
++        <translation>ໂມດູນ "%1" ບໍ່ໄດ້ຕິດຕັ້ງ</translation></message>
++    <message>
++        <source>Namespace %1 cannot be used as a type</source>
++        <translation>ຊື່ພື້ນທີ່ %1 ບໍ່ສາມາດນຳໃຊ້ເປັນປະເພດໄດ້</translation></message>
++    <message>
++        <source>Unreported error adding script import to import database</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ໄດ້ລາຍງານໃນການເພີ່ມການນໍາເຂົ້າສະຄຣິບຕໍ່ຖານຂໍ້ມູນນໍາເຂົ້າ</translation></message>
++    <message>
++        <source>%1 %2</source>
++        <translation>%1 %2</translation></message>
++</context>
++<context>
++    <name>QQuickAbstractAnimation</name>
++    <message>
++        <source>Cannot animate non-existent property "%1"</source>
++        <translation>ບໍ່ສາມາດເຮັດໃຫ້ມີການເຄື່ອນໄຫວຂອງຄຸນສົມບັດ "%1" ທີ່ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>Cannot animate read-only property "%1"</source>
++        <translation>ບໍ່ສາມາດເຮັດອະນິເມຊັນຄຸນສົມບັດທີ່ອ່ານໄດ້ຢ່າງດຽວ "%1"</translation></message>
++    <message>
++        <source>Animation is an abstract class</source>
++        <translation>ພາບເຄື່ອນໄຫວແມ່ນຫ້ອງຮຽນທີ່ບໍ່ມີຮູບຮ່າງ</translation></message>
++    <message>
++        <source>Animator is an abstract class</source>
++        <translation>Animator ແມ່ນຫ້ອງຮຽນທີ່ບໍ່ມີຕົວຕົນ</translation></message>
++</context>
++<context>
++    <name>QQuickAccessibleAttached</name>
++    <message>
++        <source>Accessible is only available via attached properties</source>
++        <translation>ການເຂົ້າເຖິງສາມາດໃຊ້ໄດ້ພຽງແຕ່ຜ່ານຄຸນສົມບັດທີ່ຕິດພັນ</translation></message>
++</context>
++<context>
++    <name>QQuickAnchorAnimation</name>
++    <message>
++        <source>Cannot set a duration of &lt; 0</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າໄລຍະເວລາທີ່ &lt; 0</translation></message>
++</context>
++<context>
++    <name>QQuickAnchors</name>
++    <message>
++        <source>Possible anchor loop detected on fill.</source>
++        <translation>ອາດຈະພົບການວົນຊ້ອນຂອງຈຸດອ້າງອີງໃນການຕື່ມ.</translation></message>
++    <message>
++        <source>Possible anchor loop detected on centerIn.</source>
++        <translation>ອາດຈະພົບການວົນວຽນຂອງຈຸດຕິດຕໍ່ໃນ centerIn</translation></message>
++    <message>
++        <source>Cannot anchor to an item that isn't a parent or sibling.</source>
++        <translation>ບໍ່ສາມາດຕິດຕັ້ງສະຖານທີ່ກັບລາຍການທີ່ບໍ່ແມ່ນພໍ່ແມ່ຫຼືພີ່ນ້ອງ.</translation></message>
++    <message>
++        <source>Possible anchor loop detected on vertical anchor.</source>
++        <translation>ອາດຈະພົບການວົນວຽນຂອງຈຸດຕິດຕໍ່ໃນແນວຕັ້ງ.</translation></message>
++    <message>
++        <source>Possible anchor loop detected on horizontal anchor.</source>
++        <translation>ອາດຈະພົບການວົນຊ້ຳຂອງຈຸດຕິດຕໍ່ໃນແນວນອນ.</translation></message>
++    <message>
++        <source>Cannot specify left, right, and horizontalCenter anchors at the same time.</source>
++        <translation>ບໍ່ສາມາດກຳນົດຕຳແໜ່ງຊ້າຍ, ຂວາ, ແລະກາງແນວນອນໄດ້ໃນເວລາດຽວກັນ.</translation></message>
++    <message>
++        <source>Cannot anchor to a null item.</source>
++        <translation>ບໍ່ສາມາດຕິດຕັ້ງສະຖານທີ່ກັບລາຍການທີ່ບໍ່ມີຄ່າໄດ້.</translation></message>
++    <message>
++        <source>Cannot anchor a horizontal edge to a vertical edge.</source>
++        <translation>ບໍ່ສາມາດຕິດຕັ້ງຂອບແບບນອນກັບຂອບແບບຕັ້ງໄດ້.</translation></message>
++    <message>
++        <source>Cannot anchor item to self.</source>
++        <translation>ບໍ່ສາມາດຕິດຕັ້ງລາຍການໃສ່ຕົວເອງໄດ້.</translation></message>
++    <message>
++        <source>Cannot specify top, bottom, and verticalCenter anchors at the same time.</source>
++        <translation>ບໍ່ສາມາດກຳນົດຕຳແໜ່ງຕົ້ນສະບັບ, ຕຳແໜ່ງທ້າຍ, ແລະຕຳແໜ່ງກາງແນວຕັ້ງໄດ້ໃນເວລາດຽວກັນ.</translation></message>
++    <message>
++        <source>Baseline anchor cannot be used in conjunction with top, bottom, or verticalCenter anchors.</source>
++        <translation>ຈຸດອ້າງອີງພື້ນຖານບໍ່ສາມາດນຳໃຊ້ຮ່ວມກັບຈຸດອ້າງອີງດ້ານເທິງ, ດ້ານລຸ່ມ, ຫຼືຈຸດກາງແນວຕັ້ງ.</translation></message>
++    <message>
++        <source>Cannot anchor a vertical edge to a horizontal edge.</source>
++        <translation>ບໍ່ສາມາດຕິດຂອບແບບຕັ້ງກັບຂອບແບບນອນໄດ້.</translation></message>
++</context>
++<context>
++    <name>QQuickAnimatedImage</name>
++    <message>
++        <source>Qt was built without support for QMovie</source>
++        <translation>Qt ຖືກສ້າງຂຶ້ນໂດຍບໍ່ມີການສະໜັບສະໜູນສໍາລັບ QMovie</translation></message>
++</context>
++<context>
++    <name>QQuickApplication</name>
++    <message>
++        <source>Application is an abstract class</source>
++        <translation>Application ແມ່ນຫ້ອງຮຽນທີ່ບໍ່ມີຕົວຕົນ</translation></message>
++</context>
++<context>
++    <name>QQuickBehavior</name>
++    <message>
++        <source>Cannot change the animation assigned to a Behavior.</source>
++        <translation>ບໍ່ສາມາດປ່ຽນພາບເຄື່ອນໄຫວທີ່ກຳນົດໃຫ້ກັບພຶດຕິກຳໄດ້.</translation></message>
++</context>
++<context>
++    <name>QQuickDragAttached</name>
++    <message>
++        <source>Drag is only available via attached properties</source>
++        <translation>ການດຶງແມ່ນມີພຽງແຕ່ຜ່ານຄຸນສົມບັດທີ່ຕິດຕັ້ງເທົ່ານັ້ນ</translation></message>
++</context>
++<context>
++    <name>QQuickDragHandler</name>
++    <message>
++        <source>DragAxis is only available as a grouped property of DragHandler</source>
++        <translation>DragAxis ແມ່ນມີພຽງແຕ່ເປັນຄຸນສົມບັດທີ່ຖືກຈັດກຸ່ມຂອງ DragHandler</translation></message>
++</context>
++<context>
++    <name>QQuickEnterKeyAttached</name>
++    <message>
++        <source>EnterKey attached property only works with Items</source>
++        <translation>ຄຸນສົມບັດທີ່ຕິດກັບ EnterKey ເຮັດວຽກກັບ Items ເທົ່ານັ້ນ</translation></message>
++    <message>
++        <source>EnterKey is only available via attached properties</source>
++        <translation>EnterKey ມີພຽງແຕ່ຜ່ານຄຸນສົມບັດທີ່ຕິດພັນເທົ່ານັ້ນ</translation></message>
++</context>
++<context>
++    <name>QQuickFlipable</name>
++    <message>
++        <source>front is a write-once property</source>
++        <translation>ດ້ານຫນ້າແມ່ນຄຸນສົມບັດທີ່ຂຽນຄັ້ງດຽວ</translation></message>
++    <message>
++        <source>back is a write-once property</source>
++        <translation>ກັບຄືນແມ່ນຄຸນສົມບັດທີ່ຂຽນຄັ້ງດຽວ</translation></message>
++</context>
++<context>
++    <name>QQuickGraphicsInfo</name>
++    <message>
++        <source>GraphicsInfo is only available via attached properties</source>
++        <translation>GraphicsInfo ມີພຽງແຕ່ຜ່ານຄຸນສົມບັດທີ່ໄດ້ຕິດຕັ້ງເທົ່ານັ້ນ</translation></message>
++</context>
++<context>
++    <name>QQuickItemView</name>
++    <message>
++        <source>ItemView is an abstract base class</source>
++        <translation>ItemView ເປັນຫ້ອງພື້ນຖານທີ່ບໍ່ມີຕົວຕົນ</translation></message>
++    <message>
++        <source>Delegate must be of Item type</source>
++        <translation>ຜູ້ມອບຫມາຍຕ້ອງເປັນປະເພດລາຍການ</translation></message>
++</context>
++<context>
++    <name>QQuickKeyNavigationAttached</name>
++    <message>
++        <source>KeyNavigation is only available via attached properties</source>
++        <translation>KeyNavigation ມີພຽງແຕ່ສາມາດໃຊ້ໄດ້ຜ່ານຄຸນສົມບັດທີ່ຕິດຕັ້ງ</translation></message>
++</context>
++<context>
++    <name>QQuickKeysAttached</name>
++    <message>
++        <source>Keys is only available via attached properties</source>
++        <translation>Keys ມີພຽງແຕ່ທາງເຂົ້າໄດ້ຜ່ານຄຸນສົມບັດທີ່ຕິດພັນ</translation></message>
++</context>
++<context>
++    <name>QQuickLayoutMirroringAttached</name>
++    <message>
++        <source>LayoutDirection attached property only works with Items and Windows</source>
++        <translation>ຄຸນສົມບັດທີ່ຕິດກັບ LayoutDirection ເຮັດວຽກໄດ້ພຽງແຕ່ກັບລາຍການແລະຫນ້າຕ່າງເທົ່ານັ້ນ</translation></message>
++    <message>
++        <source>LayoutMirroring is only available via attached properties</source>
++        <translation>LayoutMirroring ມີພຽງແຕ່ຜ່ານຄຸນສົມບັດທີ່ເຊື່ອມຕໍ່ເທົ່ານັ້ນ</translation></message>
++</context>
++<context>
++    <name>QQuickLoader</name>
++    <message>
++        <source>setSource: value is not an object</source>
++        <translation>setSource: ຄ່າບໍ່ແມ່ນວັດຖຸ</translation></message>
++</context>
++<context>
++    <name>QQuickMouseEvent</name>
++    <message>
++        <source>GestureEvent is only available in the context of handling the gestureStarted signal from MultiPointTouchArea</source>
++        <translation>GestureEvent ແມ່ນມີພຽງໃນບໍລິບົດຂອງການຈັດການສັນຍານ gestureStarted ຈາກ MultiPointTouchArea</translation></message>
++    <message>
++        <source>MouseEvent is only available within handlers in MouseArea</source>
++        <translation>MouseEvent ມີພຽງແຕ່ພາຍໃນ handlers ໃນ MouseArea</translation></message>
++</context>
++<context>
++    <name>QQuickOpenGLInfo</name>
++    <message>
++        <source>OpenGLInfo is only available via attached properties</source>
++        <translation>OpenGLInfo ມີພຽງແຕ່ຜ່ານຄຸນສົມບັດທີ່ໄດ້ຮັບການເຊື່ອມຕໍ່ເທົ່ານັ້ນ</translation></message>
++</context>
++<context>
++    <name>QQuickPaintedItem</name>
++    <message>
++        <source>Cannot create instance of abstract class PaintedItem</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງຂອງຫ້ອງຮຽນທີ່ບໍ່ມີຕົວຕົນ PaintedItem</translation></message>
++</context>
++<context>
++    <name>QQuickParentAnimation</name>
++    <message>
++        <source>Unable to preserve appearance under complex transform</source>
++        <translation>ບໍ່ສາມາດຮັກສາຮູບລັກສະນະໄດ້ພາຍໃຕ້ການປ່ຽນແປງທີ່ຊັບຊ້ອນ</translation></message>
++    <message>
++        <source>Unable to preserve appearance under non-uniform scale</source>
++        <translation>ບໍ່ສາມາດຮັກສາຮູບລັກສະນະໄດ້ພາຍໃຕ້ການວັດແທກທີ່ບໍ່ເປັນເອກະພາບ</translation></message>
++    <message>
++        <source>Unable to preserve appearance under scale of 0</source>
++        <translation>ບໍ່ສາມາດຮັກສາຮູບລັກສະນະໄດ້ພາຍໃຕ້ສະເກດ 0</translation></message>
++</context>
++<context>
++    <name>QQuickParentChange</name>
++    <message>
++        <source>Unable to preserve appearance under complex transform</source>
++        <translation>ບໍ່ສາມາດຮັກສາຮູບລັກສະນະໄດ້ພາຍໃຕ້ການປ່ຽນແປງທີ່ຊັບຊ້ອນ</translation></message>
++    <message>
++        <source>Unable to preserve appearance under non-uniform scale</source>
++        <translation>ບໍ່ສາມາດຮັກສາຮູບລັກສະນະໄດ້ພາຍໃຕ້ການວັດແທກທີ່ບໍ່ເປັນເອກະພາບ</translation></message>
++    <message>
++        <source>Unable to preserve appearance under scale of 0</source>
++        <translation>ບໍ່ສາມາດຮັກສາຮູບລັກສະນະໄດ້ພາຍໃຕ້ສະເກດ 0</translation></message>
++</context>
++<context>
++    <name>QQuickPathAnimation</name>
++    <message>
++        <source>Cannot set a duration of &lt; 0</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າໄລຍະເວລາທີ່ &lt; 0</translation></message>
++</context>
++<context>
++    <name>QQuickPathView</name>
++    <message>
++        <source>Delegate must be of Item type</source>
++        <translation>ຜູ້ມອບຫມາຍຕ້ອງເປັນປະເພດຂອງລາຍການ</translation></message>
++</context>
++<context>
++    <name>QQuickPauseAnimation</name>
++    <message>
++        <source>Cannot set a duration of &lt; 0</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າໄລຍະເວລາທີ່ &lt; 0</translation></message>
++</context>
++<context>
++    <name>QQuickPixmap</name>
++    <message>
++        <source>Error decoding: %1: %2</source>
++        <translation>ຜິດພາດໃນການຖອດລະຫັດ: %1: %2</translation></message>
++    <message>
++        <source>Invalid image provider: %1</source>
++        <translation>ຜູ້ໃຫ້ບໍລິການຮູບພາບບໍ່ຖືກຕ້ອງ: %1</translation></message>
++    <message>
++        <source>Failed to get image from provider: %1</source>
++        <translation>ບໍ່ສາມາດເອົາຮູບຈາກຜູ້ໃຫ້ບໍລິການໄດ້: %1</translation></message>
++    <message>
++        <source>Failed to get texture from provider: %1</source>
++        <translation>ບໍ່ສາມາດເອົາພາບຈາກຜູ້ໃຫ້ບໍລິການໄດ້: %1</translation></message>
++    <message>
++        <source>Error decoding: %1</source>
++        <translation>ຜິດພາດໃນການຖອດລະຫັດ: %1</translation></message>
++    <message>
++        <source>Cannot open: %1</source>
++        <translation>ບໍ່ສາມາດເປີດໄດ້: %1</translation></message>
++</context>
++<context>
++    <name>QQuickPointerHandler</name>
++    <message>
++        <source>PointerEvent is only available as a parameter of several signals in PointerHandler</source>
++        <translation>PointerEvent ແມ່ນມີພຽງແຕ່ເປັນພາຣາມິເຕີຂອງສັນຍານຫຼາຍອັນໃນ PointerHandler</translation></message>
++    <message>
++        <source>PointerMouseEvent is only available as a parameter of several signals in PointerHandler</source>
++        <translation>PointerMouseEvent ແມ່ນມີພຽງແຕ່ເປັນພາຣາມິເຕີຂອງສັນຍານຫຼາຍອັນໃນ PointerHandler</translation></message>
++    <message>
++        <source>PointerTouchEvent is only available as a parameter of several signals in PointerHandler</source>
++        <translation>PointerTouchEvent ແມ່ນມີພຽງແຕ່ເປັນພາຣາມິເຕີຂອງສັນຍານຫຼາຍອັນໃນ PointerHandler</translation></message>
++    <message>
++        <source>EventPoint is only available as a member of PointerEvent</source>
++        <translation>EventPoint ແມ່ນມີພຽງແຕ່ເປັນສະມາຊິກຂອງ PointerEvent</translation></message>
++    <message>
++        <source>EventTouchPoint is only available as a member of PointerEvent</source>
++        <translation>EventTouchPoint ແມ່ນມີພຽງແຕ່ເປັນສະມາຊິກຂອງ PointerEvent</translation></message>
++    <message>
++        <source>PointerDevice is only available as a property of PointerEvent</source>
++        <translation>PointerDevice ແມ່ນມີພຽງແຕ່ເປັນຄຸນສົມບັດຂອງ PointerEvent ເທົ່ານັ້ນ</translation></message>
++    <message>
++        <source>PointerHandler is an abstract base class</source>
++        <translation>PointerHandler ແມ່ນຊັ້ນພື້ນຖານທີ່ບໍ່ມີຕົວຕົນ</translation></message>
++</context>
++<context>
++    <name>QQuickPropertyAnimation</name>
++    <message>
++        <source>Cannot set a duration of &lt; 0</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າໄລຍະເວລາທີ່ &lt; 0</translation></message>
++</context>
++<context>
++    <name>QQuickPropertyChanges</name>
++    <message>
++        <source>PropertyChanges does not support creating state-specific objects.</source>
++        <translation>PropertyChanges ບໍ່ສະໜັບສະໜູນການສ້າງວັດຖຸທີ່ເຈາະຈົງຕາມສະພາບ.</translation></message>
++    <message>
++        <source>Cannot assign to non-existent property "%1"</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າໃຫ້ກັບຄຸນສົມບັດທີ່ບໍ່ມີຢູ່ "%1"</translation></message>
++    <message>
++        <source>Cannot assign to read-only property "%1"</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າໃຫ້ກັບຄຸນສົມບັດທີ່ອ່ານໄດ້ຢ່າງດຽວ "%1"</translation></message>
++</context>
++<context>
++    <name>QQuickRepeater</name>
++    <message>
++        <source>Delegate must be of Item type</source>
++        <translation>ຜູ້ມອບຫມາຍຕ້ອງເປັນປະເພດຂອງລາຍການ</translation></message>
++</context>
++<context>
++    <name>QQuickShaderEffectMesh</name>
++    <message>
++        <source>Cannot create instance of abstract class ShaderEffectMesh.</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງຂອງຊັ້ນສະຫຼຸບທີ່ບໍ່ມີຕົວຕົນ ShaderEffectMesh.</translation></message>
++</context>
++<context>
++    <name>QQuickShapeGradient</name>
++    <message>
++        <source>ShapeGradient is an abstract base class</source>
++        <translation>ShapeGradient ແມ່ນຫ້ອງຮຽນພື້ນຖານທີ່ບໍ່ມີຕົວຕົນ</translation></message>
++</context>
++<context>
++    <name>QQuickTextUtil</name>
++    <message>
++        <source>%1 does not support loading non-visual cursor delegates.</source>
++        <translation>%1 ບໍ່ສະໜັບສະໜູນການໂຫຼດຕົວແທນຕົວຊີ້ທີ່ບໍ່ແມ່ນຮູບພາບ.</translation></message>
++    <message>
++        <source>Could not load cursor delegate</source>
++        <translation>ບໍ່ສາມາດໂຫຼດຕົວແທນເຄີເຊີໄດ້</translation></message>
++</context>
++<context>
++    <name>QQuickTouchPoint</name>
++    <message>
++        <source>PointingDeviceUniqueId is only available via read-only properties</source>
++        <translation>PointingDeviceUniqueId ມີພຽງແຕ່ຜ່ານຄຸນສົມບັດອ່ານເທົ່ານັ້ນ</translation></message>
++</context>
++<context>
++    <name>QQuickViewTransitionAttached</name>
++    <message>
++        <source>ViewTransition is only available via attached properties</source>
++        <translation>ViewTransition ມີພຽງແຕ່ສາມາດໃຊ້ໄດ້ຜ່ານຄຸນສົມບັດທີ່ຕິດຕັ້ງ</translation></message>
++</context>
++<context>
++    <name>QQuickWindow</name>
++    <message>
++        <source>Failed to create %1 context for format %2.
++This is most likely caused by not having the necessary graphics drivers installed.
++
++Install a driver providing OpenGL 2.0 or higher, or, if this is not possible, make sure the ANGLE Open GL ES 2.0 emulation libraries (%3, %4 and d3dcompiler_*.dll) are available in the application executable's directory or in a location listed in PATH.</source>
++        <extracomment>%1 Context type (Open GL, EGL), %2 format, ANGLE %3, %4 library names</extracomment>
++        <translation>ບໍ່ສາມາດສ້າງບໍລິບົດ %1 ສຳລັບຮູບແບບ %2.
++ນີ້ອາດເກີດຈາກການບໍ່ມີໄດຣເວີກາຟິກທີ່ຈຳເປັນຕິດຕັ້ງ.
++
++ກະລຸນາຕິດຕັ້ງໄດຣເວີທີ່ສະໜອງ OpenGL 2.0 ຫຼືສູງກວ່າ, ຫຼືຖ້າບໍ່ສາມາດເຮັດໄດ້, ໃຫ້ແນ່ໃຈວ່າຫໍສະໝຸດການຈຳລອງ ANGLE Open GL ES 2.0 (%3, %4 ແລະ d3dcompiler_*.dll) ມີຢູ່ໃນໂຟນເດີຂອງໄຟລ໌ປະຕິບັດງານຂອງແອັບພລິເຄຊັນ ຫຼືໃນສະຖານທີ່ທີ່ລະບຸໄວ້ໃນ PATH.</translation></message>
++    <message>
++        <source>Failed to create %1 context for format %2</source>
++        <extracomment>%1 Context type (Open GL, EGL), %2 format specification</extracomment>
++        <translation>ບໍ່ສາມາດສ້າງບໍລິບົດ %1 ສຳລັບຮູບແບບ %2</translation></message>
++</context>
++<context>
++    <name>QQuickWindowQmlImpl</name>
++    <message>
++        <source>Conflicting properties 'visible' and 'visibility' for Window '%1'</source>
++        <translation>ຄຸນສົມບັດທີ່ຂັດແຍ້ງກັນ 'visible' ແລະ 'visibility' ສຳລັບວິນໂດ '%1'</translation></message>
++    <message>
++        <source>Conflicting properties 'visible' and 'visibility'</source>
++        <translation>ຄຸນສົມບັດທີ່ຂັດແຍ້ງກັນ 'visible' ແລະ 'visibility'</translation></message>
++</context>
++<context>
++    <name>SignalHandlerConverter</name>
++    <message>
++        <source>Non-existent attached object</source>
++        <translation>ວັດຖຸທີ່ຕິດພັນບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>Signal uses unnamed parameter followed by named parameter.</source>
++        <translation>Signal ໃຊ້ພາຣາມິເຕີທີ່ບໍ່ມີຊື່ຕາມດ້ວຍພາຣາມິເຕີທີ່ມີຊື່.</translation></message>
++    <message>
++        <source>Signal parameter "%1" hides global variable.</source>
++        <translation>ພາລາມິເຕີສັນຍານ "%1" ເຊື່ອງຕົວແປທົ່ວໂລກ.</translation></message>
++    <message>
++        <source>"%1.%2" is not available in %3 %4.%5.</source>
++        <translation>"%1.%2" ບໍ່ມີໃນ %3 %4.%5.</translation></message>
++    <message>
++        <source>"%1.%2" is not available due to component versioning.</source>
++        <translation>"%1.%2" ບໍ່ມີພ້ອມໃຫ້ໃຊ້ເນື່ອງຈາກການຈັດລະບຽບເວີຊັນຂອງອົງປະກອບ.</translation></message>
++    <message>
++        <source>Cannot assign a value to a signal (expecting a script to be run)</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າໃຫ້ກັບສັນຍານ (ຄາດຫວັງໃຫ້ສະຄຣິບຖືກດຳເນີນ)</translation></message>
++    <message>
++        <source>Incorrectly specified signal assignment</source>
++        <translation>ການກຳນົດສັນຍານບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>SignalTransition</name>
++    <message>
++        <source>Specified signal does not exist.</source>
++        <translation>ສັນຍານທີ່ລະບຸໄວ້ບໍ່ມີຢູ່.</translation></message>
++    <message>
++        <source>Cannot assign to non-existent property "%1"</source>
++        <translation>ບໍ່ສາມາດກຳນົດຄ່າໃຫ້ກັບຄຸນສົມບັດທີ່ບໍ່ມີຢູ່ "%1"</translation></message>
++    <message>
++        <source>SignalTransition: script expected</source>
++        <translation>SignalTransition: ສະຄິບທີ່ຄາດຫວັງ</translation></message>
++</context>
++<context>
++    <name>qmlRegisterType</name>
++    <message>
++        <source>Invalid QML %1 name "%2"; type names must begin with an uppercase letter</source>
++        <translation>QML %1 ບໍ່ຖືກຕ້ອງ ຊື່ "%2"; ຊື່ປະເພດຕ້ອງເລີ່ມຕົ້ນດ້ວຍຕົວອັກສອນໃຫຍ່</translation></message>
++    <message>
++        <source>Invalid QML %1 name "%2"</source>
++        <translation>QML ບໍ່ຖືກຕ້ອງ %1 ຊື່ "%2"</translation></message>
++    <message>
++        <source>Cannot install %1 '%2' into protected namespace '%3'</source>
++        <translation>ບໍ່ສາມາດຕິດຕັ້ງ %1 '%2' ເຂົ້າໃນ namespace ທີ່ຖືກປົກປ້ອງ '%3'</translation></message>
++    <message>
++        <source>Cannot install %1 '%2' into protected module '%3' version '%4'</source>
++        <translation>ບໍ່ສາມາດຕິດຕັ້ງ %1 '%2' ເຂົ້າໃນໂມດູນທີ່ປົກປ້ອງ '%3' ລຸ້ນ '%4'</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qtlocation_lo.ts b/translations/qtlocation_lo.ts
+new file mode 100644
+index 0000000..8c0fdd7
+--- /dev/null
++++ b/translations/qtlocation_lo.ts
+@@ -0,0 +1,1166 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>GeoServiceProviderFactoryEsri</name>
++    <message>
++        <source>Esri plugin requires a 'esri.token' parameter.
++Please visit https://developers.arcgis.com/authentication/accessing-arcgis-online-services/</source>
++        <translation>ປລັກອິນ Esri ຕ້ອງການພາຣາມິເຕີ 'esri.token'.
++ກະລຸນາເຂົ້າໄປທີ່ https://developers.arcgis.com/authentication/accessing-arcgis-online-services/</translation></message>
++</context>
++<context>
++    <name>LocaleForm.ui</name>
++    <message>
++        <source />
++        <translation type="unfinished" /></message>
++</context>
++<context>
++    <name>PlaceSearchReplyEsri</name>
++    <message>
++        <source>Response parse error</source>
++        <translation>ຜິດພາດການວິເຄາະຕອບຮັບ</translation></message>
++</context>
++<context>
++    <name>QDeclarativeGeoMap</name>
++    <message>
++        <source>No Map</source>
++        <translation>ບໍ່ມີແຜນທີ່</translation></message>
++    <message>
++        <source>Plugin does not support mapping.</source>
++        <translation>ປລັກອິນບໍ່ສະໜັບສະໜູນການແປງແຜນທີ່.</translation></message>
++</context>
++<context>
++    <name>QDeclarativeGeoRouteModel</name>
++    <message>
++        <source>Plugin does not support routing.</source>
++        <translation>ປລັກອິນບໍ່ຮອງຮັບການຈັດສົ່ງຂໍ້ມູນ.</translation></message>
++    <message>
++        <source>Cannot route, plugin not set.</source>
++        <translation>ບໍ່ສາມາດສົ່ງຕໍ່ໄດ້, ປັກອິນບໍ່ໄດ້ຕັ້ງຄ່າ.</translation></message>
++    <message>
++        <source>Cannot route, route manager not set.</source>
++        <translation>ບໍ່ສາມາດສົ່ງຕໍ່ໄດ້, ຕົວຈັດການເສັ້ນທາງບໍ່ໄດ້ຕັ້ງຄ່າ.</translation></message>
++    <message>
++        <source>Cannot route, valid query not set.</source>
++        <translation>ບໍ່ສາມາດສົ່ງຕໍ່ໄດ້, ການສອບຖາມທີ່ຖືກຕ້ອງບໍ່ໄດ້ຖືກຕັ້ງຄ່າ.</translation></message>
++    <message>
++        <source>Not enough waypoints for routing.</source>
++        <translation>ບໍ່ພຽງພໍຈຸດທາງສຳລັບການຄິດໄລ່ເສັ້ນທາງ.</translation></message>
++</context>
++<context>
++    <name>QDeclarativeGeocodeModel</name>
++    <message>
++        <source>Cannot geocode, plugin not set.</source>
++        <translation>ບໍ່ສາມາດກຳນົດພິກັດທາງພູມສາດ, ປັກອິນບໍ່ໄດ້ຕັ້ງຄ່າ.</translation></message>
++    <message>
++        <source>Cannot geocode, geocode manager not set.</source>
++        <translation>ບໍ່ສາມາດກຳນົດພິກັດທາງພູມສາດໄດ້, ບໍ່ໄດ້ຕັ້ງຕົວຈັດການກຳນົດພິກັດທາງພູມສາດ.</translation></message>
++    <message>
++        <source>Cannot geocode, valid query not set.</source>
++        <translation>ບໍ່ສາມາດກຳນົດພິກັດທາງພູມສາດ, ບໍ່ໄດ້ຕັ້ງຄໍາຖາມທີ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Plugin does not support (reverse) geocoding.</source>
++        <translation>ປລັກອິນບໍ່ຮອງຮັບການກຳໜົດພິກັດທີ່ຕັ້ງ (ກັບກັນ).</translation></message>
++</context>
++<context>
++    <name>QDeclarativeNavigator</name>
++    <message>
++        <source>Plugin does not support navigation.</source>
++        <translation>ປລັກອິນບໍ່ຮອງຮັບການນຳທາງ.</translation></message>
++    <message>
++        <source>Failed to create a navigator object.</source>
++        <translation>ບໍ່ສາມາດສ້າງວັດຖຸນຳທາງໄດ້.</translation></message>
++</context>
++<context>
++    <name>QGeoCodeReplyMapbox</name>
++    <message>
++        <source>Response parse error</source>
++        <translation>ຜິດພາດການວິເຄາະຕອບຮັບ</translation></message>
++</context>
++<context>
++    <name>QGeoMapMapboxGL</name>
++    <message>
++        <source>Development access token, do not use in production.</source>
++        <translation>ໂທເຄນການເຂົ້າເຖິງການພັດທະນາ, ຫ້າມໃຊ້ໃນການຜະລິດ.</translation></message>
++</context>
++<context>
++    <name>QGeoMappingManagerEngineItemsOverlay</name>
++    <message>
++        <source>Empty Map</source>
++        <translation>ແຜນທີ່ຫວ່າງເປົ່າ</translation></message>
++</context>
++<context>
++    <name>QGeoMappingManagerEngineMapboxGL</name>
++    <message>
++        <source>China Streets</source>
++        <translation>ຖະໜົນຫົນທາງຂອງຈີນ</translation></message>
++    <message>
++        <source>China Light</source>
++        <translation>ຈີນ ໄຟຟ້າ</translation></message>
++    <message>
++        <source>China Dark</source>
++        <translation>ຈີນມືດ</translation></message>
++    <message>
++        <source>Streets</source>
++        <translation>ຖະຫນົນຫົນທາງ</translation></message>
++    <message>
++        <source>Basic</source>
++        <translation>ພື້ນຖານ</translation></message>
++    <message>
++        <source>Bright</source>
++        <translation>ສົດໃສ</translation></message>
++    <message>
++        <source>Outdoors</source>
++        <translation>ພາຍນອກ</translation></message>
++    <message>
++        <source>Satellite</source>
++        <translation>ດາວທຽມ</translation></message>
++    <message>
++        <source>Satellite Streets</source>
++        <translation>ຖະຫນົນຫົນທາງດາວທຽມ</translation></message>
++    <message>
++        <source>Light</source>
++        <translation>ແສງ</translation></message>
++    <message>
++        <source>Dark</source>
++        <translation>ມືດ</translation></message>
++    <message>
++        <source>Navigation Preview Day</source>
++        <translation>ການເບິ່ງລ່ວງຫນ້າການນຳທາງ ມື້</translation></message>
++    <message>
++        <source>Navigation Preview Night</source>
++        <translation>ການສະແດງຕົວຢ່າງການນຳທາງຕອນກາງຄືນ</translation></message>
++    <message>
++        <source>Navigation Guidance Day</source>
++        <translation>ການນຳທາງມື້ນຳທາງ</translation></message>
++    <message>
++        <source>Navigation Guidance Night</source>
++        <translation>ຄຳແນະນຳການນຳທາງຕອນກາງຄືນ</translation></message>
++    <message>
++        <source>User provided style</source>
++        <translation>ຜູ້ໃຊ້ສະໜອງຮູບແບບ</translation></message>
++</context>
++<context>
++    <name>QGeoRouteParserOsrmV4</name>
++    <message>
++        <source>Go straight.</source>
++        <translation>ໄປຊື່.</translation></message>
++    <message>
++        <source>Go straight onto %1.</source>
++        <translation>ໄປຊື່ໆເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>Turn slightly right.</source>
++        <translation>ຫັນຂວາພຽງເລັກນ້ອຍ.</translation></message>
++    <message>
++        <source>Turn slightly right onto %1.</source>
++        <translation>ຫັນຂວາພຽງເລັກນ້ອຍເຂົ້າສູ່ %1.</translation></message>
++    <message>
++        <source>Turn right.</source>
++        <translation>ຫັນຂວາ.</translation></message>
++    <message>
++        <source>Turn right onto %1.</source>
++        <translation>ຫັນຂວາເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>Make a sharp right.</source>
++        <translation>ຫັນຂວາຢ່າງຊັດເຈນ.</translation></message>
++    <message>
++        <source>Make a sharp right onto %1.</source>
++        <translation>ຫັນຂວາຢ່າງຊັດເຈນເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>When it is safe to do so, perform a U-turn.</source>
++        <translation>ເມື່ອປອດໄພທີ່ຈະເຮັດໄດ້, ປະຕິບັດການຫັນຮອບຢູເຊີ.</translation></message>
++    <message>
++        <source>Make a sharp left.</source>
++        <translation>ຫັນຊ້າຍຢ່າງແຫຼມ.</translation></message>
++    <message>
++        <source>Make a sharp left onto %1.</source>
++        <translation>ເຮັດທາງຊ້າຍຢ່າງຊັດເຈນເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>Turn left.</source>
++        <translation>ຫັນຊ້າຍ.</translation></message>
++    <message>
++        <source>Turn left onto %1.</source>
++        <translation>ລ້ຽວຊ້າຍເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>Turn slightly left.</source>
++        <translation>ຫັນຊ້າຍເລັກນ້ອຍ.</translation></message>
++    <message>
++        <source>Turn slightly left onto %1.</source>
++        <translation>ຫັນຊ້າຍເລັກນ້ອຍເຂົ້າສູ່ %1.</translation></message>
++    <message>
++        <source>Reached waypoint.</source>
++        <translation>ຮອດຈຸດທີ່ກຳນົດໄວ້.</translation></message>
++    <message>
++        <source>Head on.</source>
++        <translation>ຫົວຂອງ.</translation></message>
++    <message>
++        <source>Head onto %1.</source>
++        <translation>ໄປທີ່ %1.</translation></message>
++    <message>
++        <source>Enter the roundabout.</source>
++        <translation>ເຂົ້າໄປໃນວົງກົມ.</translation></message>
++    <message>
++        <source>At the roundabout take the first exit.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ອອກທາງອອກທຳອິດ.</translation></message>
++    <message>
++        <source>At the roundabout take the first exit onto %1.</source>
++        <translation>ຢູ່ທີ່ວົງມົນ ໃຫ້ອອກທາງອອກທຳອິດເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>At the roundabout take the second exit.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ອອກທາງອອກທີສອງ.</translation></message>
++    <message>
++        <source>At the roundabout take the second exit onto %1.</source>
++        <translation>ຢູ່ທີ່ທາງແຍກ ໃຫ້ອອກທາງອອກທີ່ສອງເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>At the roundabout take the third exit.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ອອກທາງອອກທີ່ສາມ.</translation></message>
++    <message>
++        <source>At the roundabout take the third exit onto %1.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ເອົາທາງອອກທີ່ສາມເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>At the roundabout take the fourth exit.</source>
++        <translation>ຢູ່ທີ່ວົງກົມໃຫ້ເອົາທາງອອກທີ່ສີ່.</translation></message>
++    <message>
++        <source>At the roundabout take the fourth exit onto %1.</source>
++        <translation>ຢູ່ທີ່ທາງແຍກ ໃຫ້ອອກທາງອອກທີ່ສີ່ເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>At the roundabout take the fifth exit.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ອອກທາງອອກທີຫ້າ.</translation></message>
++    <message>
++        <source>At the roundabout take the fifth exit onto %1.</source>
++        <translation>ຢູ່ທີ່ວົງກົມໃຫ້ເອົາທາງອອກທີ່ຫ້າຂອງ %1.</translation></message>
++    <message>
++        <source>At the roundabout take the sixth exit.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ເອົາທາງອອກທີ່ຫົກ.</translation></message>
++    <message>
++        <source>At the roundabout take the sixth exit onto %1.</source>
++        <translation>ຢູ່ທີ່ວົງກົມໃຫ້ເອົາທາງອອກທີ່ຫົກສຸດເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>At the roundabout take the seventh exit.</source>
++        <translation>ຢູ່ທີ່ວົງກົມໃຫ້ເອົາທາງອອກທີ່ເຈັດ.</translation></message>
++    <message>
++        <source>At the roundabout take the seventh exit onto %1.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ເອົາທາງອອກທີ່ເຈັດຂອງ %1.</translation></message>
++    <message>
++        <source>At the roundabout take the eighth exit.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ອອກທາງອອກທີ່ແປດ.</translation></message>
++    <message>
++        <source>At the roundabout take the eighth exit onto %1.</source>
++        <translation>ຢູ່ທີ່ວົງກົມໃຫ້ເອົາທາງອອກທີ່ແປດສຸດທ້າຍເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>At the roundabout take the ninth exit.</source>
++        <translation>ຢູ່ທີ່ວົງມົນໃຫ້ອອກທາງອອກທີເກົ້າ.</translation></message>
++    <message>
++        <source>At the roundabout take the ninth exit onto %1.</source>
++        <translation>ຢູ່ທີ່ວົງກົມໃຫ້ເອົາທາງອອກທີເກົ້າເຂົ້າໄປໃນ %1.</translation></message>
++    <message>
++        <source>Leave the roundabout.</source>
++        <translation>ອອກຈາກວົງຈອນ.</translation></message>
++    <message>
++        <source>Leave the roundabout onto %1.</source>
++        <translation>ອອກຈາກວົງຈອນເຂົ້າສູ່ %1.</translation></message>
++    <message>
++        <source>Stay on the roundabout.</source>
++        <translation>ຢູ່ເທິງທາງວົງກົມ.</translation></message>
++    <message>
++        <source>Start at the end of the street.</source>
++        <translation>ເລີ່ມຕົ້ນທີ່ທ້າຍຂອງຖະໜົນ.</translation></message>
++    <message>
++        <source>Start at the end of %1.</source>
++        <translation>ເລີ່ມຕົ້ນທີ່ທ້າຍຂອງ %1.</translation></message>
++    <message>
++        <source>You have reached your destination.</source>
++        <translation>ທ່ານໄດ້ຮອດຈຸດປາຍທາງແລ້ວ.</translation></message>
++    <message>
++        <source>Don't know what to say for '%1'</source>
++        <translation>ບໍ່ຮູ້ວ່າຈະເວົ້າຫຍັງສໍາລັບ '%1'</translation></message>
++</context>
++<context>
++    <name>QGeoRouteParserOsrmV5</name>
++    <message>
++        <source>North</source>
++        <extracomment>Translations exist at https://github.com/Project-OSRM/osrm-text-instructions. Always used in "Head %1 [onto &lt;street name&gt;]"</extracomment>
++        <translation>ພາກເໜືອ</translation></message>
++    <message>
++        <source>East</source>
++        <translation>ຕາເວັນອອກ</translation></message>
++    <message>
++        <source>South</source>
++        <translation>ພາກໃຕ້</translation></message>
++    <message>
++        <source>West</source>
++        <translation>ຕາເວັນຕົກ</translation></message>
++    <message>
++        <source>first</source>
++        <comment>roundabout exit</comment>
++        <extracomment>always used in " and take the %1 exit [onto &lt;street name&gt;]"</extracomment>
++        <translation>ທຳອິດ</translation></message>
++    <message>
++        <source>second</source>
++        <comment>roundabout exit</comment>
++        <translation>ທີສອງ</translation></message>
++    <message>
++        <source>third</source>
++        <comment>roundabout exit</comment>
++        <translation>ທີສາມ</translation></message>
++    <message>
++        <source>fourth</source>
++        <comment>roundabout exit</comment>
++        <translation>ທີສີ່</translation></message>
++    <message>
++        <source>fifth</source>
++        <comment>roundabout exit</comment>
++        <translation>ທີຫ້າ</translation></message>
++    <message>
++        <source>sixth</source>
++        <comment>roundabout exit</comment>
++        <translation>ທີຫົກ</translation></message>
++    <message>
++        <source>seventh</source>
++        <comment>roundabout exit</comment>
++        <translation>ເຈັດ</translation></message>
++    <message>
++        <source>eighth</source>
++        <comment>roundabout exit</comment>
++        <translation>ແປດ</translation></message>
++    <message>
++        <source>ninth</source>
++        <comment>roundabout exit</comment>
++        <translation>ເກົ້າ</translation></message>
++    <message>
++        <source>tenth</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບ</translation></message>
++    <message>
++        <source>eleventh</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບເອັດ</translation></message>
++    <message>
++        <source>twelfth</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບສອງ</translation></message>
++    <message>
++        <source>thirteenth</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບສາມ</translation></message>
++    <message>
++        <source>fourteenth</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບສີ່</translation></message>
++    <message>
++        <source>fifteenth</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບຫ້າ</translation></message>
++    <message>
++        <source>sixteenth</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບຫົກ</translation></message>
++    <message>
++        <source>seventeenth</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບເຈັດ</translation></message>
++    <message>
++        <source>eighteenth</source>
++        <comment>roundabout exit</comment>
++        <translation>ສິບແປດ</translation></message>
++    <message>
++        <source>nineteenth</source>
++        <comment>roundabout exit</comment>
++        <translation>ຊາວເກົ້າ</translation></message>
++    <message>
++        <source>twentieth</source>
++        <comment>roundabout exit</comment>
++        <translation>ຊາວ</translation></message>
++    <message>
++        <source> and take the %1 exit</source>
++        <extracomment>Always appended to one of the following strings: - "Enter the roundabout" - "Enter the rotary" - "Enter the rotary &lt;rotaryname&gt;"</extracomment>
++        <translation>ແລະ ໃຊ້ທາງອອກ %1</translation></message>
++    <message>
++        <source> and take the %1 exit onto %2</source>
++        <translation>ແລະ ເຂົ້າທາງອອກ %1 ໄປຍັງ %2</translation></message>
++    <message>
++        <source>You have arrived at your destination, straight ahead</source>
++        <translation>ທ່ານໄດ້ມາຮອດຈຸດປາຍທາງຂອງທ່ານແລ້ວ, ຊື່ໆຢູ່ທາງໜ້າ</translation></message>
++    <message>
++        <source>You have arrived at your destination, on the left</source>
++        <translation>ທ່ານໄດ້ມາຮອດຈຸດປາຍທາງຂອງທ່ານແລ້ວ, ຢູ່ທາງຊ້າຍ</translation></message>
++    <message>
++        <source>You have arrived at your destination, on the right</source>
++        <translation>ທ່ານໄດ້ມາຮອດຈຸດປາຍທາງຂອງທ່ານແລ້ວ, ຢູ່ທາງຂວາ</translation></message>
++    <message>
++        <source>You have arrived at your destination</source>
++        <translation>ທ່ານໄດ້ມາຮອດຈຸດປາຍທາງແລ້ວ</translation></message>
++    <message>
++        <source>Continue straight</source>
++        <translation>ສືບຕໍ່ຊື່</translation></message>
++    <message>
++        <source>Continue straight on %1</source>
++        <translation>ສືບຕໍ່ຊື່ໆໃນ %1</translation></message>
++    <message>
++        <source>Continue left</source>
++        <translation>ສືບຕໍ່ຊ້າຍ</translation></message>
++    <message>
++        <source>Continue left onto %1</source>
++        <translation>ສືບຕໍ່ຊ້າຍໄປຍັງ %1</translation></message>
++    <message>
++        <source>Continue slightly left</source>
++        <translation>ສືບຕໍ່ໄປທາງຊ້າຍເລັກນ້ອຍ</translation></message>
++    <message>
++        <source>Continue slightly left on %1</source>
++        <translation>ສືບຕໍ່ໄປທາງຊ້າຍເລັກນ້ອຍຕາມ %1</translation></message>
++    <message>
++        <source>Continue right</source>
++        <translation>ສືບຕໍ່ຂວາ</translation></message>
++    <message>
++        <source>Continue right onto %1</source>
++        <translation>ສືບຕໍ່ຂວາເຂົ້າໄປຍັງ %1</translation></message>
++    <message>
++        <source>Continue slightly right</source>
++        <translation>ສືບຕໍ່ໄປທາງຂວານ້ອຍໜຶ່ງ</translation></message>
++    <message>
++        <source>Continue slightly right on %1</source>
++        <translation>ສືບຕໍ່ໄປທາງຂວານ້ອຍໜຶ່ງຕາມ %1</translation></message>
++    <message>
++        <source>Make a U-turn</source>
++        <translation>ຫັນກັບທິດທາງ</translation></message>
++    <message>
++        <source>Make a U-turn onto %1</source>
++        <translation>ຫັນກັບຫົວລົດໄປທາງ %1</translation></message>
++    <message>
++        <source>Continue</source>
++        <translation>ສືບຕໍ່</translation></message>
++    <message>
++        <source>Continue on %1</source>
++        <translation>ສືບຕໍ່ໃນ %1</translation></message>
++    <message>
++        <source>Head %1</source>
++        <extracomment>%1 is "North", "South", "East" or "West"</extracomment>
++        <translation>ຫົວ %1</translation></message>
++    <message>
++        <source>Head %1 onto %2</source>
++        <translation>ຫົວ %1 ໃສ່ %2</translation></message>
++    <message>
++        <source>Depart</source>
++        <translation>ອອກເດີນທາງ</translation></message>
++    <message>
++        <source>Depart onto %1</source>
++        <translation>ອອກເດີນທາງໄປຍັງ %1</translation></message>
++    <message>
++        <source>At the end of the road, turn left</source>
++        <translation>ທີ່ທາງຍ່ອມຂອງຖະໜົນ, ຫັນຊ້າຍ</translation></message>
++    <message>
++        <source>At the end of the road, turn left onto %1</source>
++        <translation>ທີ່ທາງຍ່ອຍຂອງຖະໜົນ, ຫັນຊ້າຍເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the end of the road, turn right</source>
++        <translation>ຢູ່ທ້າຍຂອງຖະໜົນ, ຫັນຂວາ</translation></message>
++    <message>
++        <source>At the end of the road, turn right onto %1</source>
++        <translation>ທີ່ທາງຍ່ອຍຂອງຖະໜົນ, ລ້ຽວຂວາເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the end of the road, make a U-turn</source>
++        <translation>ຢູ່ທ້າຍຂອງທາງ, ເຮັດການຫັນຮອບຢູ</translation></message>
++    <message>
++        <source>At the end of the road, make a U-turn onto %1</source>
++        <translation>ຢູ່ທ້າຍຂອງທາງ, ເຮັດການຫັນຮອບຢູ່ເທິງ %1</translation></message>
++    <message>
++        <source>At the end of the road, continue straight</source>
++        <translation>ທີ່ສຸດຂອງຖະໜົນ, ສືບຕໍ່ໄປຕົງ</translation></message>
++    <message>
++        <source>At the end of the road, continue straight onto %1</source>
++        <translation>ທີ່ທາງຍ່ອຍຂອງຖະໜົນ, ສືບຕໍ່ໄປຕົງເຂົ້າ %1</translation></message>
++    <message>
++        <source>At the end of the road, continue</source>
++        <translation>ທີ່ທາງຍ່ອມຂອງຖະໜົນ, ສືບຕໍ່</translation></message>
++    <message>
++        <source>At the end of the road, continue onto %1</source>
++        <translation>ທີ່ສຸດຂອງຖະໜົນ, ສືບຕໍ່ໄປຍັງ %1</translation></message>
++    <message>
++        <source>Take the ferry</source>
++        <translation>ຂຶ້ນເຮືອຂ້າມຟາກ</translation></message>
++    <message>
++        <source>At the fork, take a sharp left</source>
++        <translation>ຢູ່ທາງແຍກ, ໃຫ້ລ້ຽວຊ້າຍຢ່າງແຫຼມ</translation></message>
++    <message>
++        <source>At the fork, take a sharp left onto %1</source>
++        <translation>ຢູ່ຈຸດສາມແຍກ, ຫັນຊ້າຍຢ່າງສັກສິດເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the fork, turn left</source>
++        <translation>ຢູ່ສາຍແບ່ງ, ຫັນຊ້າຍ</translation></message>
++    <message>
++        <source>At the fork, turn left onto %1</source>
++        <translation>ຢູ່ຈຸດສາມແຍກ, ຫັນຊ້າຍເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the fork, keep left</source>
++        <translation>ຢູ່ທາງແຍກ, ຢູ່ຊ້າຍ</translation></message>
++    <message>
++        <source>At the fork, keep left onto %1</source>
++        <translation>ຢູ່ທາງແຍກ, ຢູ່ຊ້າຍເຂົ້າໄປທາງ %1</translation></message>
++    <message>
++        <source>At the fork, take a sharp right</source>
++        <translation>ຢູ່ທາງແຍກ, ລ້ຽວຂວາຢ່າງຊັດເຈນ</translation></message>
++    <message>
++        <source>At the fork, take a sharp right onto %1</source>
++        <translation>ຢູ່ທາງແຍກ, ລ້ຽວຂວາຢ່າງສັກສິດເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the fork, turn right</source>
++        <translation>ຢູ່ສາຍແບ່ງ, ຫັນຂວາ</translation></message>
++    <message>
++        <source>At the fork, turn right onto %1</source>
++        <translation>ຢູ່ຈຸດສາມແຍກ, ຫັນຂວາເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the fork, keep right</source>
++        <translation>ຢູ່ທາງແຍກ, ຢູ່ຂວາ</translation></message>
++    <message>
++        <source>At the fork, keep right onto %1</source>
++        <translation>ຢູ່ທາງແຍກ, ຮັກສາທາງຂວາເຂົ້າໄປຫາ %1</translation></message>
++    <message>
++        <source>At the fork, continue straight ahead</source>
++        <translation>ຢູ່ທາງແຍກ, ສືບຕໍ່ໄປທາງເລື່ອງຕໍ່ໄປ</translation></message>
++    <message>
++        <source>At the fork, continue straight ahead onto %1</source>
++        <translation>ຢູ່ທາງແຍກ, ສືບຕໍ່ໄປທາງຊ້າຍເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the fork, continue</source>
++        <translation>ຢູ່ທີ່ສາຍແບ່ງ, ສືບຕໍ່</translation></message>
++    <message>
++        <source>At the fork, continue onto %1</source>
++        <translation>ຢູ່ທາງແຍກ, ສືບຕໍ່ເຂົ້າໄປຫາ %1</translation></message>
++    <message>
++        <source>Merge sharply left</source>
++        <translation>ລວມເຂົ້າຊ້າຍຢ່າງແຫຼມຊຶມ</translation></message>
++    <message>
++        <source>Merge sharply left onto %1</source>
++        <translation>ລວມເຂົ້າກັນທາງຊ້າຍຢ່າງແຫຼມສູ່ %1</translation></message>
++    <message>
++        <source>Merge left</source>
++        <translation>ລວມຊ້າຍ</translation></message>
++    <message>
++        <source>Merge left onto %1</source>
++        <translation>ລວມຊ້າຍເຂົ້າ %1</translation></message>
++    <message>
++        <source>Merge slightly left</source>
++        <translation>ລວມເຂົ້າກັນເບື້ອງຊ້າຍເລັກນ້ອຍ</translation></message>
++    <message>
++        <source>Merge slightly left on %1</source>
++        <translation>ປະສົມເຂົ້າກັນທາງຊ້າຍເລັກນ້ອຍໃນ %1</translation></message>
++    <message>
++        <source>Merge sharply right</source>
++        <translation>ລວມເຂົ້າຂວາຢ່າງແຫຼມ</translation></message>
++    <message>
++        <source>Merge sharply right onto %1</source>
++        <translation>ລວມເຂົ້າກັນຢ່າງແຫຼມຂວາເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>Merge right</source>
++        <translation>ລວມຂວາ</translation></message>
++    <message>
++        <source>Merge right onto %1</source>
++        <translation>ລວມເຂົ້າກັນທາງຂວາສູ່ %1</translation></message>
++    <message>
++        <source>Merge slightly right</source>
++        <translation>ລວມເຂົ້າກັນເລັກນ້ອຍທາງຂວາ</translation></message>
++    <message>
++        <source>Merge slightly right on %1</source>
++        <translation>ລວມເຂົ້າກັນເລັກນ້ອຍທາງຂວາໃນ %1</translation></message>
++    <message>
++        <source>Merge straight</source>
++        <translation>ລວມເຂົ້າກັນຕົງ</translation></message>
++    <message>
++        <source>Merge straight on %1</source>
++        <translation>ລວມເຂົ້າກັນໂດຍກົງໃນ %1</translation></message>
++    <message>
++        <source>Merge</source>
++        <translation>ລວມເຂົ້າກັນ</translation></message>
++    <message>
++        <source>Merge onto %1</source>
++        <translation>ລວມເຂົ້າກັນໃນ %1</translation></message>
++    <message>
++        <source>Take a sharp left</source>
++        <translation>ຫັນຊ້າຍຢ່າງແຫຼມຊຶ່ງ</translation></message>
++    <message>
++        <source>Take a sharp left onto %1</source>
++        <translation>ຫັນຊ້າຍຢ່າງຊັດເຈນເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>Turn left</source>
++        <translation>ຫັນຊ້າຍ</translation></message>
++    <message>
++        <source>Turn left onto %1</source>
++        <translation>ຫັນຊ້າຍເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>Continue slightly left onto %1</source>
++        <translation>ສືບຕໍ່ໄປທາງຊ້າຍເລັກນ້ອຍເຂົ້າໄປຍັງ %1</translation></message>
++    <message>
++        <source>Take a sharp right</source>
++        <translation>ຫັນຂວາແຫຼມ</translation></message>
++    <message>
++        <source>Take a sharp right onto %1</source>
++        <translation>ຫັນຂວາຢ່າງຊັດເຈນເຂົ້າໄປຍັງ %1</translation></message>
++    <message>
++        <source>Turn right</source>
++        <translation>ຫັນຂວາ</translation></message>
++    <message>
++        <source>Turn right onto %1</source>
++        <translation>ຫັນຂວາເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>Continue slightly right onto %1</source>
++        <translation>ສືບຕໍ່ໄປທາງຂວາຫນ້ອຍໜຶ່ງເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>Continue straight onto %1</source>
++        <translation>ສືບຕໍ່ຊື່ໆໄປຍັງ %1</translation></message>
++    <message>
++        <source>Continue onto %1</source>
++        <translation>ສືບຕໍ່ໄປຍັງ %1</translation></message>
++    <message>
++        <source>Continue on the left</source>
++        <translation>ສືບຕໍ່ໄປທາງຊ້າຍ</translation></message>
++    <message>
++        <source>Continue on the left on %1</source>
++        <translation>ສືບຕໍ່ທາງຊ້າຍຢູ່ %1</translation></message>
++    <message>
++        <source>Continue on the right</source>
++        <translation>ສືບຕໍ່ໄປທາງຂວາ</translation></message>
++    <message>
++        <source>Continue on the right on %1</source>
++        <translation>ສືບຕໍ່ໄປທາງຂວາໃນ %1</translation></message>
++    <message>
++        <source>Take the ramp on the left</source>
++        <translation>ຍ່າງຂຶ້ນທາງລ່ຽງຊ້າຍ</translation></message>
++    <message>
++        <source>Take the ramp on the left onto %1</source>
++        <translation>ເອົາທາງລົດທີ່ຊ້າຍຂຶ້ນໄປຍັງ %1</translation></message>
++    <message>
++        <source>Take the ramp on the right</source>
++        <translation>ເອົາທາງລົດເລື່ອນທາງຂວາ</translation></message>
++    <message>
++        <source>Take the ramp on the right onto %1</source>
++        <translation>ເອົາທາງລົດທີ່ຢູ່ທາງຂວາເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>Take the ramp</source>
++        <translation>ເອົາທາງລົດໄຟ</translation></message>
++    <message>
++        <source>Take the ramp onto %1</source>
++        <translation>ເຂົ້າທາງລ່ອງເຂົ້າ %1</translation></message>
++    <message>
++        <source>Get off the bike and push</source>
++        <translation>ລົງຈາກລົດຖີບແລະຍູ້</translation></message>
++    <message>
++        <source>Get off the bike and push onto %1</source>
++        <translation>ລົງຈາກລົດຖີບ ແລະ ຍູ້ເຂົ້າໄປຍັງ %1</translation></message>
++    <message>
++        <source>Enter the rotary</source>
++        <extracomment>This string will be prepended to " and take the &lt;nth&gt; exit [onto &lt;streetname&gt;]</extracomment>
++        <translation>ປ້ອນລະຫັດລັອກ</translation></message>
++    <message>
++        <source>Enter the roundabout</source>
++        <extracomment>This string will be prepended to " and take the &lt;nth&gt; exit [onto &lt;streetname&gt;]</extracomment>
++        <translation>ເຂົ້າສູ່ວົງກົມຈຸດພັກລົດ</translation></message>
++    <message>
++        <source>At the roundabout, continue straight</source>
++        <translation>ຢູ່ທີ່ວົງກົມ, ສືບຕໍ່ໄປຕົງ</translation></message>
++    <message>
++        <source>At the roundabout, continue straight on %1</source>
++        <translation>ຢູ່ທີ່ວົງກົມ, ສືບຕໍ່ໄປຕົງເລື້ອຍ %1</translation></message>
++    <message>
++        <source>At the roundabout, turn left</source>
++        <translation>ຢູ່ທີ່ວົງມົນ, ຫັນຊ້າຍ</translation></message>
++    <message>
++        <source>At the roundabout, turn left onto %1</source>
++        <translation>ຢູ່ທີ່ວົງກົມ, ຫັນຊ້າຍເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the roundabout, turn right</source>
++        <translation>ຢູ່ທີ່ວົງກົມ, ຫັນຂວາ</translation></message>
++    <message>
++        <source>At the roundabout, turn right onto %1</source>
++        <translation>ຢູ່ທີ່ວົງມົນ, ຫັນຂວາເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>At the roundabout, turn around</source>
++        <translation>ຢູ່ທີ່ວົງກົມ, ຫັນຫຼັງ</translation></message>
++    <message>
++        <source>At the roundabout, turn around onto %1</source>
++        <translation>ຢູ່ທີ່ວົງກົມ, ຫັນຫຼັງໄປຫາ %1</translation></message>
++    <message>
++        <source>At the roundabout, continue</source>
++        <translation>ຢູ່ທີ່ວົງກົມ, ສືບຕໍ່</translation></message>
++    <message>
++        <source>At the roundabout, continue onto %1</source>
++        <translation>ຢູ່ທີ່ວົງກົມ, ສືບຕໍ່ເຂົ້າໄປທີ່ %1</translation></message>
++    <message>
++        <source>Take the train</source>
++        <translation>ຂຶ້ນລົດໄຟ</translation></message>
++    <message>
++        <source>Take the train [%1]</source>
++        <translation>ຂຶ້ນລົດໄຟ [%1]</translation></message>
++    <message>
++        <source>Go straight</source>
++        <translation>ໄປຊື່</translation></message>
++    <message>
++        <source>Go straight onto %1</source>
++        <translation>ໄປຊື່ໆເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source>Turn slightly left</source>
++        <translation>ຫັນຊ້າຍໜ້ອຍໜຶ່ງ</translation></message>
++    <message>
++        <source>Turn slightly left onto %1</source>
++        <translation>ຫັນຊ້າຍເລັກນ້ອຍເຂົ້າສູ່ %1</translation></message>
++    <message>
++        <source>Turn slightly right</source>
++        <translation>ຫັນຂວາພຽງເລັກນ້ອຍ</translation></message>
++    <message>
++        <source>Turn slightly right onto %1</source>
++        <translation>ຫັນຂວາພຽງເລັກນ້ອຍເຂົ້າສູ່ %1</translation></message>
++    <message>
++        <source>Turn</source>
++        <translation>ປ່ຽນ</translation></message>
++    <message>
++        <source>Turn onto %1</source>
++        <translation>ຫັນເຂົ້າ %1</translation></message>
++    <message>
++        <source> and continue straight</source>
++        <extracomment>This string will be prepended with lane instructions. E.g., "Use the left or the right lane and continue straight"</extracomment>
++        <translation>ແລະຕໍ່ໄປຢ່າງຕໍ່ເນື່ອງ</translation></message>
++    <message>
++        <source> and continue straight onto %1</source>
++        <translation>ແລະຕໍ່ໄປຢ່າງຕໍ່ເນື່ອງໃນ %1</translation></message>
++    <message>
++        <source> and make a sharp left</source>
++        <translation>ແລະເຮັດການຫັນຊ້າຍຢ່າງແຫຼມຊຶມ</translation></message>
++    <message>
++        <source> and make a sharp left onto %1</source>
++        <translation>ແລະ ຫັນຊ້າຍຢ່າງຊັດເຈນເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source> and turn left</source>
++        <translation>ແລະຫັນຊ້າຍ</translation></message>
++    <message>
++        <source> and turn left onto %1</source>
++        <translation>ແລະຫັນຊ້າຍເຂົ້າໄປທາງ %1</translation></message>
++    <message>
++        <source> and make a slight left</source>
++        <translation>ແລະເຮັດຊ້າຍເລັກນ້ອຍ</translation></message>
++    <message>
++        <source> and make a slight left onto %1</source>
++        <translation>ແລະເຮັດການຫັນຊ້າຍເລັກນ້ອຍໄປຍັງ %1</translation></message>
++    <message>
++        <source> and make a sharp right</source>
++        <translation>ແລະ ຫັນຂວາຢ່າງສັກສິດ</translation></message>
++    <message>
++        <source> and make a sharp right onto %1</source>
++        <translation>ແລະ ຫັນຂວາຢ່າງສັກສິດເຂົ້າສູ່ %1</translation></message>
++    <message>
++        <source> and turn right</source>
++        <translation>ແລະຫັນຂວາ</translation></message>
++    <message>
++        <source> and turn right onto %1</source>
++        <translation>ແລະຫັນຂວາເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source> and make a slight right</source>
++        <translation>ແລະເຮັດການຫັນຂວາພຽງເລັກນ້ອຍ</translation></message>
++    <message>
++        <source> and make a slight right onto %1</source>
++        <translation>ແລະຫັນຂວາພຽງເລັກນ້ອຍເຂົ້າໄປໃນ %1</translation></message>
++    <message>
++        <source> and make a U-turn</source>
++        <translation>ແລະຫັນຫົວກັບ</translation></message>
++    <message>
++        <source> and make a U-turn onto %1</source>
++        <translation>ແລະ ຫັນລົດກັບທິດທາງກົງກັນຂ້າມເຂົ້າໄປໃນ %1</translation></message>
++</context>
++<context>
++    <name>QGeoServiceProviderFactoryMapbox</name>
++    <message>
++        <source>Mapbox plugin requires a 'mapbox.access_token' parameter.
++Please visit https://www.mapbox.com</source>
++        <translation>ປລັກອິນ Mapbox ຕ້ອງການພາຣາມິເຕີ 'mapbox.access_token'.
++ກະລຸນາເຂົ້າໄປທີ່ https://www.mapbox.com</translation></message>
++</context>
++<context>
++    <name>QGeoTileFetcherNokia</name>
++    <message>
++        <source>Mapping manager no longer exists</source>
++        <translation>ຜູ້ຈັດການແຜນທີ່ບໍ່ມີຢູ່ອີກຕໍ່ໄປ</translation></message>
++</context>
++<context>
++    <name>QGeoTiledMappingManagerEngineMapbox</name>
++    <message>
++        <source>Street</source>
++        <extracomment>Noun describing map type 'Street map'</extracomment>
++        <translation>ຖະໜົນ</translation></message>
++    <message>
++        <source>Light</source>
++        <extracomment>Noun describing type of a map using light colors (weak contrast)</extracomment>
++        <translation>ແສງ</translation></message>
++    <message>
++        <source>Dark</source>
++        <extracomment>Noun describing type of a map using dark colors</extracomment>
++        <translation>ມືດ</translation></message>
++    <message>
++        <source>Satellite</source>
++        <extracomment>Noun describing type of a map created by satellite</extracomment>
++        <translation>ດາວທຽມ</translation></message>
++    <message>
++        <source>Streets Satellite</source>
++        <extracomment>Noun describing type of a street map created by satellite</extracomment>
++        <translation>ຖະຫນົນຫົນທາງດາວທຽມ</translation></message>
++    <message>
++        <source>Wheatpaste</source>
++        <extracomment>Noun describing type of a map using wheat paste colors</extracomment>
++        <translation>ການປັກກະຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍການຕິດດ້ວຍ</translation></message>
++    <message>
++        <source>Streets Basic</source>
++        <extracomment>Noun describing type of a basic street map</extracomment>
++        <translation>ຖະໜົນພື້ນຖານ</translation></message>
++    <message>
++        <source>Comic</source>
++        <extracomment>Noun describing type of a map using cartoon-style fonts</extracomment>
++        <translation>ກາຕູນ</translation></message>
++    <message>
++        <source>Outdoors</source>
++        <extracomment>Noun describing type of a map for outdoor activities</extracomment>
++        <translation>ພາຍນອກ</translation></message>
++    <message>
++        <source>Run Bike Hike</source>
++        <extracomment>Noun describing type of a map for sports</extracomment>
++        <translation>ວ່າງ ລົດຖີບ ຍ່າງປ່າ</translation></message>
++    <message>
++        <source>Pencil</source>
++        <extracomment>Noun describing type of a map drawn by pencil</extracomment>
++        <translation>ສໍ</translation></message>
++    <message>
++        <source>Pirates</source>
++        <extracomment>Noun describing type of a treasure map with pirate boat watermark</extracomment>
++        <translation>ກຸ່ມໂຈນສະລັດ</translation></message>
++    <message>
++        <source>Emerald</source>
++        <extracomment>Noun describing type of a map using emerald colors</extracomment>
++        <translation>ມຣກຕ</translation></message>
++    <message>
++        <source>High Contrast</source>
++        <extracomment>Noun describing type of a map with high contrast</extracomment>
++        <translation>ຄວາມແຕກຕ່າງສູງ</translation></message>
++</context>
++<context>
++    <name>QGeoTiledMappingManagerEngineNokia</name>
++    <message>
++        <source>Street Map</source>
++        <translation>ແຜນທີ່ຖະໜົນ</translation></message>
++    <message>
++        <source>Normal map view in daylight mode</source>
++        <translation>ມຸມມອງແຜນທີ່ປົກກະຕິໃນໂໝດມື້</translation></message>
++    <message>
++        <source>Satellite Map</source>
++        <translation>ແຜນທີ່ດາວທຽມ</translation></message>
++    <message>
++        <source>Satellite map view in daylight mode</source>
++        <translation>ແຜນທີ່ດາວທຽມໃນໂໝດມື້</translation></message>
++    <message>
++        <source>Terrain Map</source>
++        <translation>ແຜນທີ່ພູມສັນຖານ</translation></message>
++    <message>
++        <source>Terrain map view in daylight mode</source>
++        <translation>ແຜນທີ່ພູມສັນຖານໃນໂໝດມື້ສວາຍ</translation></message>
++    <message>
++        <source>Hybrid Map</source>
++        <translation>ແຜນທີ່ລວມ</translation></message>
++    <message>
++        <source>Satellite map view with streets in daylight mode</source>
++        <translation>ແຜນທີ່ດາວທຽມທີ່ມີຖະໜົນໃນໂໝດມື້</translation></message>
++    <message>
++        <source>Transit Map</source>
++        <translation>ແຜນທີ່ຂົນສົ່ງສາທາລະນະ</translation></message>
++    <message>
++        <source>Color-reduced map view with public transport scheme in daylight mode</source>
++        <translation>ແຜນທີ່ທີ່ຫຼຸດສີລົງພ້ອມກັບແຜນການຂົນສົ່ງສາທາລະນະໃນໂໝດມື້ສວຍສົດ</translation></message>
++    <message>
++        <source>Gray Street Map</source>
++        <translation>ແຜນທີ່ຖະຫນົນສີຂີ້ເຖົ່າ</translation></message>
++    <message>
++        <source>Color-reduced map view in daylight mode</source>
++        <translation>ແຜນທີ່ທີ່ຫຼຸດສີໃນໂໝດມື້</translation></message>
++    <message>
++        <source>Mobile Street Map</source>
++        <translation>ແຜນທີ່ຖະໜົນມືຖື</translation></message>
++    <message>
++        <source>Mobile normal map view in daylight mode</source>
++        <translation>ແຜນທີ່ປົກກະຕິຂອງມືຖືໃນໂໝດມືດສະຫວ່າງ</translation></message>
++    <message>
++        <source>Mobile Terrain Map</source>
++        <translation>ແຜນທີ່ພື້ນທີ່ມືຖື</translation></message>
++    <message>
++        <source>Mobile terrain map view in daylight mode</source>
++        <translation>ແຜນທີ່ພູມສັນຖານມືຖືໃນໂໝດມື້ສວາຍ</translation></message>
++    <message>
++        <source>Mobile Hybrid Map</source>
++        <translation>ແຜນທີ່ລວມມືຖື</translation></message>
++    <message>
++        <source>Mobile satellite map view with streets in daylight mode</source>
++        <translation>ແຜນທີ່ດາວທຽມມືຖືທີ່ສະແດງຖະໜົນຫົນທາງໃນໂໝດມື້ສະຫວ່າງ</translation></message>
++    <message>
++        <source>Mobile Transit Map</source>
++        <translation>ແຜນທີ່ຂົນສົ່ງມືຖື</translation></message>
++    <message>
++        <source>Mobile color-reduced map view with public transport scheme in daylight mode</source>
++        <translation>ແຜນທີ່ມຸມມອງສີຫຼຸດລົງໃນໂທລະສັບມືຖືພ້ອມກັບແຜນການຂົນສົ່ງສາທາລະນະໃນໂຫມດມື້ສວຍສົດ</translation></message>
++    <message>
++        <source>Mobile Gray Street Map</source>
++        <translation>ແຜນທີ່ຖະຫນົນສີເທົາມືຖື</translation></message>
++    <message>
++        <source>Mobile color-reduced map view in daylight mode</source>
++        <translation>ແຜນທີ່ສີຫຼຸດລົງໃນໂທລະສັບມືຖືໃນໂຫມດມື້</translation></message>
++    <message>
++        <source>Custom Street Map</source>
++        <translation>ແຜນທີ່ຖະໜົນທີ່ກຳນົດເອງ</translation></message>
++    <message>
++        <source>Night Street Map</source>
++        <translation>ແຜນທີ່ຖະໜົນຕອນກາງຄືນ</translation></message>
++    <message>
++        <source>Normal map view in night mode</source>
++        <translation>ມຸມມອງແຜນທີ່ປົກກະຕິໃນໂໝດກາງຄືນ</translation></message>
++    <message>
++        <source>Mobile Night Street Map</source>
++        <translation>ແຜນທີ່ຖະຫນົນຕອນກາງຄືນທາງໂທລະສັບມືຖື</translation></message>
++    <message>
++        <source>Mobile normal map view in night mode</source>
++        <translation>ແຜນທີ່ມືຖືໃນຮູບແບບປົກກະຕິໃນໂໝດກາງຄືນ</translation></message>
++    <message>
++        <source>Gray Night Street Map</source>
++        <translation>ແຜນທີ່ຖະຫນົນຕອນກາງຄືນສີເທົາ</translation></message>
++    <message>
++        <source>Color-reduced map view in night mode (especially used for background maps)</source>
++        <translation>ແຜນທີ່ທີ່ຫຼຸດສີໃນໂໝດກາງຄືນ (ໂດຍສະເພາະໃຊ້ສຳລັບແຜນທີ່ພື້ນຫຼັງ)</translation></message>
++    <message>
++        <source>Mobile Gray Night Street Map</source>
++        <translation>ແຜນທີ່ຖະຫນົນຕອນກາງຄືນສີເທົາທີ່ມືຖື</translation></message>
++    <message>
++        <source>Mobile color-reduced map view in night mode (especially used for background maps)</source>
++        <translation>ແຜນທີ່ສີຫຼຸດລົງໃນໂທລະສັບມືຖືໃນໂໝດກາງຄືນ (ໂດຍສະເພາະໃຊ້ສຳລັບແຜນທີ່ພື້ນຫຼັງ)</translation></message>
++    <message>
++        <source>Pedestrian Street Map</source>
++        <translation>ແຜນທີ່ຖະໜົນຍ່ຽວ</translation></message>
++    <message>
++        <source>Pedestrian map view in daylight mode</source>
++        <translation>ແຜນທີ່ຂອງຄົນຍ່າງຖະຫນົນໃນໂຫມດມືດ</translation></message>
++    <message>
++        <source>Mobile Pedestrian Street Map</source>
++        <translation>ແຜນທີ່ຖະຫນົນຫົນທາງສໍາລັບຜູ້ເດີນທາງທາງມືຖື</translation></message>
++    <message>
++        <source>Mobile pedestrian map view in daylight mode for mobile usage</source>
++        <translation>ແຜນທີ່ຂອງຜູ້ເດີນທາງທາງມືຖືໃນໂໝດມື້ສຳລັບການນຳໃຊ້ທາງມືຖື</translation></message>
++    <message>
++        <source>Pedestrian Night Street Map</source>
++        <translation>ແຜນທີ່ຖະຫນົນຍາມກາງຄືນສໍາລັບຜູ້ເດີນທາງ</translation></message>
++    <message>
++        <source>Pedestrian map view in night mode</source>
++        <translation>ແຜນທີ່ຂອງຄົນຍ່າງທາງໃນໂໝດຕອນກາງຄືນ</translation></message>
++    <message>
++        <source>Mobile Pedestrian Night Street Map</source>
++        <translation>ແຜນທີ່ຖະຫນົນຕອນກາງຄືນສໍາລັບຜູ້ເດີນທາງທາງມືຖື</translation></message>
++    <message>
++        <source>Mobile pedestrian map view in night mode for mobile usage</source>
++        <translation>ແຜນທີ່ຂອງຜູ້ເດີນທາງທາງມືຖືໃນໂໝດກາງຄືນສຳລັບການນຳໃຊ້ທາງມືຖື</translation></message>
++    <message>
++        <source>Car Navigation Map</source>
++        <translation>ແຜນທີ່ນຳທາງລົດ</translation></message>
++    <message>
++        <source>Normal map view in daylight mode for car navigation</source>
++        <translation>ມຸມມອງແຜນທີ່ປົກກະຕິໃນໂໝດມື້ສຳລັບການນຳທາງລົດ</translation></message>
++</context>
++<context>
++    <name>QGeoTiledMappingManagerEngineOsm</name>
++    <message>
++        <source>Street Map</source>
++        <translation>ແຜນທີ່ຖະໜົນ</translation></message>
++    <message>
++        <source>Street map view in daylight mode</source>
++        <translation>ແຜນທີ່ຖະໜົນໃນໂໝດມື້ສວຍສົດ</translation></message>
++    <message>
++        <source>Satellite Map</source>
++        <translation>ແຜນທີ່ດາວທຽມ</translation></message>
++    <message>
++        <source>Satellite map view in daylight mode</source>
++        <translation>ແຜນທີ່ດາວທຽມໃນໂໝດມື້</translation></message>
++    <message>
++        <source>Cycle Map</source>
++        <translation>ແຜນທີ່ວົງຈອນ</translation></message>
++    <message>
++        <source>Cycle map view in daylight mode</source>
++        <translation>ແຜນທີ່ວົງຈອນໃນໂໝດມື້ສວັດ</translation></message>
++    <message>
++        <source>Transit Map</source>
++        <translation>ແຜນທີ່ຂົນສົ່ງສາທາລະນະ</translation></message>
++    <message>
++        <source>Public transit map view in daylight mode</source>
++        <translation>ແຜນທີ່ການຂົນສົ່ງສາທາລະນະໃນໂໝດມື້ສວຍສົດ</translation></message>
++    <message>
++        <source>Night Transit Map</source>
++        <translation>ແຜນທີ່ຂົນສົ່ງຕອນກາງຄືນ</translation></message>
++    <message>
++        <source>Public transit map view in night mode</source>
++        <translation>ແຜນທີ່ຂົນສົ່ງສາທາລະນະໃນໂໝດຕອນກາງຄືນ</translation></message>
++    <message>
++        <source>Terrain Map</source>
++        <translation>ແຜນທີ່ພູມສັນຖານ</translation></message>
++    <message>
++        <source>Terrain map view</source>
++        <translation>ມຸມມອງແຜນທີ່ພູມສັນຖານ</translation></message>
++    <message>
++        <source>Hiking Map</source>
++        <translation>ແຜນທີ່ການຍ່າງປ່າ</translation></message>
++    <message>
++        <source>Hiking map view</source>
++        <translation>ມຸມມອງແຜນທີ່ການເດີນປ່າ</translation></message>
++    <message>
++        <source>Custom URL Map</source>
++        <translation>ແຜນທີ່ URL ທີ່ກຳນົດເອງ</translation></message>
++    <message>
++        <source>Custom url map view set via urlprefix parameter</source>
++        <translation>ກຳນົດຊຸດມຸມມອງແຜນທີ່ url ທີ່ກຳນົດເອງຜ່ານພາລາມິເຕີ urlprefix</translation></message>
++</context>
++<context>
++    <name>QPlaceManagerEngineOsm</name>
++    <message>
++        <source>Aeroway</source>
++        <translation>ທາງອາກາດ</translation></message>
++    <message>
++        <source>Amenity</source>
++        <translation>ສິ່ງອຳນວຍຄວາມສະດວກ</translation></message>
++    <message>
++        <source>Building</source>
++        <translation>ກຳລັງກໍ່ສ້າງ</translation></message>
++    <message>
++        <source>Highway</source>
++        <translation>ທາງຫຼວງ</translation></message>
++    <message>
++        <source>Historic</source>
++        <translation>ປະຫວັດສາດ</translation></message>
++    <message>
++        <source>Land use</source>
++        <translation>ການນຳໃຊ້ທີ່ດິນ</translation></message>
++    <message>
++        <source>Leisure</source>
++        <translation>ພັກຜ່ອນ</translation></message>
++    <message>
++        <source>Man made</source>
++        <translation>ມະນຸດສ້າງ</translation></message>
++    <message>
++        <source>Natural</source>
++        <translation>ທຳມະຊາດ</translation></message>
++    <message>
++        <source>Place</source>
++        <translation>ວາງ</translation></message>
++    <message>
++        <source>Railway</source>
++        <translation>ທາງລົດໄຟ</translation></message>
++    <message>
++        <source>Shop</source>
++        <translation>ຮ້ານຄ້າ</translation></message>
++    <message>
++        <source>Tourism</source>
++        <translation>ການທ່ອງທ່ຽວ</translation></message>
++    <message>
++        <source>Waterway</source>
++        <translation>ທາງນໍ້າ</translation></message>
++    <message>
++        <source>Network request error</source>
++        <translation>ຂໍ້ຜິດພາດການຮ້ອງຂໍເຄືອຂ່າຍ</translation></message>
++</context>
++<context>
++    <name>QPlaceSearchReplyMapbox</name>
++    <message>
++        <source>Response parse error</source>
++        <translation>ຜິດພາດການວິເຄາະຕອບຮັບ</translation></message>
++</context>
++<context>
++    <name>QPlaceSearchReplyOsm</name>
++    <message>
++        <source>Response parse error</source>
++        <translation>ຜິດພາດການວິເຄາະຕອບຮັບ</translation></message>
++</context>
++<context>
++    <name>QPlaceSearchSuggestionReplyMapbox</name>
++    <message>
++        <source>Response parse error</source>
++        <translation>ຂໍ້ຜິດພາດໃນການວິເຄາະຕອບຮັບ</translation></message>
++</context>
++<context>
++    <name>QtLocationQML</name>
++    <message>
++        <source>Plugin property is not set.</source>
++        <translation>ຄຸນສົມບັດຂອງ Plugin ບໍ່ໄດ້ຖືກຕັ້ງຄ່າ.</translation></message>
++    <message>
++        <source>Plugin Error (%1): %2</source>
++        <translation>ຜິດພາດ Plugin (%1): %2</translation></message>
++    <message>
++        <source>Plugin Error (%1): Could not instantiate provider</source>
++        <translation>ຜິດພາດ Plugin (%1): ບໍ່ສາມາດສ້າງຜູ້ໃຫ້ບໍລິການໄດ້</translation></message>
++    <message>
++        <source>Plugin is not valid</source>
++        <translation>ປລັກອິນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Unable to initialize categories</source>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນປະເພດໄດ້</translation></message>
++    <message>
++        <source>Unable to create request</source>
++        <translation>ບໍ່ສາມາດສ້າງຄຳຮ້ອງຂໍໄດ້</translation></message>
++    <message>
++        <source>Index '%1' out of range</source>
++        <translation>ດັດສະນີ '%1' ອອກຈາກຂອບເຂດ</translation></message>
++    <message>
++        <source>Qt Location requires app_id and token parameters.
++Please register at https://developer.here.com/ to get your personal application credentials.</source>
++        <translation>Qt Location ຕ້ອງການພາລາມິເຕີ app_id ແລະ token.
++ກະລຸນາລົງທະບຽນທີ່ https://developer.here.com/ ເພື່ອເອົາຂໍ້ມູນຄວາມລັບຂອງແອັບພິເຄຊັນສ່ວນຕົວຂອງທ່ານ.</translation></message>
++    <message>
++        <source>Saving places is not supported.</source>
++        <translation>ບໍ່ສາມາດບັນທຶກສະຖານທີ່ໄດ້.</translation></message>
++    <message>
++        <source>Removing places is not supported.</source>
++        <translation>ການຖອນສະຖານທີ່ບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ.</translation></message>
++    <message>
++        <source>Saving categories is not supported.</source>
++        <translation>ບໍ່ສາມາດບັນທຶກປະເພດໄດ້.</translation></message>
++    <message>
++        <source>Removing categories is not supported.</source>
++        <translation>ການຖອນປະເພດອອກບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ.</translation></message>
++    <message>
++        <source>Error parsing response.</source>
++        <translation>ຜິດພາດໃນການວິເຄາະການຕອບຮັບ.</translation></message>
++    <message>
++        <source>Network error.</source>
++        <translation>ຂໍ້ຜິດພາດເຄືອຂ່າຍ.</translation></message>
++    <message>
++        <source>Request was canceled.</source>
++        <translation>ການຮ້ອງຂໍໄດ້ຖືກຍົກເລີກ.</translation></message>
++    <message>
++        <source>The response from the service was not in a recognizable format.</source>
++        <translation>ການຕອບກັບຈາກບໍລິການບໍ່ໄດ້ຢູ່ໃນຮູບແບບທີ່ຮັບຮູ້ໄດ້.</translation></message>
++</context>
++<context>
++    <name>ReverseGeocodeForm.ui</name>
++    <message>
++        <source />
++        <translation type="unfinished" /></message>
++</context>
++<context>
++    <name>SearchBoundingBoxForm.ui</name>
++    <message>
++        <source />
++        <translation type="unfinished" /></message>
++</context>
++<context>
++    <name>SearchBoundingCircleForm.ui</name>
++    <message>
++        <source />
++        <translation type="unfinished" /></message>
++</context>
++<context>
++    <name>SearchCenterForm.ui</name>
++    <message>
++        <source />
++        <translation type="unfinished" /></message>
++</context>
++<context>
++    <name>SearchOptionsForm.ui</name>
++    <message>
++        <source />
++        <translation type="unfinished" /></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qtmultimedia_lo.ts b/translations/qtmultimedia_lo.ts
+new file mode 100644
+index 0000000..8646135
+--- /dev/null
++++ b/translations/qtmultimedia_lo.ts
+@@ -0,0 +1,404 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>AudioContainerControl</name>
++    <message>
++        <source>RAW (headerless) file format</source>
++        <translation>ຮູບແບບໄຟລ໌ RAW (ບໍ່ມີຫົວ)</translation></message>
++    <message>
++        <source>WAV file format</source>
++        <translation>ຮູບແບບໄຟລ໌ WAV</translation></message>
++</context>
++<context>
++    <name>AudioEncoderControl</name>
++    <message>
++        <source>Linear PCM audio data</source>
++        <translation>ຂໍ້ມູນສຽງ Linear PCM</translation></message>
++</context>
++<context>
++    <name>CameraBinImageCapture</name>
++    <message>
++        <source>Camera not ready</source>
++        <translation>ກ້ອງຖ່າຍຮູບບໍ່ພ້ອມ</translation></message>
++</context>
++<context>
++    <name>CameraBinImageEncoder</name>
++    <message>
++        <source>JPEG image</source>
++        <translation>ຮູບພາບ JPEG</translation></message>
++</context>
++<context>
++    <name>CameraBinRecorder</name>
++    <message>
++        <source>QMediaRecorder::pause() is not supported by camerabin2.</source>
++        <translation>QMediaRecorder::pause() ບໍ່ຖືກສະຫນັບສະຫນູນໂດຍ camerabin2.</translation></message>
++    <message>
++        <source>Service has not been started</source>
++        <translation>ບໍລິການຍັງບໍ່ໄດ້ເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Recording permissions are not available</source>
++        <translation>ການອະນຸຍາດການບັນທຶກບໍ່ມີ</translation></message>
++</context>
++<context>
++    <name>CameraBinSession</name>
++    <message>
++        <source>Camera error</source>
++        <translation>ຜິດພາດກ້ອງຖ່າຍຮູບ</translation></message>
++</context>
++<context>
++    <name>DSCameraSession</name>
++    <message>
++        <source>Failed to configure preview format</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າຮູບແບບການເບິ່ງລ່ວງໜ້າໄດ້</translation></message>
++    <message>
++        <source>Failed to connect graph</source>
++        <translatorcomment>graph 是一个特定单词，应该指向的是相机图像信息的“直方图”图表。结合后面的 filter graph，更加明显是直方图。滤镜是非图形的，它们一般都是通过调整直方图曲线来实现对图像的处理。</translatorcomment>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ກຣາຟໄດ້</translation></message>
++    <message>
++        <source>Failed to get stream control</source>
++        <translation>ບໍ່ສາມາດເອົາການຄວບຄຸມສະຕຣີມໄດ້</translation></message>
++    <message>
++        <source>Failed to start</source>
++        <translation>ບໍ່ສາມາດເລີ່ມຕົ້ນໄດ້</translation></message>
++    <message>
++        <source>Failed to stop</source>
++        <translation>ບໍ່ສາມາດຢຸດໄດ້</translation></message>
++    <message>
++        <source>Camera not ready for capture</source>
++        <translation>ກ້ອງຖ່າຍຮູບບໍ່ພ້ອມສຳລັບການຖ່າຍຮູບ</translation></message>
++    <message>
++        <source>Could not save image to file.</source>
++        <translation>ບໍ່ສາມາດບັນທຶກຮູບພາບໄປຍັງໄຟລ໌ໄດ້.</translation></message>
++    <message>
++        <source>Failed to create filter graph</source>
++        <translatorcomment>此为相机语境。在此语境中 filter 几乎肯定意味着“滤镜”。滤镜是非图形的，它们一般都是通过调整直方图曲线来实现对图像的处理。因为直方图就是图表，因此此处就应该翻译为“滤镜图表”。</translatorcomment>
++        <translation>ບໍ່ສາມາດສ້າງກຣາຟຕົວກອງ</translation></message>
++    <message>
++        <source>Failed to create graph builder</source>
++        <translatorcomment>这是相机语境。且上下文有 filter，在此语境中 filter 几乎肯定意味着“滤镜”。滤镜是非图形的，它们一般都是通过调整直方图曲线来实现对图像的处理。因为直方图就是图表，因此此处就应该翻译为“图表”。</translatorcomment>
++        <translation>ບໍ່ສາມາດສ້າງຕົວສ້າງເສັ້ນສະແດງໄດ້</translation></message>
++    <message>
++        <source>Failed to connect capture graph and filter graph</source>
++        <translatorcomment>结合前面几项理解，capture graph 就是捕获图像的直方图，而filter graph 就是滤镜的直方图。它们均属于图表。</translatorcomment>
++        <translation>ບໍ່ສາມາດເຊື່ອມຕໍ່ກຣາຟການຈັບການ ແລະ ກຣາຟຕົວກອງ</translation></message>
++    <message>
++        <source>No capture device found</source>
++        <translation>ບໍ່ພົບອຸປະກອນຈັບສັນຍານ</translation></message>
++    <message>
++        <source>Failed to create null renderer</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວເລືອກສະແດງຜົນ null ໄດ້</translation></message>
++</context>
++<context>
++    <name>MFPlayerSession</name>
++    <message>
++        <source>Invalid stream source.</source>
++        <translation>ແຫຼ່ງສະຕຣີມບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Attempting to play invalid Qt resource.</source>
++        <translation>ພະຍາຍາມຫຼິ້ນຊັບພະຍາກອນ Qt ທີ່ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>The system cannot find the file specified.</source>
++        <translation>ລະບົບບໍ່ສາມາດຊອກຫາໄຟລ໌ທີ່ລະບຸໄວ້ໄດ້.</translation></message>
++    <message>
++        <source>The specified server could not be found.</source>
++        <translation>ເຊີບເວີທີ່ກຳນົດໄວ້ບໍ່ສາມາດພົບເຫັນໄດ້.</translation></message>
++    <message>
++        <source>Unsupported media type.</source>
++        <translation>ປະເພດສື່ບໍ່ຮອງຮັບ.</translation></message>
++    <message>
++        <source>Failed to load source.</source>
++        <translation>ບໍ່ສາມາດໂຫຼດແຫຼ່ງຂໍ້ມູນໄດ້</translation></message>
++    <message>
++        <source>Cannot create presentation descriptor.</source>
++        <translation>ບໍ່ສາມາດສ້າງລາຍລະອຽດຂອງການນຳສະເໜີໄດ້.</translation></message>
++    <message>
++        <source>Failed to get stream count.</source>
++        <translation>ບໍ່ສາມາດເກັບຈຳນວນສະຕຣີມໄດ້.</translation></message>
++    <message>
++        <source>Failed to create topology.</source>
++        <translation>ບໍ່ສາມາດສ້າງໂທໂປໂລຍີໄດ້.</translation></message>
++    <message>
++        <source>Unable to play any stream.</source>
++        <translation>ບໍ່ສາມາດຫຼິ້ນສະຕຣີມໃດໆໄດ້.</translation></message>
++    <message>
++        <source>Unable to play.</source>
++        <translation>ບໍ່ສາມາດຫຼິ້ນໄດ້.</translation></message>
++    <message>
++        <source>Failed to set topology.</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄ່າ topology ໄດ້.</translation></message>
++    <message>
++        <source>Unknown stream type.</source>
++        <translation>ປະເພດສະຕຣີມທີ່ບໍ່ຮູ້ຈັກ.</translation></message>
++    <message>
++        <source>Failed to stop.</source>
++        <translation>ບໍ່ສາມາດຢຸດໄດ້.</translation></message>
++    <message>
++        <source>failed to start playback</source>
++        <translation>ບໍ່ສາມາດເລີ່ມການຫຼິ້ນໄດ້</translation></message>
++    <message>
++        <source>Failed to pause.</source>
++        <translation>ບໍ່ສາມາດຢຸດຊົ່ວຄາວໄດ້.</translation></message>
++    <message>
++        <source>Unable to create mediasession.</source>
++        <translation>ບໍ່ສາມາດສ້າງ mediasession ໄດ້.</translation></message>
++    <message>
++        <source>Unable to pull session events.</source>
++        <translation>ບໍ່ສາມາດດຶງເອົາກິດຈະກໍາຂອງຊິດຊັ່ນໄດ້.</translation></message>
++    <message>
++        <source>Failed to seek.</source>
++        <translation>ບໍ່ສາມາດຊອກຫາໄດ້.</translation></message>
++    <message>
++        <source>Media session non-fatal error.</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮ້າຍແຮງຂອງການເຊື່ອມຕໍ່ສື່.</translation></message>
++    <message>
++        <source>Media session serious error.</source>
++        <translation>ຂໍ້ຜິດພາດຮ້າຍແຮງໃນການເຊື່ອມຕໍ່ສື່.</translation></message>
++    <message>
++        <source>Unsupported media, a codec is missing.</source>
++        <translation>ສື່ທີ່ບໍ່ຮອງຮັບ, ຂາດ codec.</translation></message>
++</context>
++<context>
++    <name>QAndroidAudioEncoderSettingsControl</name>
++    <message>
++        <source>Adaptive Multi-Rate Narrowband (AMR-NB) audio codec</source>
++        <translation>ລະຫັດເຄື່ອງສຽງ Adaptive Multi-Rate Narrowband (AMR-NB)</translation></message>
++    <message>
++        <source>Adaptive Multi-Rate Wideband (AMR-WB) audio codec</source>
++        <translation>ລະຫັດເຄື່ອງມືສຽງ Adaptive Multi-Rate Wideband (AMR-WB)</translation></message>
++    <message>
++        <source>AAC Low Complexity (AAC-LC) audio codec</source>
++        <translation>AAC ຄວາມສັບຊ້ອນຕ່ຳ (AAC-LC) ລະຫັດສຽງ</translation></message>
++</context>
++<context>
++    <name>QAndroidCameraSession</name>
++    <message>
++        <source>Camera not ready</source>
++        <translation>ກ້ອງຖ່າຍຮູບບໍ່ພ້ອມ</translation></message>
++    <message>
++        <source>Drive mode not supported</source>
++        <extracomment>Drive mode is the camera's shutter mode, for example single shot, continuos exposure, etc.</extracomment>
++        <translation>ໂໝດຂັບລົດບໍ່ຖືກຮອງຮັບ</translation></message>
++    <message>
++        <source>Failed to capture image</source>
++        <translation>ບໍ່ສາມາດຖ່າຍຮູບໄດ້</translation></message>
++    <message>
++        <source>Camera preview failed to start.</source>
++        <translation>ການສະແດງຕົວຢ່າງກ້ອງຖ່າຍຮູບລົ້ມເຫລວໃນການເລີ່ມຕົ້ນ.</translation></message>
++    <message>
++        <source>Could not open destination file: %1</source>
++        <translation>ບໍ່ສາມາດເປີດໄຟລ໌ປາຍທາງ: %1</translation></message>
++</context>
++<context>
++    <name>QAndroidImageEncoderControl</name>
++    <message>
++        <source>JPEG image</source>
++        <translation>ຮູບພາບ JPEG</translation></message>
++</context>
++<context>
++    <name>QAndroidMediaContainerControl</name>
++    <message>
++        <source>MPEG4 media file format</source>
++        <translation>ຮູບແບບໄຟລ໌ສື່ MPEG4</translation></message>
++    <message>
++        <source>3GPP media file format</source>
++        <translation>ຮູບແບບໄຟລ໌ສື່ 3GPP</translation></message>
++    <message>
++        <source>AMR NB file format</source>
++        <translation>ຮູບແບບໄຟລ໌ AMR NB</translation></message>
++    <message>
++        <source>AMR WB file format</source>
++        <translation>ຮູບແບບໄຟລ໌ AMR WB</translation></message>
++</context>
++<context>
++    <name>QAndroidVideoEncoderSettingsControl</name>
++    <message>
++        <source>H.263 compression</source>
++        <translation>ການບີບອັດ H.263</translation></message>
++    <message>
++        <source>H.264 compression</source>
++        <translation>ການບີບອັດ H.264</translation></message>
++    <message>
++        <source>MPEG-4 SP compression</source>
++        <translation>ການບີບອັດ MPEG-4 SP</translation></message>
++</context>
++<context>
++    <name>QAudioDecoder</name>
++    <message>
++        <source>The QAudioDecoder object does not have a valid service</source>
++        <translation>ວັດຖຸ QAudioDecoder ບໍ່ມີບໍລິການທີ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QCamera</name>
++    <message>
++        <source>The camera service is missing</source>
++        <translation>ການບໍລິການກ້ອງຖ່າຍຮູບບໍ່ມີ</translation></message>
++</context>
++<context>
++    <name>QCameraImageCapture</name>
++    <message>
++        <source>Device does not support images capture.</source>
++        <translation>ອຸປະກອນບໍ່ຮອງຮັບການຈັບຮູບພາບ.</translation></message>
++</context>
++<context>
++    <name>QDeclarativeAudio</name>
++    <message>
++        <source>volume should be between 0.0 and 1.0</source>
++        <translation>ລະດັບສຽງຄວນຢູ່ລະຫວ່າງ 0.0 ແລະ 1.0</translation></message>
++</context>
++<context>
++    <name>QGstreamerAudioDecoderSession</name>
++    <message>
++        <source>Cannot play stream of type: &lt;unknown&gt;</source>
++        <translation>ບໍ່ສາມາດຫຼິ້ນສະຕຣີມປະເພດ: &lt;unknown&gt;</translation></message>
++</context>
++<context>
++    <name>QGstreamerAudioInputSelector</name>
++    <message>
++        <source>System default device</source>
++        <translation>ອຸປະກອນເລີ່ມຕົ້ນຂອງລະບົບ</translation></message>
++</context>
++<context>
++    <name>QGstreamerCameraControl</name>
++    <message>
++        <source>State not supported.</source>
++        <translation>ສະຖານະບໍ່ຖືກຮັບຮອງ.</translation></message>
++</context>
++<context>
++    <name>QGstreamerCaptureSession</name>
++    <message>
++        <source>Could not create an audio source element</source>
++        <translation>ບໍ່ສາມາດສ້າງອົງປະກອບແຫຼ່ງສຽງໄດ້</translation></message>
++    <message>
++        <source>Failed to build media capture pipeline.</source>
++        <translation>ບໍ່ສາມາດສ້າງທໍ່ຈັບສື່ມວນສຶກສາໄດ້.</translation></message>
++</context>
++<context>
++    <name>QGstreamerImageCaptureControl</name>
++    <message>
++        <source>Not ready to capture</source>
++        <translation>ຍັງບໍ່ພ້ອມທີ່ຈະບັນທຶກ</translation></message>
++</context>
++<context>
++    <name>QGstreamerImageEncode</name>
++    <message>
++        <source>JPEG image encoder</source>
++        <translation>ຕົວເຂົ້າລະຫັດຮູບພາບ JPEG</translation></message>
++</context>
++<context>
++    <name>QGstreamerPlayerControl</name>
++    <message>
++        <source>Attempting to play invalid user stream</source>
++        <translation>ພະຍາຍາມຫຼິ້ນສະຕຣີມຜູ້ໃຊ້ທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QGstreamerPlayerSession</name>
++    <message>
++        <source>Cannot play stream of type: &lt;unknown&gt;</source>
++        <translation>ບໍ່ສາມາດຫຼິ້ນສະຕຣີມປະເພດ: &lt;unknown&gt;</translation></message>
++    <message>
++        <source>UDP source timeout</source>
++        <translation>ໄທມເອທຂອງແຫຼ່ງ UDP</translation></message>
++</context>
++<context>
++    <name>QGstreamerRecorderControl</name>
++    <message>
++        <source>Service has not been started</source>
++        <translation>ບໍລິການຍັງບໍ່ໄດ້ເລີ່ມຕົ້ນ</translation></message>
++    <message>
++        <source>Not compatible codecs and container format.</source>
++        <translation>ລະຫັດແລະຮູບແບບພາຊະນະບໍ່ສາມາດໃຊ້ຮ່ວມກັນໄດ້.</translation></message>
++</context>
++<context>
++    <name>QGstreamerVideoInputDeviceControl</name>
++    <message>
++        <source>Main camera</source>
++        <translation>ກ້ອງຖ່າຍຮູບຫຼັກ</translation></message>
++    <message>
++        <source>Front camera</source>
++        <translation>ກ້ອງຫນ້າ</translation></message>
++</context>
++<context>
++    <name>QMediaPlayer</name>
++    <message>
++        <source>Attempting to play invalid Qt resource</source>
++        <translation>ພະຍາຍາມຫຼີ້ນຊັບພະຍາກອນ Qt ທີ່ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>The QMediaPlayer object does not have a valid service</source>
++        <translation>ວັດຖຸ QMediaPlayer ບໍ່ມີບໍລິການທີ່ຖືກຕ້ອງ</translation></message>
++</context>
++<context>
++    <name>QMediaPlaylist</name>
++    <message>
++        <source>Could not add items to read only playlist.</source>
++        <translation>ບໍ່ສາມາດເພີ່ມລາຍການເຂົ້າໃນລາຍການຮັບຟັງທີ່ອ່ານໄດ້ຢ່າງດຽວ.</translation></message>
++    <message>
++        <source>Playlist format is not supported</source>
++        <translation>ຮູບແບບລາຍການສຽງບໍ່ຖືກຮັບຮອງ</translation></message>
++    <message>
++        <source>The file could not be accessed.</source>
++        <translation>ຟາຍບໍ່ສາມາດເຂົ້າເຖິງໄດ້.</translation></message>
++    <message>
++        <source>Playlist format is not supported.</source>
++        <translation>ຮູບແບບລາຍການສຽງບໍ່ຖືກຮັບຮອງເອົາ.</translation></message>
++</context>
++<context>
++    <name>QMultimediaDeclarativeModule</name>
++    <message>
++        <source>CameraCapture is provided by Camera</source>
++        <translation>CameraCapture ຖືກສະໜອງໂດຍ Camera</translation></message>
++    <message>
++        <source>CameraRecorder is provided by Camera</source>
++        <translation>CameraRecorder ຖືກສະ​ໜອງ​ໂດຍ Camera</translation></message>
++    <message>
++        <source>CameraExposure is provided by Camera</source>
++        <translation>CameraExposure ແມ່ນຖືກສະໜອງໂດຍ Camera</translation></message>
++    <message>
++        <source>CameraFocus is provided by Camera</source>
++        <translation>CameraFocus ຖືກສະໜອງໂດຍ Camera</translation></message>
++    <message>
++        <source>CameraFlash is provided by Camera</source>
++        <translation>CameraFlash ແມ່ນຖືກສະໜອງໂດຍ Camera</translation></message>
++    <message>
++        <source>CameraImageProcessing is provided by Camera</source>
++        <translation>CameraImageProcessing ຖືກສະໜອງໂດຍ Camera</translation></message>
++    <message>
++        <source>CameraViewfinder is provided by Camera</source>
++        <translation>ກ້ອງຖ່າຍຮູບຖືກສະໜອງໂດຍກ້ອງຖ່າຍຮູບ</translation></message>
++</context>
++<context>
++    <name>QPlaylistFileParser</name>
++    <message>
++        <source>%1 playlist type is unknown</source>
++        <translation>%1 ປະເພດລາຍການເພງບໍ່ຮູ້ຈັກ</translation></message>
++    <message>
++        <source>invalid line in playlist file</source>
++        <translation>ແຖວບໍ່ຖືກຕ້ອງໃນໄຟລ໌ລາຍການເພງ</translation></message>
++    <message>
++        <source>Invalid stream</source>
++        <translation>ສະຕຣີມບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>%1 does not exist</source>
++        <translation>%1 ບໍ່ມີຢູ່</translation></message>
++    <message>
++        <source>Empty file provided</source>
++        <translation>ໃຫ້ໄຟລ໌ຫວ່າງເປົ່າ</translation></message>
++</context>
++<context>
++    <name>QWinRTCameraImageCaptureControl</name>
++    <message>
++        <source>Camera not ready</source>
++        <translation>ກ້ອງຖ່າຍຮູບບໍ່ພ້ອມ</translation></message>
++    <message>
++        <source>Invalid photo data length.</source>
++        <translation>ຂໍ້ມູນຮູບພາບບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Image saving failed</source>
++        <translation>ບໍ່ສາມາດບັນທຶກຮູບພາບໄດ້</translation></message>
++</context>
++<context>
++    <name>QWinRTImageEncoderControl</name>
++    <message>
++        <source>JPEG image</source>
++        <translation>ຮູບພາບ JPEG</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qtserialport_lo.ts b/translations/qtserialport_lo.ts
+new file mode 100644
+index 0000000..8b32e5d
+--- /dev/null
++++ b/translations/qtserialport_lo.ts
+@@ -0,0 +1,54 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>QSerialPort</name>
++    <message>
++        <source>Device is already open</source>
++        <translation>ອຸປະກອນໄດ້ເປີດຢູ່ແລ້ວ</translation></message>
++    <message>
++        <source>Unsupported open mode</source>
++        <translation>ໂໝດເປີດບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>Device is not open</source>
++        <translation>ອຸປະກອນບໍ່ໄດ້ເປີດ</translation></message>
++    <message>
++        <source>Permission error while creating lock file</source>
++        <translation>ຂໍ້ຜິດພາດການອະນຸຍາດໃນຂະນະສ້າງໄຟລ໌ລັອກ</translation></message>
++    <message>
++        <source>Permission error while locking the device</source>
++        <translation>ຂໍ້ຜິດພາດການອະນຸຍາດໃນຂະນະທີ່ລັອກອຸປະກອນ</translation></message>
++    <message>
++        <source>Cannot set custom speed for one direction</source>
++        <translation>ບໍ່ສາມາດຕັ້ງຄວາມໄວທີ່ກຳນົດເອງສຳລັບທິດທາງດຽວໄດ້</translation></message>
++    <message>
++        <source>No suitable custom baud rate divisor</source>
++        <translation>ບໍ່ມີຕົວຫານອັດຕາບອດທີ່ເໝາະສົມ</translation></message>
++    <message>
++        <source>Custom baud rate is not supported</source>
++        <translation>ອັດຕາການສົ່ງຂໍ້ມູນທີ່ກຳນົດເອງບໍ່ຖືກຮອງຮັບ</translation></message>
++    <message>
++        <source>Invalid baud rate value</source>
++        <translation>ຄ່າອັດຕາການສົ່ງຂໍ້ມູນບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>Operation timed out</source>
++        <translation>ການດຳເນີນງານໝົດເວລາ</translation></message>
++    <message>
++        <source>Custom baud rate direction is unsupported</source>
++        <translation>ທິດທາງອັດຕາບອດທີ່ກຳນົດເອງບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>No error</source>
++        <translation>ບໍ່ມີຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>Error reading from device</source>
++        <translation>ຜິດພາດໃນການອ່ານຈາກອຸປະກອນ</translation></message>
++    <message>
++        <source>Error writing to device</source>
++        <translation>ຜິດພາດໃນການຂຽນຂໍ້ມູນໄປຫາອຸປະກອນ</translation></message>
++    <message>
++        <source>Device disappeared from the system</source>
++        <translation>ອຸປະກອນຫາຍໄປຈາກລະບົບ</translation></message>
++    <message>
++        <source>The device supports only the ignoring policy</source>
++        <translation>ອຸປະກອນສະໜັບສະໜູນແຕ່ນະໂຍບາຍການລະເລີຍເທົ່ານັ້ນ</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qtwebengine_lo.ts b/translations/qtwebengine_lo.ts
+new file mode 100644
+index 0000000..86ea1b8
+--- /dev/null
++++ b/translations/qtwebengine_lo.ts
+@@ -0,0 +1,357 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>DownloadInterruptReason</name>
++    <message>
++        <source>Unknown reason or not interrupted</source>
++        <translation>ເຫດຜົນທີ່ບໍ່ຮູ້ຫຼືບໍ່ຖືກຂັດຂວາງ</translation></message>
++    <message>
++        <source>General file operation failure</source>
++        <translation>ຄວາມລົ້ມເຫຼວຂອງການດຳເນີນການໄຟລ໌ທົ່ວໄປ</translation></message>
++    <message>
++        <source>The file cannot be written locally, due to access restrictions</source>
++        <translation>ຟາຍບໍ່ສາມາດຂຽນທ້ອງຖິ່ນໄດ້, ເນື່ອງຈາກຂໍ້ຈຳກັດການເຂົ້າເຖິງ</translation></message>
++    <message>
++        <source>Insufficient space on the target drive</source>
++        <translation>ບໍ່ພຽງພໍບ່ອນໃນໄຟລ໌ເປົ້າຫມາຍ</translation></message>
++    <message>
++        <source>The directory or file name is too long</source>
++        <translation>ຊື່ໄດເລັກທໍລີ ຫຼື ໄຟລ໌ຍາວເກີນໄປ</translation></message>
++    <message>
++        <source>The file size exceeds the file system limitation</source>
++        <translation>ຂະໜາດໄຟລ໌ເກີນຂອບເຂດຈຳກັດຂອງລະບົບໄຟລ໌</translation></message>
++    <message>
++        <source>The file is infected with a virus</source>
++        <translation>ໄຟລ໌ຖືກຕິດເຊື້ອວິຣັດ</translation></message>
++    <message>
++        <source>Temporary problem (for example file in use, or too many open files)</source>
++        <translation>ບັນຫາຊົ່ວຄາວ (ຕົວຢ່າງ ໄຟລ໌ກຳລັງໃຊ້ຢູ່, ຫຼື ໄຟລ໌ເປີດຢູ່ຫຼາຍເກີນໄປ)</translation></message>
++    <message>
++        <source>The file was blocked due to local policy</source>
++        <translation>ໄຟລ໌ຖືກບລັອກເນື່ອງຈາກນະໂຍບາຍທ້ອງຖິ່ນ</translation></message>
++    <message>
++        <source>Checking the safety of the download failed due to unexpected reasons</source>
++        <translation>ການກວດສອບຄວາມປອດໄພຂອງການດາວໂຫຼດລົ້ມເຫຼວເນື່ອງຈາກເຫດຜົນທີ່ບໍ່ຄາດຄິດ</translation></message>
++    <message>
++        <source>File seek past the end of a file (resuming previously interrupted download)</source>
++        <translation>ຄົ້ນຫາໄຟລ໌ຜ່ານຕອນທ້າຍຂອງໄຟລ໌ (ດຳເນີນການດາວໂຫຼດທີ່ຖືກຂັດຂວາງກ່ອນໜ້ານີ້ຕໍ່)</translation></message>
++    <message>
++        <source>The partial file did not match the expected hash</source>
++        <translation>ໄຟລ໌ບາງສ່ວນບໍ່ກົງກັບຮາຊທີ່ຄາດໄວ້</translation></message>
++    <message>
++        <source>General network failure</source>
++        <translation>ຄວາມລົ້ມເຫຼວຂອງເຄືອຂ່າຍທົ່ວໄປ</translation></message>
++    <message>
++        <source>The network operation has timed out</source>
++        <translation>ການດໍາເນີນງານເຄືອຂ່າຍໄດ້ໝົດເວລາ</translation></message>
++    <message>
++        <source>The network connection has been terminated</source>
++        <translation>ການເຊື່ອມຕໍ່ເຄືອຂ່າຍໄດ້ຖືກຢຸດແລ້ວ</translation></message>
++    <message>
++        <source>The server has gone down</source>
++        <translation>ເຊີບເວີລົງແລ້ວ</translation></message>
++    <message>
++        <source>The network request was invalid (for example, the URL or scheme is invalid)</source>
++        <translation>ການຮ້ອງຂໍເຄືອຂ່າຍບໍ່ຖືກຕ້ອງ (ຕົວຢ່າງ, URL ຫຼືໂຄງການບໍ່ຖືກຕ້ອງ)</translation></message>
++    <message>
++        <source>General server failure</source>
++        <translation>ຄວາມລົ້ມເຫຼວຂອງເຊີບເວີທົ່ວໄປ</translation></message>
++    <message>
++        <source>The server does not have the requested data</source>
++        <translation>ເຊີບເວີບໍ່ມີຂໍ້ມູນທີ່ຮ້ອງຂໍ</translation></message>
++    <message>
++        <source>The server did not authorize access to the resource</source>
++        <translation>ເຊີບເວີບໍ່ໄດ້ອະນຸຍາດການເຂົ້າເຖິງຊັບພະຍາກອນ</translation></message>
++    <message>
++        <source>A problem with the server certificate occurred</source>
++        <translation>ມີບັນຫາກັບໃບຢັ້ງຢືນເຊີບເວີ</translation></message>
++    <message>
++        <source>Access forbidden by the server</source>
++        <translation>ເຂົ້າເຖິງຖືກຫ້າມໂດຍເຊີບເວີ</translation></message>
++    <message>
++        <source>Unexpected server response</source>
++        <translation>ການຕອບສະຫນອງຈາກເຊີບເວີທີ່ບໍ່ຄາດຄິດ</translation></message>
++    <message>
++        <source>Download canceled by the user</source>
++        <translation>ດາວໂຫຼດຖືກຍົກເລີກໂດຍຜູ້ໃຊ້</translation></message>
++</context>
++<context>
++    <name>QQuickPdfDocument</name>
++    <message>
++        <source>no error</source>
++        <translation>ບໍ່ມີຂໍ້ຜິດພາດ</translation></message>
++    <message>
++        <source>data not yet available</source>
++        <translation>ຂໍ້ມູນຍັງບໍ່ມີ</translation></message>
++    <message>
++        <source>file not found</source>
++        <translation>ບໍ່ພົບໄຟລ໌</translation></message>
++    <message>
++        <source>invalid file format</source>
++        <translation>ຮູບແບບໄຟລ໌ບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>incorrect password</source>
++        <translation>ລະຫັດຜ່ານບໍ່ຖືກຕ້ອງ</translation></message>
++    <message>
++        <source>unsupported security scheme</source>
++        <translation>ລະບົບຄວາມປອດໄພທີ່ບໍ່ຮອງຮັບ</translation></message>
++    <message>
++        <source>unknown error</source>
++        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້ຈັກ</translation></message>
++</context>
++<context>
++    <name>QQuickWebEngineView</name>
++    <message>
++        <source>Stop</source>
++        <translation>ຢຸດ</translation></message>
++    <message>
++        <source>Reload and Bypass Cache</source>
++        <translation>ໂຫຼດຄືນໃໝ່ ແລະ ຂ້າມຄັງ</translation></message>
++    <message>
++        <source>Open link in this window</source>
++        <translation>ເປີດລິງໃນປ່ອງຢ້ຽມນີ້</translation></message>
++    <message>
++        <source>Toggle Play/Pause</source>
++        <translation>ປ່ຽນການຫຼິ້ນ/ຢຸດຊົ່ວຄາວ</translation></message>
++    <message>
++        <source>Toggle Mute</source>
++        <translation>ປິດ/ເປີດສຽງ</translation></message>
++    <message>
++        <source>Close Page</source>
++        <translation>ປິດໜ້າ</translation></message>
++    <message>
++        <source>Unselect</source>
++        <translation>ຍົກເລີກການເລືອກ</translation></message>
++    <message>
++        <source>&amp;Bold</source>
++        <translation>&amp;&lt;b&gt;ໂຕໜາ&lt;/b&gt;</translation></message>
++    <message>
++        <source>&amp;Italic</source>
++        <translation>&lt;ຕົວເລືອກ&gt;</translation></message>
++    <message>
++        <source>&amp;Underline</source>
++        <translation>&amp;lt;ຂີດສະແດງພາຍໃຕ້&amp;gt;</translation></message>
++    <message>
++        <source>&amp;Strikethrough</source>
++        <translation>&amp;ຂີດຂ້າມ</translation></message>
++    <message>
++        <source>Align &amp;Left</source>
++        <translation>ຈັດຕຳແໜ່ງ &amp;ຊ້າຍ</translation></message>
++    <message>
++        <source>Align &amp;Center</source>
++        <translation>ຈັດຕຳແໜ່ງ &amp;ກາງ</translation></message>
++    <message>
++        <source>Align &amp;Right</source>
++        <translation>ຈັດຕຳແໜ່ງ &amp;ຂວາ</translation></message>
++    <message>
++        <source>Align &amp;Justified</source>
++        <translation>ຈັດຕົວອັກສອນ &amp;ຊື່ຊາຍ</translation></message>
++    <message>
++        <source>&amp;Indent</source>
++        <translation>&amp;ຍົກເລີກ</translation></message>
++    <message>
++        <source>&amp;Outdent</source>
++        <translation>&amp;ຫຼຸດການຍົກເວັ້ນ</translation></message>
++    <message>
++        <source>Insert &amp;Ordered List</source>
++        <translation>ໃສ່ &amp;ລາຍການທີ່ຈັດລຽງ</translation></message>
++    <message>
++        <source>Insert &amp;Unordered List</source>
++        <translation>ໃສ່ &amp;ລາຍການທີ່ບໍ່ມີລຳດັບ</translation></message>
++</context>
++<context>
++    <name>QWebEnginePage</name>
++    <message>
++        <source>Stop</source>
++        <translation>ຢຸດ</translation></message>
++    <message>
++        <source>Reload and Bypass Cache</source>
++        <translation>ໂຫຼດຄືນໃໝ່ ແລະ ຂ້າມຄັງ</translation></message>
++    <message>
++        <source>Toggle Play/Pause</source>
++        <translation>ປ່ຽນການຫຼິ້ນ/ຢຸດຊົ່ວຄາວ</translation></message>
++    <message>
++        <source>Toggle Mute</source>
++        <translation>ປິດ/ເປີດສຽງ</translation></message>
++    <message>
++        <source>Close Page</source>
++        <translation>ປິດໜ້າ</translation></message>
++    <message>
++        <source>Unselect</source>
++        <translation>ຍົກເລີກການເລືອກ</translation></message>
++    <message>
++        <source>Are you sure you want to leave this page? Changes that you made may not be saved.</source>
++        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການອອກຈາກໜ້ານີ້? ການປ່ຽນແປງທີ່ທ່ານໄດ້ເຮັດອາດຈະບໍ່ຖືກບັນທຶກ.</translation></message>
++    <message>
++        <source>Open link in this window</source>
++        <translation>ເປີດລິ້ງໃນປ່ອງຢ້ຽມນີ້</translation></message>
++    <message>
++        <source>Open link in new background tab</source>
++        <translation>ເປີດລິ້ງໃນແທັບພື້ນຫຼັງໃໝ່</translation></message>
++    <message>
++        <source>&amp;Bold</source>
++        <translation>&amp;&lt;b&gt;ໂຕໜາ&lt;/b&gt;</translation></message>
++    <message>
++        <source>&amp;Italic</source>
++        <translation>&amp;lt;ຕົວເລກ&amp;gt;</translation></message>
++    <message>
++        <source>&amp;Underline</source>
++        <translation>&amp;lt;ຂີດສະແດງພາຍໃຕ້&amp;gt;</translation></message>
++    <message>
++        <source>&amp;Strikethrough</source>
++        <translation>&amp;ຂີດຂ້າມ</translation></message>
++    <message>
++        <source>Align &amp;Left</source>
++        <translation>ຈັດຕຳແໜ່ງ &amp;ຊ້າຍ</translation></message>
++    <message>
++        <source>Align &amp;Center</source>
++        <translation>ຈັດຕຳແໜ່ງ &amp;ກາງ</translation></message>
++    <message>
++        <source>Align &amp;Right</source>
++        <translation>ຈັດຕຳແໜ່ງ &amp;ຂວາ</translation></message>
++    <message>
++        <source>Align &amp;Justified</source>
++        <translation>ຈັດຕົວອັກສອນ &amp;ຊື່ຊາຍ</translation></message>
++    <message>
++        <source>&amp;Indent</source>
++        <translation>&amp;ຍົກເລີກ</translation></message>
++    <message>
++        <source>&amp;Outdent</source>
++        <translation>&amp;ຫຼຸດຊ່ອງຫວ່າງ</translation></message>
++    <message>
++        <source>Insert &amp;Ordered List</source>
++        <translation>ໃສ່ &amp;ລາຍການທີ່ຈັດລຽງ</translation></message>
++    <message>
++        <source>Insert &amp;Unordered List</source>
++        <translation>ໃສ່ &amp;ລາຍການທີ່ບໍ່ມີລຳດັບ</translation></message>
++    <message>
++        <source>Select folder to upload</source>
++        <translation>ເລືອກໂຟນເດີເພື່ອອັບໂຫຼດ</translation></message>
++</context>
++<context>
++    <name>QtWebEnginePlugin</name>
++    <message>
++        <source>Cannot create separate instance of WebEngineNewViewRequest</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງແຍກຕ່າງຫາກຂອງ WebEngineNewViewRequest</translation></message>
++    <message>
++        <source>Cannot create separate instance of %1</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງແຍກຕ່າງຫາກຂອງ %1</translation></message>
++</context>
++<context>
++    <name>QtWebEngineTestSupportPlugin</name>
++    <message>
++        <source>Cannot create a separate instance of WebEngineErrorPage</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງແຍກຕ່າງຫາກຂອງ WebEngineErrorPage</translation></message>
++    <message>
++        <source>Cannot create a separate instance of WebEngineTestEvent</source>
++        <translation>ບໍ່ສາມາດສ້າງຕົວຢ່າງແຍກຕ່າງຫາກຂອງ WebEngineTestEvent</translation></message>
++</context>
++<context>
++    <name>RenderViewContextMenuQt</name>
++    <message>
++        <source>Back</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Forward</source>
++        <translation>ສົ່ງຕໍ່</translation></message>
++    <message>
++        <source>Reload</source>
++        <translation>ໂຫຼດຄືນໃໝ່</translation></message>
++    <message>
++        <source>Cut</source>
++        <translation>ຕັດ</translation></message>
++    <message>
++        <source>Copy</source>
++        <translation>ສຳເນົາ</translation></message>
++    <message>
++        <source>Paste</source>
++        <translation>ວາງ</translation></message>
++    <message>
++        <source>Undo</source>
++        <translation>ກັບຄືນ</translation></message>
++    <message>
++        <source>Redo</source>
++        <translation>ເຮັດຄືນ</translation></message>
++    <message>
++        <source>Select all</source>
++        <translation>ເລືອກທັງໝົດ</translation></message>
++    <message>
++        <source>Paste and match style</source>
++        <translation>ວາງ ແລະ ຈັດຮູບແບບໃຫ້ກົງກັນ</translation></message>
++    <message>
++        <source>Open link in new window</source>
++        <translation>ເປີດລິ້ງໃນຫນ້າຕ່າງໃຫມ່</translation></message>
++    <message>
++        <source>Open link in new tab</source>
++        <translation>ເປີດລິ້ງໃນແຖບໃໝ່</translation></message>
++    <message>
++        <source>Copy link address</source>
++        <translation>ສຳເນົາທີ່ຢູ່ລິ້ງ</translation></message>
++    <message>
++        <source>Save link</source>
++        <translation>ບັນທຶກລິ້ງ</translation></message>
++    <message>
++        <source>Copy image</source>
++        <translation>ສຳເນົາຮູບພາບ</translation></message>
++    <message>
++        <source>Copy image address</source>
++        <translation>ສຳເນົາທີ່ຢູ່ຮູບພາບ</translation></message>
++    <message>
++        <source>Save image</source>
++        <translation>ບັນທຶກຮູບພາບ</translation></message>
++    <message>
++        <source>Copy media address</source>
++        <translation>ສຳເນົາທີ່ຢູ່ສື່</translation></message>
++    <message>
++        <source>Show controls</source>
++        <translation>ສະແດງຄວບຄຸມ</translation></message>
++    <message>
++        <source>Loop</source>
++        <translation>ວົນວຽນ</translation></message>
++    <message>
++        <source>Save media</source>
++        <translation>ບັນທຶກສື່</translation></message>
++    <message>
++        <source>Inspect</source>
++        <translation>ກວດສອບ</translation></message>
++    <message>
++        <source>Exit full screen</source>
++        <translation>ອອກຈາກໜ້າຈໍເຕັມ</translation></message>
++    <message>
++        <source>Save page</source>
++        <translation>ບັນທຶກໜ້າ</translation></message>
++    <message>
++        <source>View page source</source>
++        <translation>ເບິ່ງຕົ້ນສະບັບໜ້າ</translation></message>
++</context>
++<context>
++    <name>UIDelegatesManager</name>
++    <message>
++        <source>Javascript Alert - %1</source>
++        <translation>Javascript Alert - %1</translation></message>
++    <message>
++        <source>Javascript Confirm - %1</source>
++        <translation>Javascript ຢືນຢັນ - %1</translation></message>
++    <message>
++        <source>Javascript Prompt - %1</source>
++        <translation>Javascript Prompt - %1</translation></message>
++    <message>
++        <source>Are you sure you want to leave this page?</source>
++        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການອອກຈາກໜ້ານີ້?</translation></message>
++    <message>
++        <source>Changes that you made may not be saved.</source>
++        <translation>ການປ່ຽນແປງທີ່ທ່ານເຮັດອາດຈະບໍ່ຖືກບັນທຶກ.</translation></message>
++    <message>
++        <source>Connect to proxy "%1" using:</source>
++        <translation>ເຊື່ອມຕໍ່ກັບພຣອກຊີ "%1" ໂດຍໃຊ້:</translation></message>
++    <message>
++        <source>Enter username and password for "%1" at %2://%3</source>
++        <translation>ປ້ອນຊື່ຜູ້ໃຊ້ ແລະ ລະຫັດຜ່ານສຳລັບ "%1" ທີ່ %2://%3</translation></message>
++</context>
++<context>
++    <name>WebContentsAdapter</name>
++    <message>
++        <source>HTTP-POST data can only be sent over HTTP(S) protocol</source>
++        <translation>ຂໍ້ມູນ HTTP-POST ສາມາດສົ່ງໄດ້ພຽງແຕ່ຜ່ານໂປຣໂຕຄໍ HTTP(S) ເທົ່ານັ້ນ</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+diff --git a/translations/qtwebsockets_lo.ts b/translations/qtwebsockets_lo.ts
+new file mode 100644
+index 0000000..07745b2
+--- /dev/null
++++ b/translations/qtwebsockets_lo.ts
+@@ -0,0 +1,177 @@
++<?xml version='1.0' encoding='utf-8'?>
++<TS version="2.1" language="lo">
++<context>
++    <name>QQmlWebSocket</name>
++    <message>
++        <source>Messages can only be sent when the socket is open.</source>
++        <translation>ຂໍ້ຄວາມສາມາດສົ່ງໄດ້ເມື່ອຊ໊ອກເກັດເປີດຢູ່ເທົ່ານັ້ນ.</translation></message>
++    <message>
++        <source>QQmlWebSocket is not ready.</source>
++        <translation>QQmlWebSocket ບໍ່ພ້ອມ.</translation></message>
++</context>
++<context>
++    <name>QQmlWebSocketServer</name>
++    <message>
++        <source>QQmlWebSocketServer is not ready.</source>
++        <translation>QQmlWebSocketServer ບໍ່ພ້ອມ.</translation></message>
++</context>
++<context>
++    <name>QWebSocket</name>
++    <message>
++        <source>Connection closed</source>
++        <translation>ການເຊື່ອມຕໍ່ຖືກປິດ</translation></message>
++    <message>
++        <source>Invalid URL.</source>
++        <translation>URL ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Invalid resource name.</source>
++        <translation>ຊື່ຊັບພະຍາກອນບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>SSL Sockets are not supported on this platform.</source>
++        <translation>SSL Sockets ບໍ່ຖືກສະໜັບສະໜູນໃນແພລດຟອມນີ້.</translation></message>
++    <message>
++        <source>Out of memory.</source>
++        <translation>ຫມົດພື້ນທີ່ຫນ່ວຍຄວາມຈຳ.</translation></message>
++    <message>
++        <source>Unsupported WebSocket scheme: %1</source>
++        <translation>ແບບແພັກເກດ WebSocket ບໍ່ຮອງຮັບ: %1</translation></message>
++    <message>
++        <source>Error writing bytes to socket: %1.</source>
++        <translation>ຂໍ້ຜິດພາດໃນການຂຽນໄບຕ໌ໄປຫາໂຊເກັດ: %1.</translation></message>
++    <message>
++        <source>Bytes written %1 != %2.</source>
++        <translation>ຂໍ້ມູນທີ່ຂຽນ %1 != %2.</translation></message>
++    <message>
++        <source>Invalid statusline in response: %1.</source>
++        <translation>ສະຖານະບໍ່ຖືກຕ້ອງໃນການຕອບຮັບ: %1.</translation></message>
++    <message>
++        <source>QWebSocketPrivate::processHandshake: Connection closed while reading header.</source>
++        <translation>QWebSocketPrivate::processHandshake: ການເຊື່ອມຕໍ່ຖືກປິດໃນຂະນະທີ່ກຳລັງອ່ານຫົວຂໍ້.</translation></message>
++    <message>
++        <source>Accept-Key received from server %1 does not match the client key %2.</source>
++        <translation>ຍອມຮັບ-ກະແຈທີ່ໄດ້ຮັບຈາກເຊີບເວີ %1 ບໍ່ກົງກັບກະແຈລູກຄ້າ %2.</translation></message>
++    <message>
++        <source>QWebSocketPrivate::processHandshake: Invalid statusline in response: %1.</source>
++        <translation>QWebSocketPrivate::processHandshake: ບໍ່ຖືກຕ້ອງສະຖານະໃນການຕອບສະໜອງ: %1.</translation></message>
++    <message>
++        <source>Handshake: Server requests a version that we don't support: %1.</source>
++        <translation>Handshake: ເຊີບເວີຮ້ອງຂໍເວີຊັນທີ່ພວກເຮົາບໍ່ຮອງຮັບ: %1.</translation></message>
++    <message>
++        <source>QWebSocketPrivate::processHandshake: Unknown error condition encountered. Aborting connection.</source>
++        <translation>QWebSocketPrivate::processHandshake: ພົບເຫດການຜິດພາດທີ່ບໍ່ຮູ້ຈັກ. ຍົກເລີກການເຊື່ອມຕໍ່.</translation></message>
++    <message>
++        <source>QWebSocketPrivate::processHandshake: Unhandled http status code: %1 (%2).</source>
++        <translation>QWebSocketPrivate::processHandshake: ລະຫັດສະຖານະ http ທີ່ບໍ່ມີການຈັດການ: %1 (%2).</translation></message>
++    <message>
++        <source>The resource name contains newlines. Possible attack detected.</source>
++        <translation>ຊື່ຊັບພະຍາກອນມີບັນທຶກໃໝ່. ການໂຈມຕີທີ່ເປັນໄປໄດ້ຖືກຕິດຕາມ.</translation></message>
++    <message>
++        <source>The hostname contains newlines. Possible attack detected.</source>
++        <translation>ຊື່ໂຮສຕີງມີເສັ້ນໃໝ່. ການໂຈມຕີທີ່ເປັນໄປໄດ້ຖືກຕັດພົບ.</translation></message>
++    <message>
++        <source>The origin contains newlines. Possible attack detected.</source>
++        <translation>ຕົ້ນກໍາເນີດມີແຖວໃໝ່. ການໂຈມຕີທີ່ເປັນໄປໄດ້ຖືກຕິດຕາມ.</translation></message>
++    <message>
++        <source>The extensions attribute contains newlines. Possible attack detected.</source>
++        <translation>ຄຸນສົມບັດຂອງສ່ວນຂະຫຍາຍມີເສັ້ນໃໝ່. ການໂຈມຕີທີ່ເປັນໄປໄດ້ຖືກຕິດຕາມ.</translation></message>
++    <message>
++        <source>The protocols attribute contains newlines. Possible attack detected.</source>
++        <translation>ຄຸນສົມບັດຂອງໂປຣໂຕຄອນມີເສັ້ນໃໝ່. ການໂຈມຕີທີ່ເປັນໄປໄດ້ຖືກຕິດຕາມ.</translation></message>
++</context>
++<context>
++    <name>QWebSocketDataProcessor</name>
++    <message>
++        <source>Received Continuation frame, while there is nothing to continue.</source>
++        <translation>ໄດ້ຮັບກອບຕໍ່ເນື່ອງ, ໃນຂະນະທີ່ບໍ່ມີຫຍັງຕໍ່ເນື່ອງ.</translation></message>
++    <message>
++        <source>All data frames after the initial data frame must have opcode 0 (continuation).</source>
++        <translation>ຂໍ້ມູນທັງໝົດຫຼັງຈາກຂໍ້ມູນເບື້ອງຕົ້ນຕ້ອງມີ opcode 0 (ຕໍ່ເນື່ອງ).</translation></message>
++    <message>
++        <source>Received message is too big.</source>
++        <translation>ຂໍ້ຄວາມທີ່ຮັບມາໃຫຍ່ເກີນໄປ</translation></message>
++    <message>
++        <source>Invalid UTF-8 code encountered.</source>
++        <translation>ພົບລະຫັດ UTF-8 ທີ່ບໍ່ຖືກຕ້ອງ.</translation></message>
++    <message>
++        <source>Payload of close frame is too small.</source>
++        <translation>ຂໍ້ມູນຂອງກະດານປິດມີຂະໜາດນ້ອຍເກີນໄປ.</translation></message>
++    <message>
++        <source>Invalid close code %1 detected.</source>
++        <translation>ລະຫັດປິດ %1 ທີ່ບໍ່ຖືກຕ້ອງຖືກກວດພົບ.</translation></message>
++    <message>
++        <source>Invalid opcode detected: %1</source>
++        <translation>ພົບຄຳສັ່ງບໍ່ຖືກຕ້ອງ: %1</translation></message>
++</context>
++<context>
++    <name>QWebSocketFrame</name>
++    <message>
++        <source>Timeout when reading data from socket.</source>
++        <translation>ໄລຍະເວລາຫມົດອາຍຸເມື່ອອ່ານຂໍ້ມູນຈາກຊັອກເກັດ.</translation></message>
++    <message>
++        <source>Error occurred while reading from the network: %1</source>
++        <translation>ມີຂໍ້ຜິດພາດເກີດຂຶ້ນໃນຂະນະອ່ານຈາກເຄືອຂ່າຍ: %1</translation></message>
++    <message>
++        <source>Lengths smaller than 126 must be expressed as one byte.</source>
++        <translation>ຄວາມຍາວທີ່ນ້ອຍກວ່າ 126 ຕ້ອງຖືກສະແດງອອກເປັນໄບຕ໌ດຽວ.</translation></message>
++    <message>
++        <source>Something went wrong during reading from the network.</source>
++        <translation>ມີບາງຢ່າງຜິດພາດໃນລະຫວ່າງການອ່ານຈາກເຄືອຂ່າຍ.</translation></message>
++    <message>
++        <source>Highest bit of payload length is not 0.</source>
++        <translation>ບິດສູງສຸດຂອງຄວາມຍາວຂອງ payload ບໍ່ແມ່ນ 0.</translation></message>
++    <message>
++        <source>Lengths smaller than 65536 (2^16) must be expressed as 2 bytes.</source>
++        <translation>ຄວາມຍາວທີ່ນ້ອຍກວ່າ 65536 (2^16) ຕ້ອງຖືກສະແດງເປັນ 2 ໄບຕ໌.</translation></message>
++    <message>
++        <source>Error while reading from the network: %1.</source>
++        <translation>ຜິດພາດໃນການອ່ານຈາກເຄືອຂ່າຍ: %1.</translation></message>
++    <message>
++        <source>Maximum framesize exceeded.</source>
++        <translation>ຂະໜາດເຟຣມສູງສຸດຖືກເກີນໄປ.</translation></message>
++    <message>
++        <source>Some serious error occurred while reading from the network.</source>
++        <translation>ມີຂໍ້ຜິດພາດຮ້າຍແຮງເກີດຂຶ້ນໃນຂະນະທີ່ກຳລັງອ່ານຈາກເຄືອຂ່າຍ.</translation></message>
++    <message>
++        <source>Rsv field is non-zero</source>
++        <translation>ຟີວ Rsv ບໍ່ແມ່ນສູນ</translation></message>
++    <message>
++        <source>Used reserved opcode</source>
++        <translation>ໃຊ້ລະຫັດຄຳສັ່ງທີ່ຈອງໄວ້ແລ້ວ</translation></message>
++    <message>
++        <source>Control frame is larger than 125 bytes</source>
++        <translation>ກອບຄວບຄຸມໃຫຍ່ກວ່າ 125 ໄບຕ໌</translation></message>
++    <message>
++        <source>Control frames cannot be fragmented</source>
++        <translation>ກະດານຄວບຄຸມບໍ່ສາມາດແຕກແຍກໄດ້</translation></message>
++</context>
++<context>
++    <name>QWebSocketHandshakeResponse</name>
++    <message>
++        <source>Access forbidden.</source>
++        <translation>ຫ້າມເຂົ້າເຖິງ.</translation></message>
++    <message>
++        <source>Unsupported version requested.</source>
++        <translation>ບໍ່ຮອງຮັບເວີຊັນທີ່ຮ້ອງຂໍ.</translation></message>
++    <message>
++        <source>One of the headers contains a newline. Possible attack detected.</source>
++        <translation>ຫົວຂໍ້ຫນຶ່ງມີຂໍ້ຄວາມຂຶ້ນແຖວໃຫມ່. ການໂຈມຕີທີ່ເປັນໄປໄດ້ຖືກກວດພົບ.</translation></message>
++    <message>
++        <source>Bad handshake request received.</source>
++        <translation>ການຮ້ອງຂໍຈັບມືທີ່ບໍ່ດີໄດ້ຮັບ.</translation></message>
++</context>
++<context>
++    <name>QWebSocketServer</name>
++    <message>
++        <source>Server closed.</source>
++        <translation>ເຊີບເວີປິດແລ້ວ.</translation></message>
++    <message>
++        <source>Too many pending connections.</source>
++        <translation>ມີການເຊື່ອມຕໍ່ທີ່ລໍຖ້າຢູ່ຫຼາຍເກີນໄປ.</translation></message>
++    <message>
++        <source>Upgrade to WebSocket failed.</source>
++        <translation>ອັບເກຣດເປັນ WebSocket ລົ້ມເຫລວ.</translation></message>
++    <message>
++        <source>Invalid response received.</source>
++        <translation>ການຕອບຮັບທີ່ບໍ່ຖືກຕ້ອງໄດ້ຮັບ.</translation></message>
++</context>
++</TS>
+\ No newline at end of file
+-- 
+2.51.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 add-zh-hk-update-zh-tw-translations.patch
+add-lao-translations.patch


### PR DESCRIPTION
- Add Lao (lo) language translation files as Debian patch
- Add add-lao-translations.patch to patch series
- Bump version to 6.8.0-0deepin2 in changelog

This follows Debian 3.0 (quilt) packaging format by managing translation files as patches instead of direct modifications.

PMS: BUG-329211